### PR TITLE
Makefile adapted to Windows (issue #7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ INSTALL    = /usr/local
 
 CTESTFLAGS = -Wall -Isrc/ -Itest/ -L./ -std=c++11 -lstdc++
 
+ifeq ($(OS),Windows_NT)
+    CFLAGS += -Duint=unsigned
+    CTESTFLAGS += -Duint=unsigned
+    TARGET = libsqlparser.dll
+endif
+
+
 all: library
 
 library: $(TARGET)


### PR DESCRIPTION
This add support for compilation under Windows OS.

I tested it with:
- MSYS2's bundled mingw64 (packages `mingw64/mingw-w64-x86_64-gcc` `mingw64/mingw-w64-x86_64-make` `mingw64/mingw-w64-x86_64-libc++` `mingw64/mingw-w64-x86_64-gdb` `git` `make` `bison`). It is based on GCC 5.3.
- MSYS2's bundled mingw32 (packages `mingw32/mingw-w64-i686-libc++` `mingw32/mingw-w64-i686-gcc`). It is based on GCC 5.3.

How to compile & validate:
```
make && make test
```
It should work with any version of `mingw` with a good enough support for `c++11`.
