### PR TITLE
fix build on mac

### DIFF
--- a/src/lib/sqllib.h
+++ b/src/lib/sqllib.h
@@ -1,6 +1,7 @@
 #ifndef __SQLLIB_H__
 #define __SQLLIB_H__
 
+typedef unsigned int uint;
 
 #include "SelectStatement.h"
 #include "ImportStatement.h"

--- a/src/parser/SQLParser.cpp
+++ b/src/parser/SQLParser.cpp
@@ -2,6 +2,7 @@
 #include "bison_parser.h"
 #include "flex_lexer.h"
 #include <stdio.h>
+#include <string>
 
 
 namespace hsql {


### PR DESCRIPTION
* `typedef unsigned int uint`
  `uint` isn't a standard type - `unsigned int` is.

* add missing `#include <string>`
  clang on mac complains about this