### PR TITLE
fix memory leak in SQLStatementList

### DIFF
--- a/src/lib/statements/SQLStatement.h
+++ b/src/lib/statements/SQLStatement.h
@@ -62,6 +62,9 @@ public:
 	};
 		
 	virtual ~SQLStatementList() {
+		for (std::vector<SQLStatement*>::iterator it = statements.begin(); it != statements.end(); ++it) {
+			delete *it;
+		}
 		delete parser_msg;
 	}
 


### PR DESCRIPTION
`SQLStatementList::addStatement` takes over ownership of added `SQLStatement*`. It is invoked here:

https://github.com/hyrise/sql-parser/blob/b1622ce71dfbfa37198827043e494f9b61be0ef5/src/parser/bison_parser.y#L235

When destroying `SQLStatementList`, the `SQLStatement*` owned by it should also be freed.