### PR TITLE
Fix formatter warnings

### DIFF
--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -11,7 +11,7 @@ namespace hsql {
     return std::string(numIndent, '\t');
   }
   void inprint(int64_t val, uintmax_t numIndent) {
-    printf("%s%ld  \n", indent(numIndent).c_str(), val);
+    printf("%s%lld  \n", indent(numIndent).c_str(), val);
   }
   void inprint(float val, uintmax_t numIndent) {
     printf("%s%f\n", indent(numIndent).c_str(), val);
@@ -26,7 +26,7 @@ namespace hsql {
     printf("%s%c\n", indent(numIndent).c_str(), val);
   }
   void inprintU(uint64_t val, uintmax_t numIndent) {
-    printf("%s%lu\n", indent(numIndent).c_str(), val);
+    printf("%s%llu\n", indent(numIndent).c_str(), val);
   }
 
   void printTableRefInfo(TableRef* table, uintmax_t numIndent) {


### PR DESCRIPTION
This PR fixes the following warnings on current `g++` and `clang` compilers:

```C++
src/util/sqlhelper.cpp:14:52: warning: format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Wformat]
    printf("%s%ld  \n", indent(numIndent).c_str(), val);
              ~~~                                  ^~~
              %lld
src/util/sqlhelper.cpp:29:50: warning: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
    printf("%s%lu\n", indent(numIndent).c_str(), val);
              ~~~                                ^~~
              %llu
```