### PR TITLE
Fix: use correct format specifiers for int64

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[]) {
     printf("Parsed successfully!\n");
     printf("Number of statements: %lu\n", result.size());
 
-    for (uint i = 0; i < result.size(); ++i) {
+    for (auto i = 0u; i < result.size(); ++i) {
       // Print a statement summary.
       hsql::printStatementInfo(result.getStatement(i));
     }

--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -1,6 +1,6 @@
 
 #include "sqlhelper.h"
-#include <stdio.h>
+#include <iostream>
 #include <string>
 
 namespace hsql {
@@ -11,22 +11,22 @@ namespace hsql {
     return std::string(numIndent, '\t');
   }
   void inprint(int64_t val, uintmax_t numIndent) {
-    printf("%s%lld  \n", indent(numIndent).c_str(), val);
+    std::cout << indent(numIndent).c_str() << val << "  " << std::endl;
   }
   void inprint(float val, uintmax_t numIndent) {
-    printf("%s%f\n", indent(numIndent).c_str(), val);
+    std::cout << indent(numIndent).c_str() << val << std::endl;
   }
   void inprint(const char* val, uintmax_t numIndent) {
-    printf("%s%s\n", indent(numIndent).c_str(), val);
+    std::cout << indent(numIndent).c_str() << val << std::endl;
   }
   void inprint(const char* val, const char* val2, uintmax_t numIndent) {
-    printf("%s%s->%s\n", indent(numIndent).c_str(), val, val2);
+    std::cout << indent(numIndent).c_str() << val << "->" << val2 << std::endl;
   }
   void inprintC(char val, uintmax_t numIndent) {
-    printf("%s%c\n", indent(numIndent).c_str(), val);
+    std::cout << indent(numIndent).c_str() << val << std::endl;
   }
   void inprintU(uint64_t val, uintmax_t numIndent) {
-    printf("%s%llu\n", indent(numIndent).c_str(), val);
+    std::cout << indent(numIndent).c_str() << val << std::endl;
   }
 
   void printTableRefInfo(TableRef* table, uintmax_t numIndent) {
@@ -109,7 +109,7 @@ namespace hsql {
       printOperatorExpression(expr, numIndent);
       break;
     default:
-      fprintf(stderr, "Unrecognized expression type %d\n", expr->type);
+      std::cerr << "Unrecognized expression type " << expr->type << std::endl;
       return;
     }
     if (expr->alias != nullptr) {

--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -11,7 +11,7 @@ namespace hsql {
     return std::string(numIndent, '\t');
   }
   void inprint(int64_t val, uintmax_t numIndent) {
-    printf("%s%ld  \n", indent(numIndent).c_str(), val);
+    printf("%s%lld  \n", indent(numIndent).c_str(), val);
   }
   void inprint(float val, uintmax_t numIndent) {
     printf("%s%f\n", indent(numIndent).c_str(), val);
@@ -26,7 +26,7 @@ namespace hsql {
     printf("%s%c\n", indent(numIndent).c_str(), val);
   }
   void inprintU(uint64_t val, uintmax_t numIndent) {
-    printf("%s%lu\n", indent(numIndent).c_str(), val);
+    printf("%s%llu\n", indent(numIndent).c_str(), val);
   }
 
   void printTableRefInfo(TableRef* table, uintmax_t numIndent) {


### PR DESCRIPTION
This PR fixes two compiler warnings regarding format specifiers (macOS / clang):

```c++
src/util/sqlhelper.cpp:14:52: warning:
      format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Wformat]
    printf("%s%ld  \n", indent(numIndent).c_str(), val);
              ~~~                                  ^~~
              %lld
sql-parser/src/util/sqlhelper.cpp:29:50: warning:
      format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
    printf("%s%lu\n", indent(numIndent).c_str(), val);
              ~~~                                ^~~
              %llu