### PR TITLE
Fix memory leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,30 @@ language: cpp
 install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get -qq update
-  - sudo apt-get install -y bison flex
   - sudo apt-get install -y g++-4.8 libstdc++-4.8-dev
+  - sudo apt-get install -y flex valgrind
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
+  
+  # Install bison 3.0.4.
+  - wget http://ftp.gnu.org/gnu/bison/bison-3.0.4.tar.gz
+  - tar -xvzf bison-3.0.4.tar.gz
+  - cd bison-3.0.4
+  - ./configure && make && sudo make install
+  - cd ..
+
+  # Show installed versions.
   - which g++
   - g++ -v
+  - bison --version
+  - flex --version
+  - valgrind --version
 
 compiler:
   - gcc
   - clang
 
 script:
+  - make cleanall
   - make
   - make test

--- a/src/SQLParser.cpp
+++ b/src/SQLParser.cpp
@@ -28,11 +28,12 @@ namespace hsql {
     // Parser and return early if it failed.
     if (hsql_parse(&result, scanner)) {
       // Returns an error stmt object.
+      hsql__delete_buffer(state, scanner);
+      hsql_lex_destroy(scanner);
       return result;
     }
 
     hsql__delete_buffer(state, scanner);
-
     hsql_lex_destroy(scanner);
     return result;
   }

--- a/src/SQLParserResult.cpp
+++ b/src/SQLParserResult.cpp
@@ -18,7 +18,7 @@ namespace hsql {
       delete statement;
     }
 
-    delete errorMsg_;
+    free(errorMsg_);
   }
 
   void SQLParserResult::addStatement(SQLStatement* stmt) {
@@ -57,7 +57,7 @@ namespace hsql {
     isValid_ = isValid;
   }
 
-  void SQLParserResult::setErrorDetails(const char* errorMsg, int errorLine, int errorColumn) {
+  void SQLParserResult::setErrorDetails(char* errorMsg, int errorLine, int errorColumn) {
     errorMsg_ = errorMsg;
     errorLine_ = errorLine;
     errorColumn_ = errorColumn;

--- a/src/SQLParserResult.h
+++ b/src/SQLParserResult.h
@@ -47,7 +47,8 @@ namespace hsql {
     void setIsValid(bool isValid);
 
     // Set the details of the error, if available.
-    void setErrorDetails(const char* errorMsg, int errorLine, int errorColumn);
+    // Takes ownership of errorMsg.
+    void setErrorDetails(char* errorMsg, int errorLine, int errorColumn);
 
 
    private:
@@ -58,7 +59,7 @@ namespace hsql {
     bool isValid_;
 
     // Error message, if an error occurred.
-    const char* errorMsg_;
+    char* errorMsg_;
 
     // Line number of the occurrance of the error in the query.
     int errorLine_;

--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -2,9 +2,11 @@
 all: bison_parser.cpp flex_lexer.cpp
 
 bison_parser.cpp: bison_parser.y
+	@bison --version | head -n 1
 	bison bison_parser.y -v
 
 flex_lexer.cpp: flex_lexer.l
+	@flex --version
 	flex flex_lexer.l
 
 clean:

--- a/src/parser/bison_parser.cpp
+++ b/src/parser/bison_parser.cpp
@@ -92,6 +92,7 @@
 using namespace hsql;
 
 int yyerror(YYLTYPE* llocp, SQLParserResult** result, yyscan_t scanner, const char *msg) {
+	delete *result;
 
 	SQLParserResult* list = new SQLParserResult();
 	list->setIsValid(false);
@@ -104,7 +105,7 @@ int yyerror(YYLTYPE* llocp, SQLParserResult** result, yyscan_t scanner, const ch
 
 
 
-#line 108 "bison_parser.cpp" /* yacc.c:339  */
+#line 109 "bison_parser.cpp" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -142,7 +143,7 @@ int yyerror(YYLTYPE* llocp, SQLParserResult** result, yyscan_t scanner, const ch
 extern int hsql_debug;
 #endif
 /* "%code requires" blocks.  */
-#line 40 "bison_parser.y" /* yacc.c:355  */
+#line 41 "bison_parser.y" /* yacc.c:355  */
 
 // %code requires block	
 
@@ -165,7 +166,7 @@ extern int hsql_debug;
         } \
     }
 
-#line 169 "bison_parser.cpp" /* yacc.c:355  */
+#line 170 "bison_parser.cpp" /* yacc.c:355  */
 
 /* Token type.  */
 #ifndef HSQL_TOKENTYPE
@@ -303,7 +304,7 @@ extern int hsql_debug;
 typedef union HSQL_STYPE HSQL_STYPE;
 union HSQL_STYPE
 {
-#line 99 "bison_parser.y" /* yacc.c:355  */
+#line 100 "bison_parser.y" /* yacc.c:355  */
 
 	double fval;
 	int64_t ival;
@@ -339,7 +340,7 @@ union HSQL_STYPE
 	std::vector<hsql::UpdateClause*>* update_vec;
 	std::vector<hsql::Expr*>* expr_vec;
 
-#line 343 "bison_parser.cpp" /* yacc.c:355  */
+#line 344 "bison_parser.cpp" /* yacc.c:355  */
 };
 # define HSQL_STYPE_IS_TRIVIAL 1
 # define HSQL_STYPE_IS_DECLARED 1
@@ -367,7 +368,7 @@ int hsql_parse (hsql::SQLParserResult** result, yyscan_t scanner);
 
 /* Copy the second part of user declarations.  */
 
-#line 371 "bison_parser.cpp" /* yacc.c:358  */
+#line 372 "bison_parser.cpp" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -679,21 +680,21 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   227,   227,   234,   235,   239,   244,   249,   250,   251,
-     252,   253,   254,   255,   256,   257,   265,   270,   278,   282,
-     294,   302,   306,   316,   322,   331,   332,   336,   337,   341,
-     348,   349,   350,   351,   361,   365,   377,   385,   397,   403,
-     413,   414,   424,   433,   434,   438,   450,   451,   455,   456,
-     460,   465,   477,   478,   479,   483,   494,   495,   499,   504,
-     509,   510,   514,   519,   523,   524,   527,   528,   532,   533,
-     534,   539,   540,   541,   548,   549,   553,   554,   558,   565,
-     566,   567,   568,   569,   573,   574,   575,   579,   580,   584,
-     585,   586,   587,   588,   589,   590,   591,   592,   593,   594,
-     599,   600,   601,   602,   603,   604,   608,   612,   613,   617,
-     618,   619,   623,   628,   629,   633,   637,   642,   653,   654,
-     664,   665,   671,   676,   677,   682,   692,   700,   701,   706,
-     707,   711,   712,   720,   732,   733,   734,   735,   736,   742,
-     748,   752,   761,   762,   767,   768
+       0,   241,   241,   248,   249,   253,   258,   263,   264,   265,
+     266,   267,   268,   269,   270,   271,   279,   284,   292,   296,
+     308,   316,   320,   330,   336,   345,   346,   350,   351,   355,
+     362,   363,   364,   365,   375,   379,   391,   399,   411,   417,
+     427,   428,   438,   447,   448,   452,   464,   465,   469,   470,
+     474,   479,   491,   492,   493,   497,   508,   509,   513,   518,
+     523,   524,   528,   533,   537,   538,   541,   542,   546,   547,
+     548,   553,   554,   555,   562,   563,   567,   568,   572,   579,
+     580,   581,   582,   583,   587,   588,   589,   593,   594,   598,
+     599,   600,   601,   602,   603,   604,   605,   606,   607,   608,
+     613,   614,   615,   616,   617,   618,   622,   626,   627,   631,
+     632,   633,   637,   642,   643,   647,   651,   656,   667,   668,
+     678,   679,   685,   690,   691,   696,   706,   714,   715,   720,
+     721,   725,   726,   734,   746,   747,   748,   749,   750,   756,
+     762,   766,   775,   776,   781,   782
 };
 #endif
 
@@ -1527,7 +1528,472 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  switch (yytype)
+    {
+          case 3: /* IDENTIFIER  */
+#line 141 "bison_parser.y" /* yacc.c:1257  */
+      { free( (((*yyvaluep).sval)) ); }
+#line 1537 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 4: /* STRING  */
+#line 141 "bison_parser.y" /* yacc.c:1257  */
+      { free( (((*yyvaluep).sval)) ); }
+#line 1543 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 5: /* FLOATVAL  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1549 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 6: /* INTVAL  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1555 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 7: /* NOTEQUALS  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1561 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 8: /* LESSEQ  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1567 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 9: /* GREATEREQ  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1573 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 148: /* statement_list  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).stmt_list)); }
+#line 1579 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 149: /* statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).statement)); }
+#line 1585 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 150: /* preparable_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).statement)); }
+#line 1591 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 151: /* prepare_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).prep_stmt)); }
+#line 1597 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 152: /* execute_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).exec_stmt)); }
+#line 1603 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 153: /* import_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).import_stmt)); }
+#line 1609 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 154: /* import_file_type  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1615 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 155: /* file_path  */
+#line 141 "bison_parser.y" /* yacc.c:1257  */
+      { free( (((*yyvaluep).sval)) ); }
+#line 1621 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 156: /* create_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).create_stmt)); }
+#line 1627 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 157: /* opt_not_exists  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1633 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 158: /* column_def_commalist  */
+#line 142 "bison_parser.y" /* yacc.c:1257  */
+      {
+	for (auto ptr : *(((*yyvaluep).column_vec))) {
+		delete ptr;
+	}
+	delete (((*yyvaluep).column_vec));
+}
+#line 1644 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 159: /* column_def  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).column_t)); }
+#line 1650 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 160: /* column_type  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1656 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 161: /* drop_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).drop_stmt)); }
+#line 1662 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 162: /* delete_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).delete_stmt)); }
+#line 1668 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 163: /* truncate_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).delete_stmt)); }
+#line 1674 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 164: /* insert_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).insert_stmt)); }
+#line 1680 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 165: /* opt_column_list  */
+#line 142 "bison_parser.y" /* yacc.c:1257  */
+      {
+	for (auto ptr : *(((*yyvaluep).str_vec))) {
+		delete ptr;
+	}
+	delete (((*yyvaluep).str_vec));
+}
+#line 1691 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 166: /* update_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).update_stmt)); }
+#line 1697 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 167: /* update_clause_commalist  */
+#line 142 "bison_parser.y" /* yacc.c:1257  */
+      {
+	for (auto ptr : *(((*yyvaluep).update_vec))) {
+		delete ptr;
+	}
+	delete (((*yyvaluep).update_vec));
+}
+#line 1708 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 168: /* update_clause  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).update_t)); }
+#line 1714 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 169: /* select_statement  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).select_stmt)); }
+#line 1720 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 170: /* select_with_paren  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).select_stmt)); }
+#line 1726 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 171: /* select_no_paren  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).select_stmt)); }
+#line 1732 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 173: /* select_clause  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).select_stmt)); }
+#line 1738 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 174: /* opt_distinct  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1744 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 175: /* select_list  */
+#line 142 "bison_parser.y" /* yacc.c:1257  */
+      {
+	for (auto ptr : *(((*yyvaluep).expr_vec))) {
+		delete ptr;
+	}
+	delete (((*yyvaluep).expr_vec));
+}
+#line 1755 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 176: /* from_clause  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).table)); }
+#line 1761 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 177: /* opt_where  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1767 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 178: /* opt_group  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).group_t)); }
+#line 1773 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 179: /* opt_having  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1779 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 180: /* opt_order  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).order)); }
+#line 1785 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 181: /* opt_order_type  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1791 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 182: /* opt_limit  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).limit)); }
+#line 1797 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 183: /* expr_list  */
+#line 142 "bison_parser.y" /* yacc.c:1257  */
+      {
+	for (auto ptr : *(((*yyvaluep).expr_vec))) {
+		delete ptr;
+	}
+	delete (((*yyvaluep).expr_vec));
+}
+#line 1808 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 184: /* literal_list  */
+#line 142 "bison_parser.y" /* yacc.c:1257  */
+      {
+	for (auto ptr : *(((*yyvaluep).expr_vec))) {
+		delete ptr;
+	}
+	delete (((*yyvaluep).expr_vec));
+}
+#line 1819 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 185: /* expr_alias  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1825 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 186: /* expr  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1831 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 187: /* scalar_expr  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1837 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 188: /* unary_expr  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1843 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 189: /* binary_expr  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1849 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 190: /* comp_expr  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1855 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 191: /* function_expr  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1861 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 192: /* column_name  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1867 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 193: /* literal  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1873 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 194: /* string_literal  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1879 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 195: /* num_literal  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1885 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 196: /* int_literal  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1891 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 197: /* star_expr  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1897 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 198: /* placeholder_expr  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1903 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 199: /* table_ref  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).table)); }
+#line 1909 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 200: /* table_ref_atomic  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).table)); }
+#line 1915 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 201: /* table_ref_commalist  */
+#line 142 "bison_parser.y" /* yacc.c:1257  */
+      {
+	for (auto ptr : *(((*yyvaluep).table_vec))) {
+		delete ptr;
+	}
+	delete (((*yyvaluep).table_vec));
+}
+#line 1926 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 202: /* table_ref_name  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).table)); }
+#line 1932 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 203: /* table_ref_name_no_alias  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).table)); }
+#line 1938 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 204: /* table_name  */
+#line 141 "bison_parser.y" /* yacc.c:1257  */
+      { free( (((*yyvaluep).sval)) ); }
+#line 1944 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 205: /* alias  */
+#line 141 "bison_parser.y" /* yacc.c:1257  */
+      { free( (((*yyvaluep).sval)) ); }
+#line 1950 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 206: /* opt_alias  */
+#line 141 "bison_parser.y" /* yacc.c:1257  */
+      { free( (((*yyvaluep).sval)) ); }
+#line 1956 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 207: /* join_clause  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).table)); }
+#line 1962 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 208: /* opt_join_type  */
+#line 140 "bison_parser.y" /* yacc.c:1257  */
+      { }
+#line 1968 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 209: /* join_table  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).table)); }
+#line 1974 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 210: /* join_condition  */
+#line 148 "bison_parser.y" /* yacc.c:1257  */
+      { delete (((*yyvaluep).expr)); }
+#line 1980 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+    case 212: /* ident_commalist  */
+#line 142 "bison_parser.y" /* yacc.c:1257  */
+      {
+	for (auto ptr : *(((*yyvaluep).str_vec))) {
+		delete ptr;
+	}
+	delete (((*yyvaluep).str_vec));
+}
+#line 1991 "bison_parser.cpp" /* yacc.c:1257  */
+        break;
+
+
+      default:
+        break;
+    }
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -1629,7 +2095,7 @@ YYLTYPE yylloc = yyloc_default;
   yychar = YYEMPTY; /* Cause a token to be read.  */
 
 /* User initialization code.  */
-#line 77 "bison_parser.y" /* yacc.c:1429  */
+#line 78 "bison_parser.y" /* yacc.c:1429  */
 {
 	// Initialize
 	yylloc.first_column = 0;
@@ -1640,7 +2106,7 @@ YYLTYPE yylloc = yyloc_default;
 	yylloc.placeholder_id = 0;
 }
 
-#line 1644 "bison_parser.cpp" /* yacc.c:1429  */
+#line 2110 "bison_parser.cpp" /* yacc.c:1429  */
   yylsp[0] = yylloc;
   goto yysetstate;
 
@@ -1827,356 +2293,356 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 227 "bison_parser.y" /* yacc.c:1646  */
+#line 241 "bison_parser.y" /* yacc.c:1646  */
     {
 			*result = (yyvsp[-1].stmt_list);
 		}
-#line 1835 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2301 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 234 "bison_parser.y" /* yacc.c:1646  */
+#line 248 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.stmt_list) = new SQLParserResult((yyvsp[0].statement)); }
-#line 1841 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2307 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 235 "bison_parser.y" /* yacc.c:1646  */
+#line 249 "bison_parser.y" /* yacc.c:1646  */
     { (yyvsp[-2].stmt_list)->addStatement((yyvsp[0].statement)); (yyval.stmt_list) = (yyvsp[-2].stmt_list); }
-#line 1847 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2313 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 239 "bison_parser.y" /* yacc.c:1646  */
+#line 253 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyvsp[0].prep_stmt)->setPlaceholders(yyloc.placeholder_list);
 			yyloc.placeholder_list.clear();
 			(yyval.statement) = (yyvsp[0].prep_stmt);
 		}
-#line 1857 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2323 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 249 "bison_parser.y" /* yacc.c:1646  */
+#line 263 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.statement) = (yyvsp[0].select_stmt); }
-#line 1863 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2329 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 250 "bison_parser.y" /* yacc.c:1646  */
+#line 264 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.statement) = (yyvsp[0].import_stmt); }
-#line 1869 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2335 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 251 "bison_parser.y" /* yacc.c:1646  */
+#line 265 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.statement) = (yyvsp[0].create_stmt); }
-#line 1875 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2341 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 252 "bison_parser.y" /* yacc.c:1646  */
+#line 266 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.statement) = (yyvsp[0].insert_stmt); }
-#line 1881 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2347 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 253 "bison_parser.y" /* yacc.c:1646  */
+#line 267 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 1887 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2353 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 254 "bison_parser.y" /* yacc.c:1646  */
+#line 268 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 1893 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2359 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 255 "bison_parser.y" /* yacc.c:1646  */
+#line 269 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.statement) = (yyvsp[0].update_stmt); }
-#line 1899 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2365 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 256 "bison_parser.y" /* yacc.c:1646  */
+#line 270 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.statement) = (yyvsp[0].drop_stmt); }
-#line 1905 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2371 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 257 "bison_parser.y" /* yacc.c:1646  */
+#line 271 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.statement) = (yyvsp[0].exec_stmt); }
-#line 1911 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2377 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 265 "bison_parser.y" /* yacc.c:1646  */
+#line 279 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.prep_stmt) = new PrepareStatement();
 			(yyval.prep_stmt)->name = (yyvsp[-2].sval);
 			(yyval.prep_stmt)->query = new SQLParserResult((yyvsp[0].statement));
 		}
-#line 1921 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2387 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 270 "bison_parser.y" /* yacc.c:1646  */
+#line 284 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.prep_stmt) = new PrepareStatement();
 			(yyval.prep_stmt)->name = (yyvsp[-4].sval);
 			(yyval.prep_stmt)->query = (yyvsp[-2].stmt_list);
 		}
-#line 1931 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2397 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 278 "bison_parser.y" /* yacc.c:1646  */
+#line 292 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.exec_stmt) = new ExecuteStatement();
 			(yyval.exec_stmt)->name = (yyvsp[0].sval);
 		}
-#line 1940 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2406 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 282 "bison_parser.y" /* yacc.c:1646  */
+#line 296 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.exec_stmt) = new ExecuteStatement();
 			(yyval.exec_stmt)->name = (yyvsp[-3].sval);
 			(yyval.exec_stmt)->parameters = (yyvsp[-1].expr_vec);
 		}
-#line 1950 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2416 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 294 "bison_parser.y" /* yacc.c:1646  */
+#line 308 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.import_stmt) = new ImportStatement((ImportStatement::ImportType) (yyvsp[-4].uval));
 			(yyval.import_stmt)->filePath = (yyvsp[-2].sval);
 			(yyval.import_stmt)->tableName = (yyvsp[0].sval);
 		}
-#line 1960 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2426 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 302 "bison_parser.y" /* yacc.c:1646  */
+#line 316 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.uval) = ImportStatement::kImportCSV; }
-#line 1966 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2432 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 306 "bison_parser.y" /* yacc.c:1646  */
+#line 320 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.sval) = strdup((yyvsp[0].expr)->name); delete (yyvsp[0].expr); }
-#line 1972 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2438 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 316 "bison_parser.y" /* yacc.c:1646  */
+#line 330 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.create_stmt) = new CreateStatement(CreateStatement::kTableFromTbl);
 			(yyval.create_stmt)->ifNotExists = (yyvsp[-5].bval);
 			(yyval.create_stmt)->tableName = (yyvsp[-4].sval);
 			(yyval.create_stmt)->filePath = (yyvsp[0].sval);
 		}
-#line 1983 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2449 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 322 "bison_parser.y" /* yacc.c:1646  */
+#line 336 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.create_stmt) = new CreateStatement(CreateStatement::kTable);
 			(yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
 			(yyval.create_stmt)->tableName = (yyvsp[-3].sval);
 			(yyval.create_stmt)->columns = (yyvsp[-1].column_vec);
 		}
-#line 1994 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2460 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 331 "bison_parser.y" /* yacc.c:1646  */
+#line 345 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.bval) = true; }
-#line 2000 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2466 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 332 "bison_parser.y" /* yacc.c:1646  */
+#line 346 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.bval) = false; }
-#line 2006 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2472 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 336 "bison_parser.y" /* yacc.c:1646  */
+#line 350 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.column_vec) = new std::vector<ColumnDefinition*>(); (yyval.column_vec)->push_back((yyvsp[0].column_t)); }
-#line 2012 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2478 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 337 "bison_parser.y" /* yacc.c:1646  */
+#line 351 "bison_parser.y" /* yacc.c:1646  */
     { (yyvsp[-2].column_vec)->push_back((yyvsp[0].column_t)); (yyval.column_vec) = (yyvsp[-2].column_vec); }
-#line 2018 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2484 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 341 "bison_parser.y" /* yacc.c:1646  */
+#line 355 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.column_t) = new ColumnDefinition((yyvsp[-1].sval), (ColumnDefinition::DataType) (yyvsp[0].uval));
 		}
-#line 2026 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2492 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 348 "bison_parser.y" /* yacc.c:1646  */
+#line 362 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.uval) = ColumnDefinition::INT; }
-#line 2032 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2498 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 349 "bison_parser.y" /* yacc.c:1646  */
+#line 363 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.uval) = ColumnDefinition::INT; }
-#line 2038 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2504 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 32:
-#line 350 "bison_parser.y" /* yacc.c:1646  */
+#line 364 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.uval) = ColumnDefinition::DOUBLE; }
-#line 2044 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2510 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 351 "bison_parser.y" /* yacc.c:1646  */
+#line 365 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.uval) = ColumnDefinition::TEXT; }
-#line 2050 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2516 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 361 "bison_parser.y" /* yacc.c:1646  */
+#line 375 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.drop_stmt) = new DropStatement(DropStatement::kTable);
 			(yyval.drop_stmt)->name = (yyvsp[0].sval);
 		}
-#line 2059 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2525 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 35:
-#line 365 "bison_parser.y" /* yacc.c:1646  */
+#line 379 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.drop_stmt) = new DropStatement(DropStatement::kPreparedStatement);
 			(yyval.drop_stmt)->name = (yyvsp[0].sval);
 		}
-#line 2068 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2534 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 377 "bison_parser.y" /* yacc.c:1646  */
+#line 391 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.delete_stmt) = new DeleteStatement();
 			(yyval.delete_stmt)->tableName = (yyvsp[-1].sval);
 			(yyval.delete_stmt)->expr = (yyvsp[0].expr);
 		}
-#line 2078 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2544 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 385 "bison_parser.y" /* yacc.c:1646  */
+#line 399 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.delete_stmt) = new DeleteStatement();
 			(yyval.delete_stmt)->tableName = (yyvsp[0].sval);
 		}
-#line 2087 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2553 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 38:
-#line 397 "bison_parser.y" /* yacc.c:1646  */
+#line 411 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.insert_stmt) = new InsertStatement(InsertStatement::kInsertValues);
 			(yyval.insert_stmt)->tableName = (yyvsp[-5].sval);
 			(yyval.insert_stmt)->columns = (yyvsp[-4].str_vec);
 			(yyval.insert_stmt)->values = (yyvsp[-1].expr_vec);
 		}
-#line 2098 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2564 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 403 "bison_parser.y" /* yacc.c:1646  */
+#line 417 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.insert_stmt) = new InsertStatement(InsertStatement::kInsertSelect);
 			(yyval.insert_stmt)->tableName = (yyvsp[-2].sval);
 			(yyval.insert_stmt)->columns = (yyvsp[-1].str_vec);
 			(yyval.insert_stmt)->select = (yyvsp[0].select_stmt);
 		}
-#line 2109 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2575 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 413 "bison_parser.y" /* yacc.c:1646  */
+#line 427 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.str_vec) = (yyvsp[-1].str_vec); }
-#line 2115 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2581 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 414 "bison_parser.y" /* yacc.c:1646  */
+#line 428 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.str_vec) = NULL; }
-#line 2121 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2587 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 424 "bison_parser.y" /* yacc.c:1646  */
+#line 438 "bison_parser.y" /* yacc.c:1646  */
     {
 		(yyval.update_stmt) = new UpdateStatement();
 		(yyval.update_stmt)->table = (yyvsp[-3].table);
 		(yyval.update_stmt)->updates = (yyvsp[-1].update_vec);
 		(yyval.update_stmt)->where = (yyvsp[0].expr);
 	}
-#line 2132 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2598 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 433 "bison_parser.y" /* yacc.c:1646  */
+#line 447 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.update_vec) = new std::vector<UpdateClause*>(); (yyval.update_vec)->push_back((yyvsp[0].update_t)); }
-#line 2138 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2604 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 434 "bison_parser.y" /* yacc.c:1646  */
+#line 448 "bison_parser.y" /* yacc.c:1646  */
     { (yyvsp[-2].update_vec)->push_back((yyvsp[0].update_t)); (yyval.update_vec) = (yyvsp[-2].update_vec); }
-#line 2144 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2610 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 438 "bison_parser.y" /* yacc.c:1646  */
+#line 452 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.update_t) = new UpdateClause();
 			(yyval.update_t)->column = (yyvsp[-2].sval);
 			(yyval.update_t)->value = (yyvsp[0].expr);
 		}
-#line 2154 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2620 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 48:
-#line 455 "bison_parser.y" /* yacc.c:1646  */
+#line 469 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 2160 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2626 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 456 "bison_parser.y" /* yacc.c:1646  */
+#line 470 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 2166 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2632 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 50:
-#line 460 "bison_parser.y" /* yacc.c:1646  */
+#line 474 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.select_stmt) = (yyvsp[-2].select_stmt);
 			(yyval.select_stmt)->order = (yyvsp[-1].order);
 			(yyval.select_stmt)->limit = (yyvsp[0].limit);
 		}
-#line 2176 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2642 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 465 "bison_parser.y" /* yacc.c:1646  */
+#line 479 "bison_parser.y" /* yacc.c:1646  */
     {
 			// TODO: allow multiple unions (through linked list)
 			// TODO: capture type of set_operator
@@ -2186,11 +2652,11 @@ yyreduce:
 			(yyval.select_stmt)->order = (yyvsp[-1].order);
 			(yyval.select_stmt)->limit = (yyvsp[0].limit);
 		}
-#line 2190 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2656 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 483 "bison_parser.y" /* yacc.c:1646  */
+#line 497 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.select_stmt) = new SelectStatement();
 			(yyval.select_stmt)->selectDistinct = (yyvsp[-4].bval);
@@ -2199,381 +2665,381 @@ yyreduce:
 			(yyval.select_stmt)->whereClause = (yyvsp[-1].expr);
 			(yyval.select_stmt)->groupBy = (yyvsp[0].group_t);
 		}
-#line 2203 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2669 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 494 "bison_parser.y" /* yacc.c:1646  */
+#line 508 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.bval) = true; }
-#line 2209 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2675 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 495 "bison_parser.y" /* yacc.c:1646  */
+#line 509 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.bval) = false; }
-#line 2215 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2681 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 59:
-#line 504 "bison_parser.y" /* yacc.c:1646  */
+#line 518 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.table) = (yyvsp[0].table); }
-#line 2221 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2687 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 509 "bison_parser.y" /* yacc.c:1646  */
+#line 523 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = (yyvsp[0].expr); }
-#line 2227 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2693 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 61:
-#line 510 "bison_parser.y" /* yacc.c:1646  */
+#line 524 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = NULL; }
-#line 2233 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2699 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 62:
-#line 514 "bison_parser.y" /* yacc.c:1646  */
+#line 528 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.group_t) = new GroupByDescription();
 			(yyval.group_t)->columns = (yyvsp[-1].expr_vec);
 			(yyval.group_t)->having = (yyvsp[0].expr);
 		}
-#line 2243 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2709 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 63:
-#line 519 "bison_parser.y" /* yacc.c:1646  */
+#line 533 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.group_t) = NULL; }
-#line 2249 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2715 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 64:
-#line 523 "bison_parser.y" /* yacc.c:1646  */
+#line 537 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = (yyvsp[0].expr); }
-#line 2255 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2721 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 524 "bison_parser.y" /* yacc.c:1646  */
+#line 538 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = NULL; }
-#line 2261 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2727 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 527 "bison_parser.y" /* yacc.c:1646  */
+#line 541 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.order) = new OrderDescription((yyvsp[0].order_type), (yyvsp[-1].expr)); }
-#line 2267 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2733 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 528 "bison_parser.y" /* yacc.c:1646  */
+#line 542 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.order) = NULL; }
-#line 2273 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2739 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 532 "bison_parser.y" /* yacc.c:1646  */
+#line 546 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.order_type) = kOrderAsc; }
-#line 2279 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2745 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 533 "bison_parser.y" /* yacc.c:1646  */
+#line 547 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.order_type) = kOrderDesc; }
-#line 2285 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2751 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 534 "bison_parser.y" /* yacc.c:1646  */
+#line 548 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.order_type) = kOrderAsc; }
-#line 2291 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2757 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 539 "bison_parser.y" /* yacc.c:1646  */
+#line 553 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.limit) = new LimitDescription((yyvsp[0].expr)->ival, kNoOffset); delete (yyvsp[0].expr); }
-#line 2297 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2763 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 540 "bison_parser.y" /* yacc.c:1646  */
+#line 554 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.limit) = new LimitDescription((yyvsp[-2].expr)->ival, (yyvsp[0].expr)->ival); delete (yyvsp[-2].expr); delete (yyvsp[0].expr); }
-#line 2303 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2769 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 541 "bison_parser.y" /* yacc.c:1646  */
+#line 555 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.limit) = NULL; }
-#line 2309 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2775 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 548 "bison_parser.y" /* yacc.c:1646  */
+#line 562 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr_vec) = new std::vector<Expr*>(); (yyval.expr_vec)->push_back((yyvsp[0].expr)); }
-#line 2315 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2781 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 549 "bison_parser.y" /* yacc.c:1646  */
+#line 563 "bison_parser.y" /* yacc.c:1646  */
     { (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr)); (yyval.expr_vec) = (yyvsp[-2].expr_vec); }
-#line 2321 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2787 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 553 "bison_parser.y" /* yacc.c:1646  */
+#line 567 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr_vec) = new std::vector<Expr*>(); (yyval.expr_vec)->push_back((yyvsp[0].expr)); }
-#line 2327 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2793 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 554 "bison_parser.y" /* yacc.c:1646  */
+#line 568 "bison_parser.y" /* yacc.c:1646  */
     { (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr)); (yyval.expr_vec) = (yyvsp[-2].expr_vec); }
-#line 2333 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2799 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 558 "bison_parser.y" /* yacc.c:1646  */
+#line 572 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.expr) = (yyvsp[-1].expr);
 			(yyval.expr)->alias = (yyvsp[0].sval);
 		}
-#line 2342 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2808 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 79:
-#line 565 "bison_parser.y" /* yacc.c:1646  */
+#line 579 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = (yyvsp[-1].expr); }
-#line 2348 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2814 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 87:
-#line 579 "bison_parser.y" /* yacc.c:1646  */
+#line 593 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpUnary(Expr::UMINUS, (yyvsp[0].expr)); }
-#line 2354 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2820 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 580 "bison_parser.y" /* yacc.c:1646  */
+#line 594 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpUnary(Expr::NOT, (yyvsp[0].expr)); }
-#line 2360 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2826 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 585 "bison_parser.y" /* yacc.c:1646  */
+#line 599 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '-', (yyvsp[0].expr)); }
-#line 2366 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2832 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 586 "bison_parser.y" /* yacc.c:1646  */
+#line 600 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '+', (yyvsp[0].expr)); }
-#line 2372 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2838 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 587 "bison_parser.y" /* yacc.c:1646  */
+#line 601 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '/', (yyvsp[0].expr)); }
-#line 2378 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2844 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 588 "bison_parser.y" /* yacc.c:1646  */
+#line 602 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '*', (yyvsp[0].expr)); }
-#line 2384 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2850 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 94:
-#line 589 "bison_parser.y" /* yacc.c:1646  */
+#line 603 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '%', (yyvsp[0].expr)); }
-#line 2390 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2856 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 590 "bison_parser.y" /* yacc.c:1646  */
+#line 604 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '^', (yyvsp[0].expr)); }
-#line 2396 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2862 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 96:
-#line 591 "bison_parser.y" /* yacc.c:1646  */
+#line 605 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), Expr::AND, (yyvsp[0].expr)); }
-#line 2402 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2868 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 592 "bison_parser.y" /* yacc.c:1646  */
+#line 606 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), Expr::OR, (yyvsp[0].expr)); }
-#line 2408 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2874 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 593 "bison_parser.y" /* yacc.c:1646  */
+#line 607 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), Expr::LIKE, (yyvsp[0].expr)); }
-#line 2414 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2880 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 594 "bison_parser.y" /* yacc.c:1646  */
+#line 608 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-3].expr), Expr::NOT_LIKE, (yyvsp[0].expr)); }
-#line 2420 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2886 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 100:
-#line 599 "bison_parser.y" /* yacc.c:1646  */
+#line 613 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '=', (yyvsp[0].expr)); }
-#line 2426 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2892 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 600 "bison_parser.y" /* yacc.c:1646  */
+#line 614 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), Expr::NOT_EQUALS, (yyvsp[0].expr)); }
-#line 2432 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2898 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 601 "bison_parser.y" /* yacc.c:1646  */
+#line 615 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '<', (yyvsp[0].expr)); }
-#line 2438 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2904 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 602 "bison_parser.y" /* yacc.c:1646  */
+#line 616 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '>', (yyvsp[0].expr)); }
-#line 2444 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2910 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 603 "bison_parser.y" /* yacc.c:1646  */
+#line 617 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), Expr::LESS_EQ, (yyvsp[0].expr)); }
-#line 2450 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2916 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 604 "bison_parser.y" /* yacc.c:1646  */
+#line 618 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), Expr::GREATER_EQ, (yyvsp[0].expr)); }
-#line 2456 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2922 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 608 "bison_parser.y" /* yacc.c:1646  */
+#line 622 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-4].sval), (yyvsp[-1].expr), (yyvsp[-2].bval)); }
-#line 2462 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2928 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 612 "bison_parser.y" /* yacc.c:1646  */
+#line 626 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeColumnRef((yyvsp[0].sval)); }
-#line 2468 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2934 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 613 "bison_parser.y" /* yacc.c:1646  */
+#line 627 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeColumnRef((yyvsp[-2].sval), (yyvsp[0].sval)); }
-#line 2474 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2940 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 623 "bison_parser.y" /* yacc.c:1646  */
+#line 637 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeLiteral((yyvsp[0].sval)); }
-#line 2480 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2946 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 113:
-#line 628 "bison_parser.y" /* yacc.c:1646  */
+#line 642 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeLiteral((yyvsp[0].fval)); }
-#line 2486 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2952 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 633 "bison_parser.y" /* yacc.c:1646  */
+#line 647 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = Expr::makeLiteral((yyvsp[0].ival)); }
-#line 2492 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2958 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 637 "bison_parser.y" /* yacc.c:1646  */
+#line 651 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.expr) = new Expr(kExprStar); }
-#line 2498 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2964 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 642 "bison_parser.y" /* yacc.c:1646  */
+#line 656 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.expr) = Expr::makePlaceholder(yylloc.total_column);
 			yyloc.placeholder_list.push_back((yyval.expr));
 		}
-#line 2507 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2973 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 654 "bison_parser.y" /* yacc.c:1646  */
+#line 668 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyvsp[0].table_vec)->push_back((yyvsp[-2].table));
 			auto tbl = new TableRef(kTableCrossProduct);
 			tbl->list = (yyvsp[0].table_vec);
 			(yyval.table) = tbl;
 		}
-#line 2518 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2984 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 665 "bison_parser.y" /* yacc.c:1646  */
+#line 679 "bison_parser.y" /* yacc.c:1646  */
     {
 			auto tbl = new TableRef(kTableSelect);
 			tbl->select = (yyvsp[-2].select_stmt);
 			tbl->alias = (yyvsp[0].sval);
 			(yyval.table) = tbl;
 		}
-#line 2529 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2995 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 123:
-#line 676 "bison_parser.y" /* yacc.c:1646  */
+#line 690 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.table_vec) = new std::vector<TableRef*>(); (yyval.table_vec)->push_back((yyvsp[0].table)); }
-#line 2535 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3001 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 124:
-#line 677 "bison_parser.y" /* yacc.c:1646  */
+#line 691 "bison_parser.y" /* yacc.c:1646  */
     { (yyvsp[-2].table_vec)->push_back((yyvsp[0].table)); (yyval.table_vec) = (yyvsp[-2].table_vec); }
-#line 2541 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3007 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 125:
-#line 682 "bison_parser.y" /* yacc.c:1646  */
+#line 696 "bison_parser.y" /* yacc.c:1646  */
     {
 			auto tbl = new TableRef(kTableName);
 			tbl->name = (yyvsp[-1].sval);
 			tbl->alias = (yyvsp[0].sval);
 			(yyval.table) = tbl;
 		}
-#line 2552 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3018 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 126:
-#line 692 "bison_parser.y" /* yacc.c:1646  */
+#line 706 "bison_parser.y" /* yacc.c:1646  */
     {
 			(yyval.table) = new TableRef(kTableName);
 			(yyval.table)->name = (yyvsp[0].sval);
 		}
-#line 2561 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3027 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 129:
-#line 706 "bison_parser.y" /* yacc.c:1646  */
+#line 720 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.sval) = (yyvsp[0].sval); }
-#line 2567 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3033 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 132:
-#line 712 "bison_parser.y" /* yacc.c:1646  */
+#line 726 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.sval) = NULL; }
-#line 2573 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3039 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 133:
-#line 721 "bison_parser.y" /* yacc.c:1646  */
+#line 735 "bison_parser.y" /* yacc.c:1646  */
     { 
 			(yyval.table) = new TableRef(kTableJoin);
 			(yyval.table)->join = new JoinDefinition();
@@ -2582,64 +3048,64 @@ yyreduce:
 			(yyval.table)->join->right = (yyvsp[-2].table);
 			(yyval.table)->join->condition = (yyvsp[0].expr);
 		}
-#line 2586 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3052 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 134:
-#line 732 "bison_parser.y" /* yacc.c:1646  */
+#line 746 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.uval) = kJoinInner; }
-#line 2592 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3058 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 135:
-#line 733 "bison_parser.y" /* yacc.c:1646  */
+#line 747 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.uval) = kJoinOuter; }
-#line 2598 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3064 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 136:
-#line 734 "bison_parser.y" /* yacc.c:1646  */
+#line 748 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.uval) = kJoinLeft; }
-#line 2604 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3070 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 137:
-#line 735 "bison_parser.y" /* yacc.c:1646  */
+#line 749 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.uval) = kJoinRight; }
-#line 2610 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3076 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 138:
-#line 736 "bison_parser.y" /* yacc.c:1646  */
+#line 750 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.uval) = kJoinInner; }
-#line 2616 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3082 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 139:
-#line 742 "bison_parser.y" /* yacc.c:1646  */
+#line 756 "bison_parser.y" /* yacc.c:1646  */
     {
 			auto tbl = new TableRef(kTableSelect);
 			tbl->select = (yyvsp[-2].select_stmt);
 			tbl->alias = (yyvsp[0].sval);
 			(yyval.table) = tbl;
 		}
-#line 2627 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3093 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 144:
-#line 767 "bison_parser.y" /* yacc.c:1646  */
+#line 781 "bison_parser.y" /* yacc.c:1646  */
     { (yyval.str_vec) = new std::vector<char*>(); (yyval.str_vec)->push_back((yyvsp[0].sval)); }
-#line 2633 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3099 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
   case 145:
-#line 768 "bison_parser.y" /* yacc.c:1646  */
+#line 782 "bison_parser.y" /* yacc.c:1646  */
     { (yyvsp[-2].str_vec)->push_back((yyvsp[0].sval)); (yyval.str_vec) = (yyvsp[-2].str_vec); }
-#line 2639 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3105 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 
 
-#line 2643 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3109 "bison_parser.cpp" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -2874,7 +3340,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 771 "bison_parser.y" /* yacc.c:1906  */
+#line 785 "bison_parser.y" /* yacc.c:1906  */
 
 /*********************************
  ** Section 4: Additional C code

--- a/src/parser/bison_parser.cpp
+++ b/src/parser/bison_parser.cpp
@@ -1967,7 +1967,7 @@ yyreduce:
 
   case 22:
 #line 306 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.sval) = (yyvsp[0].expr)->name; }
+    { (yyval.sval) = strdup((yyvsp[0].expr)->name); delete (yyvsp[0].expr); }
 #line 1972 "bison_parser.cpp" /* yacc.c:1646  */
     break;
 

--- a/src/parser/bison_parser.h
+++ b/src/parser/bison_parser.h
@@ -48,7 +48,7 @@
 extern int hsql_debug;
 #endif
 /* "%code requires" blocks.  */
-#line 40 "bison_parser.y" /* yacc.c:1909  */
+#line 41 "bison_parser.y" /* yacc.c:1909  */
 
 // %code requires block	
 
@@ -209,7 +209,7 @@ extern int hsql_debug;
 typedef union HSQL_STYPE HSQL_STYPE;
 union HSQL_STYPE
 {
-#line 99 "bison_parser.y" /* yacc.c:1909  */
+#line 100 "bison_parser.y" /* yacc.c:1909  */
 
 	double fval;
 	int64_t ival;

--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -19,6 +19,7 @@
 using namespace hsql;
 
 int yyerror(YYLTYPE* llocp, SQLParserResult** result, yyscan_t scanner, const char *msg) {
+	delete *result;
 
 	SQLParserResult* list = new SQLParserResult();
 	list->setIsValid(false);
@@ -132,6 +133,19 @@ int yyerror(YYLTYPE* llocp, SQLParserResult** result, yyscan_t scanner, const ch
 	std::vector<hsql::Expr*>* expr_vec;
 }
 
+
+/*********************************
+ ** Descrutor symbols
+ *********************************/
+%destructor { } <fval> <ival> <uval> <bval> <order_type>
+%destructor { free( ($$) ); } <sval>
+%destructor {
+	for (auto ptr : *($$)) {
+		delete ptr;
+	}
+	delete ($$);
+} <str_vec> <table_vec> <column_vec> <update_vec> <expr_vec>
+%destructor { delete ($$); } <*>
 
 
 /*********************************

--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -303,7 +303,7 @@ import_file_type:
 	;
 
 file_path:
-		string_literal { $$ = $1->name; }
+		string_literal { $$ = strdup($1->name); delete $1; }
 	;
 
 

--- a/src/sql/CreateStatement.h
+++ b/src/sql/CreateStatement.h
@@ -34,8 +34,8 @@ namespace hsql {
 
     CreateType type;
     bool ifNotExists; // default: false
-    const char* filePath; // default: NULL
-    const char* tableName; // default: NULL
+    char* filePath; // default: NULL
+    char* tableName; // default: NULL
     std::vector<ColumnDefinition*>* columns; // default: NULL
   };
 

--- a/src/sql/DropStatement.h
+++ b/src/sql/DropStatement.h
@@ -20,7 +20,7 @@ namespace hsql {
     virtual ~DropStatement();
 
     EntityType type;
-    const char* name;
+    char* name;
   };
 
 } // namespace hsql

--- a/src/sql/ExecuteStatement.h
+++ b/src/sql/ExecuteStatement.h
@@ -12,7 +12,7 @@ namespace hsql {
     ExecuteStatement();
     virtual ~ExecuteStatement();
 
-    const char* name;
+    char* name;
     std::vector<Expr*>* parameters;
   };
 

--- a/src/sql/Expr.cpp
+++ b/src/sql/Expr.cpp
@@ -124,7 +124,7 @@ namespace hsql {
 
   char* substr(const char* source, int from, int to) {
     int len = to - from;
-    char* copy = new char[len + 1];
+    char* copy = (char*) malloc(len + 1);;
     strncpy(copy, source + from, len);
     copy[len] = '\0';
     return copy;

--- a/src/sql/Expr.cpp
+++ b/src/sql/Expr.cpp
@@ -16,8 +16,9 @@ namespace hsql {
   Expr::~Expr() {
     delete expr;
     delete expr2;
-    delete name;
-    delete table;
+    free(name);
+    free(table);
+    free(alias);
   }
 
   Expr* Expr::makeOpUnary(OperatorType op, Expr* expr) {

--- a/src/sql/InsertStatement.h
+++ b/src/sql/InsertStatement.h
@@ -19,7 +19,7 @@ namespace hsql {
     virtual ~InsertStatement();
 
     InsertType type;
-    const char* tableName;
+    char* tableName;
     std::vector<char*>* columns;
     std::vector<Expr*>* values;
     SelectStatement* select;

--- a/src/sql/PrepareStatement.h
+++ b/src/sql/PrepareStatement.h
@@ -23,8 +23,12 @@ namespace hsql {
      */
     void setPlaceholders(std::vector<void*> ph);
 
-    const char* name;
+    char* name;
     SQLParserResult* query;
+
+    // The expressions are not owned by this statement.
+    // Rather they are owned by the query and destroyed, when
+    // the query is destroyed.
     std::vector<Expr*> placeholders;
   };
 

--- a/src/sql/statements.cpp
+++ b/src/sql/statements.cpp
@@ -192,6 +192,7 @@ namespace hsql {
     delete fromTable;
     delete whereClause;
     delete groupBy;
+    delete unionSelect;
     delete order;
     delete limit;
 
@@ -236,10 +237,19 @@ namespace hsql {
     join(NULL) {}
 
   TableRef::~TableRef() {
+    free(schema);
     free(name);
     free(alias);
+
     delete select;
-    delete list;
+    delete join;
+
+    if (list != NULL) {
+      for (TableRef* table : *list) {
+        delete table;
+      }
+      delete list;
+    }
   }
 
   bool TableRef::hasSchema() {

--- a/src/sql/statements.cpp
+++ b/src/sql/statements.cpp
@@ -142,8 +142,14 @@ namespace hsql {
     having(NULL) {}
 
   GroupByDescription::~GroupByDescription() {
-    delete columns;
     delete having;
+
+    if (columns != NULL) {
+      for (Expr* expr : *columns) {
+        delete expr;
+      }
+      delete columns;
+    }
   }
 
   // SelectStatement
@@ -160,11 +166,18 @@ namespace hsql {
 
   SelectStatement::~SelectStatement() {
     delete fromTable;
-    delete selectList;
     delete whereClause;
     delete groupBy;
     delete order;
     delete limit;
+
+    // Delete each element in the select list.
+    if (selectList != NULL) {
+      for (Expr* expr : *selectList) {
+        delete expr;
+      }
+      delete selectList;
+    }
   }
 
   // UpdateStatement
@@ -191,8 +204,8 @@ namespace hsql {
     join(NULL) {}
 
   TableRef::~TableRef() {
-    delete name;
-    delete alias;
+    free(name);
+    free(alias);
     delete select;
     delete list;
   }

--- a/test/lib/helper.h
+++ b/test/lib/helper.h
@@ -2,21 +2,21 @@
 #define __HELPER_H__
 
 
-#define TEST_PARSE_SQL_QUERY(query, outputVar, numStatements) \
-	const SQLParserResult* outputVar = SQLParser::parseSQLString(query); \
-	ASSERT(outputVar->isValid()); \
-	ASSERT_EQ(outputVar->size(), numStatements);
+#define TEST_PARSE_SQL_QUERY(query, result, numStatements) \
+	const SQLParserResult* result = SQLParser::parseSQLString(query); \
+	ASSERT(result->isValid()); \
+	ASSERT_EQ(result->size(), numStatements);
 
 
-#define TEST_PARSE_SINGLE_SQL(query, stmtType, stmtClass, outputVar) \
-	TEST_PARSE_SQL_QUERY(query, stmt_list, 1); \
-    ASSERT_EQ(stmt_list->getStatement(0)->type(), stmtType); \
-    const stmtClass* outputVar = (const stmtClass*) stmt_list->getStatement(0);
+#define TEST_PARSE_SINGLE_SQL(query, stmtType, stmtClass, result, outputVar) \
+	TEST_PARSE_SQL_QUERY(query, result, 1); \
+    ASSERT_EQ(result->getStatement(0)->type(), stmtType); \
+    const stmtClass* outputVar = (const stmtClass*) result->getStatement(0);
 
 
-#define TEST_CAST_STMT(stmt_list, stmt_index, stmtType, stmtClass, outputVar) \
-    ASSERT_EQ(stmt_list->getStatement(stmt_index)->type(), stmtType); \
-    const stmtClass* outputVar = (const stmtClass*) stmt_list->getStatement(stmt_index);
+#define TEST_CAST_STMT(result, stmt_index, stmtType, stmtClass, outputVar) \
+    ASSERT_EQ(result->getStatement(stmt_index)->type(), stmtType); \
+    const stmtClass* outputVar = (const stmtClass*) result->getStatement(stmt_index);
 
 
 #endif

--- a/test/lib/select.cpp
+++ b/test/lib/select.cpp
@@ -7,15 +7,28 @@
 using namespace hsql;
 
 TEST(SelectTest) {
-  TEST_PARSE_SINGLE_SQL("SELECT * FROM students;", kStmtSelect, SelectStatement, stmt);
+  TEST_PARSE_SINGLE_SQL(
+    "SELECT * FROM students;",
+    kStmtSelect,
+    SelectStatement,
+    result,
+    stmt);
 
   ASSERT_NULL(stmt->whereClause);
   ASSERT_NULL(stmt->groupBy);
+
+  delete result;
 }
 
 
 TEST(SelectHavingTest) {
-  TEST_PARSE_SINGLE_SQL("SELECT city, AVG(grade) AS avg_grade FROM students GROUP BY city HAVING AVG(grade) < 2.0", kStmtSelect, SelectStatement, stmt);
+  TEST_PARSE_SINGLE_SQL(
+    "SELECT city, AVG(grade) AS avg_grade FROM students GROUP BY city HAVING AVG(grade) < 2.0",
+    kStmtSelect,
+    SelectStatement,
+    result,
+    stmt);
+
   ASSERT_FALSE(stmt->selectDistinct);
 
   GroupByDescription* group = stmt->groupBy;
@@ -24,23 +37,39 @@ TEST(SelectHavingTest) {
   ASSERT(group->having->isSimpleOp('<'));
   ASSERT(group->having->expr->isType(kExprFunctionRef));
   ASSERT(group->having->expr2->isType(kExprLiteralFloat));
+
+  delete result;
 }
 
 
 TEST(SelectDistinctTest) {
-  TEST_PARSE_SINGLE_SQL("SELECT DISTINCT grade, city FROM students;", kStmtSelect, SelectStatement, stmt);
+  TEST_PARSE_SINGLE_SQL(
+    "SELECT DISTINCT grade, city FROM students;",
+    kStmtSelect,
+    SelectStatement, 
+    result,
+    stmt);
 
   ASSERT(stmt->selectDistinct);
   ASSERT_NULL(stmt->whereClause);
+
+  delete result;
 }
 
 TEST(SelectGroupDistinctTest) {
-  TEST_PARSE_SINGLE_SQL("SELECT city, COUNT(name), COUNT(DISTINCT grade) FROM students GROUP BY city;", kStmtSelect, SelectStatement, stmt);
+  TEST_PARSE_SINGLE_SQL(
+    "SELECT city, COUNT(name), COUNT(DISTINCT grade) FROM students GROUP BY city;",
+    kStmtSelect,
+    SelectStatement,
+    result,
+    stmt);
 
   ASSERT_FALSE(stmt->selectDistinct);
   ASSERT_EQ(stmt->selectList->size(), 3);
   ASSERT(!stmt->selectList->at(1)->distinct);
   ASSERT(stmt->selectList->at(2)->distinct);
+
+  delete result;
 }
 
 

--- a/test/lib/test.cpp
+++ b/test/lib/test.cpp
@@ -8,13 +8,13 @@ class TestsManager {
   // http://www.parashift.com/c++-faq-lite/static-init-order-on-first-use.html
  public:
   static std::vector<std::string>& testNames() {
-    static std::vector<std::string>* _testNames = new std::vector<std::string>;
-    return *_testNames;
+    static std::vector<std::string> testNames;
+    return testNames;
   }
 
   static std::vector<void (*)(void)>& tests() {
-    static std::vector<void (*)(void)>* tests = new std::vector<void (*)(void)>;
-    return *tests;
+    static std::vector<void (*)(void)> tests;
+    return tests;
   }
 };
 

--- a/test/lib/test.h
+++ b/test/lib/test.h
@@ -7,8 +7,10 @@
 
 
 #define TEST(name) \
-	void name(); \
-	namespace g_dummy { int _##name = AddTest(name, #name); } \
+	void name();\
+	namespace g_dummy {\
+		int _##name = AddTest(name, #name);\
+	}\
 	void name()
 
 

--- a/test/lib/valid_queries.sql
+++ b/test/lib/valid_queries.sql
@@ -6,7 +6,7 @@ SELECT * from "table" JOIN table2 ON a = b WHERE (b OR NOT a) AND a = 12.5
 (SELECT a FROM foo WHERE a > 12 OR b > 3 AND c NOT LIKE 's%' LIMIT 10);
 SELECT * FROM "table" LIMIT 10 OFFSET 10; SELECT * FROM second;
 SELECT * FROM t1 UNION SELECT * FROM t2 ORDER BY col1;
-# SELECT * FROM t1 UNION (SELECT * FROM t2 UNION SELECT * FROM t3) ORDER BY col1; 
+-- SELECT * FROM t1 UNION (SELECT * FROM t2 UNION SELECT * FROM t3) ORDER BY col1; 
 # JOIN
 SELECT t1.a, t1.b, t2.c FROM "table" AS t1 JOIN (SELECT * FROM foo JOIN bar ON foo.id = bar.id) t2 ON t1.a = t2.b WHERE (t1.b OR NOT t1.a) AND t2.c = 12.5
 SELECT * FROM t1 JOIN t2 ON c1 = c2;

--- a/test/lib/valid_queries.sql
+++ b/test/lib/valid_queries.sql
@@ -37,3 +37,10 @@ PREPARE prep2 { INSERT INTO test VALUES (?, 0, 0); INSERT INTO test VALUES (0, ?
 EXECUTE prep_inst(1, 2, 3);
 EXECUTE prep;
 DEALLOCATE PREPARE prep;
+# Error expeced
+!
+!1
+!gibberish;
+!SELECT abc;
+!CREATE TABLE "table" FROM TBL FILE 'students.tbl';SELECT 1
+!CREATE TABLE "table" FROM TBL FILE 'students.tbl';1

--- a/test/sql_grammar_test.cpp
+++ b/test/sql_grammar_test.cpp
@@ -36,14 +36,14 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    bool expectFalse = false;
+    bool globalExpectFalse = false;
     bool useFile = false;
     std::string filePath = "";
     
     // Parse command line arguments
     int i = 1;
     for (; i < argc; ++i) {
-        if (STREQ(argv[i], "--false")) expectFalse = true;
+        if (STREQ(argv[i], "--false")) globalExpectFalse = true;
         else if (STREQ(argv[i], "-f")) {
             useFile = true;
             filePath = argv[++i];
@@ -65,6 +65,12 @@ int main(int argc, char *argv[]) {
     // Execute queries
     int numFailed = 0;
     for (std::string sql : queries) {
+        bool expectFalse = globalExpectFalse;
+        if (sql.at(0) == '!') {
+            expectFalse = !expectFalse;
+            sql = sql.substr(1);
+        }
+
         // Measuring the parsing time
         std::chrono::time_point<std::chrono::system_clock> start, end;
         start = std::chrono::system_clock::now();

--- a/test/sql_grammar_test.cpp
+++ b/test/sql_grammar_test.cpp
@@ -18,9 +18,12 @@ std::vector<std::string> readlines(std::string path) {
         std::istringstream iss(line);
 
         // Skip comments
-        if (line[0] != '#') {
-            lines.push_back(line);
+        if (line[0] == '#' || 
+            (line[0] == '-' && line[1] == '-')) {
+            continue;
         }
+        
+        lines.push_back(line);
     }
     return lines;
 }
@@ -82,6 +85,8 @@ int main(int argc, char *argv[]) {
             // TODO: indicate whether expectFalse was set
             printf("\033[0;32m{      ok} (%.1fus)\033[0m %s\n", us, sql.c_str());
         }
+
+        delete result;
     }
 
     if (numFailed == 0) {

--- a/test/sql_tests.cpp
+++ b/test/sql_tests.cpp
@@ -22,6 +22,8 @@ TEST(DeleteStatementTest) {
 	ASSERT(stmt->expr->isType(kExprOperator));
 	ASSERT_STREQ(stmt->expr->expr->name, "grade");
 	ASSERT_EQ(stmt->expr->expr2->fval, 2.0);
+
+	delete result;
 }
 
 TEST(CreateStatementTest) {
@@ -43,6 +45,8 @@ TEST(CreateStatementTest) {
 	ASSERT_EQ(stmt->columns->at(1)->type, ColumnDefinition::INT);
 	ASSERT_EQ(stmt->columns->at(2)->type, ColumnDefinition::INT);
 	ASSERT_EQ(stmt->columns->at(3)->type, ColumnDefinition::DOUBLE);
+
+	delete result;
 }
 
 
@@ -69,25 +73,40 @@ TEST(UpdateStatementTest) {
 	ASSERT(stmt->where->isType(kExprOperator));
 	ASSERT(stmt->where->isSimpleOp('='));
 	ASSERT_STREQ(stmt->where->expr->name, "name");
-	ASSERT_STREQ(stmt->where->expr2->name, "Max Mustermann");
+	ASSERT_STREQ(stmt->where->expr2->name, "Max Mustermann");\
 
+	delete result;
 }
 
 
 TEST(InsertStatementTest) {
-	TEST_PARSE_SINGLE_SQL("INSERT INTO students VALUES ('Max Mustermann', 12345, 'Musterhausen', 2.0)", kStmtInsert, InsertStatement, stmt);
+	TEST_PARSE_SINGLE_SQL(
+		"INSERT INTO students VALUES ('Max Mustermann', 12345, 'Musterhausen', 2.0)",
+		kStmtInsert,
+		InsertStatement,
+		result,
+		stmt);
 
 	ASSERT_EQ(stmt->values->size(), 4);
 	// TODO
+
+	delete result;
 }
 
 
 TEST(DropTableStatementTest) {
-	TEST_PARSE_SINGLE_SQL("DROP TABLE students", kStmtDrop, DropStatement, stmt);
+	TEST_PARSE_SINGLE_SQL(
+		"DROP TABLE students",
+		kStmtDrop,
+		DropStatement,
+		result,
+		stmt);
 
 	ASSERT_EQ(stmt->type, DropStatement::kTable);
 	ASSERT_NOTNULL(stmt->name);
 	ASSERT_STREQ(stmt->name, "students");
+
+	delete result;
 }
 
 
@@ -134,12 +153,16 @@ TEST(PrepareStatementTest) {
 	// Deallocate Statement
 	ASSERT_EQ(drop->type, DropStatement::kPreparedStatement);
 	ASSERT_STREQ(drop->name, "stmt");
+
+	delete result;
 }
 
 
 TEST(ExecuteStatementTest) {
-	TEST_PARSE_SINGLE_SQL("EXECUTE test(1, 2);", kStmtExecute, ExecuteStatement, stmt);
+	TEST_PARSE_SINGLE_SQL("EXECUTE test(1, 2);", kStmtExecute, ExecuteStatement, result, stmt);
 
 	ASSERT_STREQ(stmt->name, "test");
 	ASSERT_EQ(stmt->parameters->size(), 2);
+
+	delete result;
 }


### PR DESCRIPTION
Includes:
 * Fixes several memory leaks in the parser.
 * Valgrind used for leak detection.
 * Adds automatic leak detection to CI script (using valgrind)
 * Fixes CI builds to always use bison 3.0.4

Note: Inspired by @ahalam 's PR #20. Thanks for your work!