### PR TITLE
Add enum types for formerly 'simple' operands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ lib-test/
 *.out
 *.app
 
+# IDE
+.idea/
+
+# CMAKE
+cmake-build-debug/
+
 *.cpp.orig
 *.h.orig
 

--- a/src/parser/bison_parser.cpp
+++ b/src/parser/bison_parser.cpp
@@ -2228,7 +2228,7 @@ YYLTYPE yylloc = yyloc_default;
   yychar = YYEMPTY; /* Cause a token to be read.  */
 
 /* User initialization code.  */
-#line 71 "bison_parser.y" /* yacc.c:1429  */
+#line 71 "bison_parser.y" /* yacc.c:1436  */
 {
 	// Initialize
 	yylloc.first_column = 0;
@@ -2238,7 +2238,7 @@ YYLTYPE yylloc = yyloc_default;
 	yylloc.total_column = 0;
 }
 
-#line 2242 "bison_parser.cpp" /* yacc.c:1429  */
+#line 2242 "bison_parser.cpp" /* yacc.c:1436  */
   yylsp[0] = yylloc;
   goto yysetstate;
 
@@ -2425,7 +2425,7 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 236 "bison_parser.y" /* yacc.c:1646  */
+#line 236 "bison_parser.y" /* yacc.c:1661  */
     {
 			for (SQLStatement* stmt : *(yyvsp[-1].stmt_vec)) {
 				// Transfers ownership of the statement.
@@ -2443,211 +2443,211 @@ yyreduce:
 			}
 			delete (yyvsp[-1].stmt_vec);
 		}
-#line 2447 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2447 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 3:
-#line 257 "bison_parser.y" /* yacc.c:1646  */
+#line 257 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.stmt_vec) = new std::vector<SQLStatement*>(); (yyval.stmt_vec)->push_back((yyvsp[0].statement)); }
-#line 2453 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2453 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 4:
-#line 258 "bison_parser.y" /* yacc.c:1646  */
+#line 258 "bison_parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].stmt_vec)->push_back((yyvsp[0].statement)); (yyval.stmt_vec) = (yyvsp[-2].stmt_vec); }
-#line 2459 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2459 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 5:
-#line 262 "bison_parser.y" /* yacc.c:1646  */
+#line 262 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.statement) = (yyvsp[-1].prep_stmt);
 			(yyval.statement)->hints = (yyvsp[0].expr_vec);
 		}
-#line 2468 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2468 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 6:
-#line 266 "bison_parser.y" /* yacc.c:1646  */
+#line 266 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.statement) = (yyvsp[-1].statement);
 			(yyval.statement)->hints = (yyvsp[0].expr_vec);
 		}
-#line 2477 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2477 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 7:
-#line 274 "bison_parser.y" /* yacc.c:1646  */
+#line 274 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.statement) = (yyvsp[0].select_stmt); }
-#line 2483 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2483 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 8:
-#line 275 "bison_parser.y" /* yacc.c:1646  */
+#line 275 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.statement) = (yyvsp[0].import_stmt); }
-#line 2489 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2489 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 9:
-#line 276 "bison_parser.y" /* yacc.c:1646  */
+#line 276 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.statement) = (yyvsp[0].create_stmt); }
-#line 2495 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2495 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 10:
-#line 277 "bison_parser.y" /* yacc.c:1646  */
+#line 277 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.statement) = (yyvsp[0].insert_stmt); }
-#line 2501 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2501 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 11:
-#line 278 "bison_parser.y" /* yacc.c:1646  */
+#line 278 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 2507 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2507 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 12:
-#line 279 "bison_parser.y" /* yacc.c:1646  */
+#line 279 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 2513 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2513 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 13:
-#line 280 "bison_parser.y" /* yacc.c:1646  */
+#line 280 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.statement) = (yyvsp[0].update_stmt); }
-#line 2519 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2519 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 14:
-#line 281 "bison_parser.y" /* yacc.c:1646  */
+#line 281 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.statement) = (yyvsp[0].drop_stmt); }
-#line 2525 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2525 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 15:
-#line 282 "bison_parser.y" /* yacc.c:1646  */
+#line 282 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.statement) = (yyvsp[0].exec_stmt); }
-#line 2531 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2531 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 16:
-#line 291 "bison_parser.y" /* yacc.c:1646  */
+#line 291 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr_vec) = (yyvsp[-1].expr_vec); }
-#line 2537 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2537 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 17:
-#line 292 "bison_parser.y" /* yacc.c:1646  */
+#line 292 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr_vec) = nullptr; }
-#line 2543 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2543 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 18:
-#line 297 "bison_parser.y" /* yacc.c:1646  */
+#line 297 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr_vec) = new std::vector<Expr*>(); (yyval.expr_vec)->push_back((yyvsp[0].expr)); }
-#line 2549 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2549 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 19:
-#line 298 "bison_parser.y" /* yacc.c:1646  */
+#line 298 "bison_parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr)); (yyval.expr_vec) = (yyvsp[-2].expr_vec); }
-#line 2555 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2555 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 20:
-#line 302 "bison_parser.y" /* yacc.c:1646  */
+#line 302 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.expr) = Expr::make(kExprHint);
 			(yyval.expr)->name = (yyvsp[0].sval);
 		}
-#line 2564 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2564 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 21:
-#line 306 "bison_parser.y" /* yacc.c:1646  */
+#line 306 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.expr) = Expr::make(kExprHint);
 			(yyval.expr)->name = (yyvsp[-3].sval);
 			(yyval.expr)->exprList = (yyvsp[-1].expr_vec);
 		}
-#line 2574 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2574 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 22:
-#line 318 "bison_parser.y" /* yacc.c:1646  */
+#line 318 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.prep_stmt) = new PrepareStatement();
 			(yyval.prep_stmt)->name = (yyvsp[-2].sval);
 			(yyval.prep_stmt)->query = (yyvsp[0].sval);
 		}
-#line 2584 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2584 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 24:
-#line 328 "bison_parser.y" /* yacc.c:1646  */
+#line 328 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.exec_stmt) = new ExecuteStatement();
 			(yyval.exec_stmt)->name = (yyvsp[0].sval);
 		}
-#line 2593 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2593 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 25:
-#line 332 "bison_parser.y" /* yacc.c:1646  */
+#line 332 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.exec_stmt) = new ExecuteStatement();
 			(yyval.exec_stmt)->name = (yyvsp[-3].sval);
 			(yyval.exec_stmt)->parameters = (yyvsp[-1].expr_vec);
 		}
-#line 2603 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2603 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 26:
-#line 344 "bison_parser.y" /* yacc.c:1646  */
+#line 344 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.import_stmt) = new ImportStatement((ImportType) (yyvsp[-4].uval));
 			(yyval.import_stmt)->filePath = (yyvsp[-2].sval);
 			(yyval.import_stmt)->tableName = (yyvsp[0].sval);
 		}
-#line 2613 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2613 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 27:
-#line 352 "bison_parser.y" /* yacc.c:1646  */
+#line 352 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = kImportCSV; }
-#line 2619 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2619 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 28:
-#line 356 "bison_parser.y" /* yacc.c:1646  */
+#line 356 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.sval) = strdup((yyvsp[0].expr)->name); delete (yyvsp[0].expr); }
-#line 2625 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2625 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 29:
-#line 366 "bison_parser.y" /* yacc.c:1646  */
+#line 366 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.create_stmt) = new CreateStatement(kCreateTableFromTbl);
 			(yyval.create_stmt)->ifNotExists = (yyvsp[-5].bval);
 			(yyval.create_stmt)->tableName = (yyvsp[-4].sval);
 			(yyval.create_stmt)->filePath = (yyvsp[0].sval);
 		}
-#line 2636 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2636 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 30:
-#line 372 "bison_parser.y" /* yacc.c:1646  */
+#line 372 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.create_stmt) = new CreateStatement(kCreateTable);
 			(yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
 			(yyval.create_stmt)->tableName = (yyvsp[-3].sval);
 			(yyval.create_stmt)->columns = (yyvsp[-1].column_vec);
 		}
-#line 2647 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2647 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 31:
-#line 378 "bison_parser.y" /* yacc.c:1646  */
+#line 378 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.create_stmt) = new CreateStatement(kCreateView);
 			(yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
@@ -2655,192 +2655,192 @@ yyreduce:
 			(yyval.create_stmt)->viewColumns = (yyvsp[-2].str_vec);
 			(yyval.create_stmt)->select = (yyvsp[0].select_stmt);
 		}
-#line 2659 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2659 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 32:
-#line 388 "bison_parser.y" /* yacc.c:1646  */
+#line 388 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.bval) = true; }
-#line 2665 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2665 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 33:
-#line 389 "bison_parser.y" /* yacc.c:1646  */
+#line 389 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.bval) = false; }
-#line 2671 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2671 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 34:
-#line 393 "bison_parser.y" /* yacc.c:1646  */
+#line 393 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.column_vec) = new std::vector<ColumnDefinition*>(); (yyval.column_vec)->push_back((yyvsp[0].column_t)); }
-#line 2677 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2677 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 35:
-#line 394 "bison_parser.y" /* yacc.c:1646  */
+#line 394 "bison_parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].column_vec)->push_back((yyvsp[0].column_t)); (yyval.column_vec) = (yyvsp[-2].column_vec); }
-#line 2683 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2683 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 36:
-#line 398 "bison_parser.y" /* yacc.c:1646  */
+#line 398 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.column_t) = new ColumnDefinition((yyvsp[-1].sval), (ColumnDefinition::DataType) (yyvsp[0].uval));
 		}
-#line 2691 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2691 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 37:
-#line 405 "bison_parser.y" /* yacc.c:1646  */
+#line 405 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = ColumnDefinition::INT; }
-#line 2697 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2697 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 38:
-#line 406 "bison_parser.y" /* yacc.c:1646  */
+#line 406 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = ColumnDefinition::INT; }
-#line 2703 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2703 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 39:
-#line 407 "bison_parser.y" /* yacc.c:1646  */
+#line 407 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = ColumnDefinition::DOUBLE; }
-#line 2709 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2709 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 40:
-#line 408 "bison_parser.y" /* yacc.c:1646  */
+#line 408 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = ColumnDefinition::TEXT; }
-#line 2715 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2715 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 41:
-#line 418 "bison_parser.y" /* yacc.c:1646  */
+#line 418 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.drop_stmt) = new DropStatement(kDropTable);
 			(yyval.drop_stmt)->name = (yyvsp[0].sval);
 		}
-#line 2724 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2724 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 42:
-#line 422 "bison_parser.y" /* yacc.c:1646  */
+#line 422 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.drop_stmt) = new DropStatement(kDropView);
 			(yyval.drop_stmt)->name = (yyvsp[0].sval);
 		}
-#line 2733 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2733 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 43:
-#line 426 "bison_parser.y" /* yacc.c:1646  */
+#line 426 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.drop_stmt) = new DropStatement(kDropPreparedStatement);
 			(yyval.drop_stmt)->name = (yyvsp[0].sval);
 		}
-#line 2742 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2742 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 44:
-#line 438 "bison_parser.y" /* yacc.c:1646  */
+#line 438 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.delete_stmt) = new DeleteStatement();
 			(yyval.delete_stmt)->tableName = (yyvsp[-1].sval);
 			(yyval.delete_stmt)->expr = (yyvsp[0].expr);
 		}
-#line 2752 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2752 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 45:
-#line 446 "bison_parser.y" /* yacc.c:1646  */
+#line 446 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.delete_stmt) = new DeleteStatement();
 			(yyval.delete_stmt)->tableName = (yyvsp[0].sval);
 		}
-#line 2761 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2761 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 46:
-#line 458 "bison_parser.y" /* yacc.c:1646  */
+#line 458 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.insert_stmt) = new InsertStatement(kInsertValues);
 			(yyval.insert_stmt)->tableName = (yyvsp[-5].sval);
 			(yyval.insert_stmt)->columns = (yyvsp[-4].str_vec);
 			(yyval.insert_stmt)->values = (yyvsp[-1].expr_vec);
 		}
-#line 2772 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2772 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 47:
-#line 464 "bison_parser.y" /* yacc.c:1646  */
+#line 464 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.insert_stmt) = new InsertStatement(kInsertSelect);
 			(yyval.insert_stmt)->tableName = (yyvsp[-2].sval);
 			(yyval.insert_stmt)->columns = (yyvsp[-1].str_vec);
 			(yyval.insert_stmt)->select = (yyvsp[0].select_stmt);
 		}
-#line 2783 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2783 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 48:
-#line 474 "bison_parser.y" /* yacc.c:1646  */
+#line 474 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.str_vec) = (yyvsp[-1].str_vec); }
-#line 2789 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2789 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 49:
-#line 475 "bison_parser.y" /* yacc.c:1646  */
+#line 475 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.str_vec) = nullptr; }
-#line 2795 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2795 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 50:
-#line 485 "bison_parser.y" /* yacc.c:1646  */
+#line 485 "bison_parser.y" /* yacc.c:1661  */
     {
 		(yyval.update_stmt) = new UpdateStatement();
 		(yyval.update_stmt)->table = (yyvsp[-3].table);
 		(yyval.update_stmt)->updates = (yyvsp[-1].update_vec);
 		(yyval.update_stmt)->where = (yyvsp[0].expr);
 	}
-#line 2806 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2806 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 51:
-#line 494 "bison_parser.y" /* yacc.c:1646  */
+#line 494 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.update_vec) = new std::vector<UpdateClause*>(); (yyval.update_vec)->push_back((yyvsp[0].update_t)); }
-#line 2812 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2812 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 52:
-#line 495 "bison_parser.y" /* yacc.c:1646  */
+#line 495 "bison_parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].update_vec)->push_back((yyvsp[0].update_t)); (yyval.update_vec) = (yyvsp[-2].update_vec); }
-#line 2818 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2818 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 53:
-#line 499 "bison_parser.y" /* yacc.c:1646  */
+#line 499 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.update_t) = new UpdateClause();
 			(yyval.update_t)->column = (yyvsp[-2].sval);
 			(yyval.update_t)->value = (yyvsp[0].expr);
 		}
-#line 2828 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2828 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 56:
-#line 516 "bison_parser.y" /* yacc.c:1646  */
+#line 516 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 2834 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2834 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 57:
-#line 517 "bison_parser.y" /* yacc.c:1646  */
+#line 517 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 2840 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2840 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 58:
-#line 521 "bison_parser.y" /* yacc.c:1646  */
+#line 521 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.select_stmt) = (yyvsp[-2].select_stmt);
 			(yyval.select_stmt)->order = (yyvsp[-1].order_vec);
@@ -2851,11 +2851,11 @@ yyreduce:
 				(yyval.select_stmt)->limit = (yyvsp[0].limit);
 			}
 		}
-#line 2855 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2855 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 59:
-#line 531 "bison_parser.y" /* yacc.c:1646  */
+#line 531 "bison_parser.y" /* yacc.c:1661  */
     {
 			// TODO: allow multiple unions (through linked list)
 			// TODO: capture type of set_operator
@@ -2870,11 +2870,11 @@ yyreduce:
 				(yyval.select_stmt)->limit = (yyvsp[0].limit);
 			}
 		}
-#line 2874 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2874 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 60:
-#line 545 "bison_parser.y" /* yacc.c:1646  */
+#line 545 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.select_stmt) = (yyvsp[-4].select_stmt);
 			(yyval.select_stmt)->unionSelect = (yyvsp[-2].select_stmt);
@@ -2886,11 +2886,11 @@ yyreduce:
 				(yyval.select_stmt)->limit = (yyvsp[0].limit);
 			}
 		}
-#line 2890 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2890 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 64:
-#line 565 "bison_parser.y" /* yacc.c:1646  */
+#line 565 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.select_stmt) = new SelectStatement();
 			(yyval.select_stmt)->limit = (yyvsp[-5].limit);
@@ -2900,472 +2900,472 @@ yyreduce:
 			(yyval.select_stmt)->whereClause = (yyvsp[-1].expr);
 			(yyval.select_stmt)->groupBy = (yyvsp[0].group_t);
 		}
-#line 2904 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2904 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 65:
-#line 577 "bison_parser.y" /* yacc.c:1646  */
+#line 577 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.bval) = true; }
-#line 2910 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2910 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 66:
-#line 578 "bison_parser.y" /* yacc.c:1646  */
+#line 578 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.bval) = false; }
-#line 2916 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2916 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 68:
-#line 586 "bison_parser.y" /* yacc.c:1646  */
+#line 586 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.table) = (yyvsp[0].table); }
-#line 2922 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2922 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 69:
-#line 591 "bison_parser.y" /* yacc.c:1646  */
+#line 591 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = (yyvsp[0].expr); }
-#line 2928 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2928 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 70:
-#line 592 "bison_parser.y" /* yacc.c:1646  */
+#line 592 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = nullptr; }
-#line 2934 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2934 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 71:
-#line 596 "bison_parser.y" /* yacc.c:1646  */
+#line 596 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.group_t) = new GroupByDescription();
 			(yyval.group_t)->columns = (yyvsp[-1].expr_vec);
 			(yyval.group_t)->having = (yyvsp[0].expr);
 		}
-#line 2944 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2944 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 72:
-#line 601 "bison_parser.y" /* yacc.c:1646  */
+#line 601 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.group_t) = nullptr; }
-#line 2950 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2950 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 73:
-#line 605 "bison_parser.y" /* yacc.c:1646  */
+#line 605 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = (yyvsp[0].expr); }
-#line 2956 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2956 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 74:
-#line 606 "bison_parser.y" /* yacc.c:1646  */
+#line 606 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = nullptr; }
-#line 2962 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2962 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 75:
-#line 609 "bison_parser.y" /* yacc.c:1646  */
+#line 609 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.order_vec) = (yyvsp[0].order_vec); }
-#line 2968 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2968 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 76:
-#line 610 "bison_parser.y" /* yacc.c:1646  */
+#line 610 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.order_vec) = nullptr; }
-#line 2974 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2974 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 77:
-#line 614 "bison_parser.y" /* yacc.c:1646  */
+#line 614 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.order_vec) = new std::vector<OrderDescription*>(); (yyval.order_vec)->push_back((yyvsp[0].order)); }
-#line 2980 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2980 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 78:
-#line 615 "bison_parser.y" /* yacc.c:1646  */
+#line 615 "bison_parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].order_vec)->push_back((yyvsp[0].order)); (yyval.order_vec) = (yyvsp[-2].order_vec); }
-#line 2986 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2986 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 79:
-#line 619 "bison_parser.y" /* yacc.c:1646  */
+#line 619 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.order) = new OrderDescription((yyvsp[0].order_type), (yyvsp[-1].expr)); }
-#line 2992 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2992 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 80:
-#line 623 "bison_parser.y" /* yacc.c:1646  */
+#line 623 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.order_type) = kOrderAsc; }
-#line 2998 "bison_parser.cpp" /* yacc.c:1646  */
+#line 2998 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 81:
-#line 624 "bison_parser.y" /* yacc.c:1646  */
+#line 624 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.order_type) = kOrderDesc; }
-#line 3004 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3004 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 82:
-#line 625 "bison_parser.y" /* yacc.c:1646  */
+#line 625 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.order_type) = kOrderAsc; }
-#line 3010 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3010 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 83:
-#line 631 "bison_parser.y" /* yacc.c:1646  */
+#line 631 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.limit) = new LimitDescription((yyvsp[0].expr)->ival, kNoOffset); delete (yyvsp[0].expr); }
-#line 3016 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3016 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 84:
-#line 632 "bison_parser.y" /* yacc.c:1646  */
+#line 632 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.limit) = nullptr; }
-#line 3022 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3022 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 85:
-#line 636 "bison_parser.y" /* yacc.c:1646  */
+#line 636 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.limit) = new LimitDescription((yyvsp[0].expr)->ival, kNoOffset); delete (yyvsp[0].expr); }
-#line 3028 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3028 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 86:
-#line 637 "bison_parser.y" /* yacc.c:1646  */
+#line 637 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.limit) = new LimitDescription((yyvsp[-2].expr)->ival, (yyvsp[0].expr)->ival); delete (yyvsp[-2].expr); delete (yyvsp[0].expr); }
-#line 3034 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3034 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 87:
-#line 638 "bison_parser.y" /* yacc.c:1646  */
+#line 638 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.limit) = nullptr; }
-#line 3040 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3040 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 88:
-#line 645 "bison_parser.y" /* yacc.c:1646  */
+#line 645 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr_vec) = new std::vector<Expr*>(); (yyval.expr_vec)->push_back((yyvsp[0].expr)); }
-#line 3046 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3046 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 89:
-#line 646 "bison_parser.y" /* yacc.c:1646  */
+#line 646 "bison_parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr)); (yyval.expr_vec) = (yyvsp[-2].expr_vec); }
-#line 3052 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3052 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 90:
-#line 650 "bison_parser.y" /* yacc.c:1646  */
+#line 650 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr_vec) = new std::vector<Expr*>(); (yyval.expr_vec)->push_back((yyvsp[0].expr)); }
-#line 3058 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3058 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 91:
-#line 651 "bison_parser.y" /* yacc.c:1646  */
+#line 651 "bison_parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr)); (yyval.expr_vec) = (yyvsp[-2].expr_vec); }
-#line 3064 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3064 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 92:
-#line 655 "bison_parser.y" /* yacc.c:1646  */
+#line 655 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.expr) = (yyvsp[-1].expr);
 			(yyval.expr)->alias = (yyvsp[0].sval);
 		}
-#line 3073 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3073 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 99:
-#line 671 "bison_parser.y" /* yacc.c:1646  */
+#line 671 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = (yyvsp[-1].expr); }
-#line 3079 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3079 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 104:
-#line 676 "bison_parser.y" /* yacc.c:1646  */
+#line 676 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeSelect((yyvsp[-1].select_stmt)); }
-#line 3085 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3085 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 108:
-#line 686 "bison_parser.y" /* yacc.c:1646  */
+#line 686 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpUnary(kOpMinus, (yyvsp[0].expr)); }
-#line 3091 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3091 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 109:
-#line 687 "bison_parser.y" /* yacc.c:1646  */
+#line 687 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpUnary(kOpNot, (yyvsp[0].expr)); }
-#line 3097 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3097 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 111:
-#line 692 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '-', (yyvsp[0].expr)); }
-#line 3103 "bison_parser.cpp" /* yacc.c:1646  */
+#line 692 "bison_parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpSubtract, (yyvsp[0].expr)); }
+#line 3103 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 112:
-#line 693 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '+', (yyvsp[0].expr)); }
-#line 3109 "bison_parser.cpp" /* yacc.c:1646  */
+#line 693 "bison_parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAdd, (yyvsp[0].expr)); }
+#line 3109 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 113:
-#line 694 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '/', (yyvsp[0].expr)); }
-#line 3115 "bison_parser.cpp" /* yacc.c:1646  */
+#line 694 "bison_parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpDivide, (yyvsp[0].expr)); }
+#line 3115 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 114:
-#line 695 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '*', (yyvsp[0].expr)); }
-#line 3121 "bison_parser.cpp" /* yacc.c:1646  */
+#line 695 "bison_parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpMultiply, (yyvsp[0].expr)); }
+#line 3121 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 115:
-#line 696 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '%', (yyvsp[0].expr)); }
-#line 3127 "bison_parser.cpp" /* yacc.c:1646  */
+#line 696 "bison_parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpModulo, (yyvsp[0].expr)); }
+#line 3127 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 116:
-#line 697 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '^', (yyvsp[0].expr)); }
-#line 3133 "bison_parser.cpp" /* yacc.c:1646  */
+#line 697 "bison_parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPower, (yyvsp[0].expr)); }
+#line 3133 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 117:
-#line 698 "bison_parser.y" /* yacc.c:1646  */
+#line 698 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLike, (yyvsp[0].expr)); }
-#line 3139 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3139 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 118:
-#line 699 "bison_parser.y" /* yacc.c:1646  */
+#line 699 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-3].expr), kOpNotLike, (yyvsp[0].expr)); }
-#line 3145 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3145 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 119:
-#line 703 "bison_parser.y" /* yacc.c:1646  */
+#line 703 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAnd, (yyvsp[0].expr)); }
-#line 3151 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3151 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 120:
-#line 704 "bison_parser.y" /* yacc.c:1646  */
+#line 704 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpOr, (yyvsp[0].expr)); }
-#line 3157 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3157 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 121:
-#line 708 "bison_parser.y" /* yacc.c:1646  */
+#line 708 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].expr_vec)); }
-#line 3163 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3163 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 122:
-#line 709 "bison_parser.y" /* yacc.c:1646  */
+#line 709 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].expr_vec))); }
-#line 3169 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3169 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 123:
-#line 710 "bison_parser.y" /* yacc.c:1646  */
+#line 710 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].select_stmt)); }
-#line 3175 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3175 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 124:
-#line 711 "bison_parser.y" /* yacc.c:1646  */
+#line 711 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].select_stmt))); }
-#line 3181 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3181 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 125:
-#line 716 "bison_parser.y" /* yacc.c:1646  */
+#line 716 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeCase((yyvsp[-5].expr), (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 3187 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3187 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 126:
-#line 720 "bison_parser.y" /* yacc.c:1646  */
+#line 720 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeExists((yyvsp[-1].select_stmt)); }
-#line 3193 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3193 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 127:
-#line 721 "bison_parser.y" /* yacc.c:1646  */
+#line 721 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeExists((yyvsp[-1].select_stmt))); }
-#line 3199 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3199 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 128:
-#line 725 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '=', (yyvsp[0].expr)); }
-#line 3205 "bison_parser.cpp" /* yacc.c:1646  */
+#line 725 "bison_parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
+#line 3205 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 129:
-#line 726 "bison_parser.y" /* yacc.c:1646  */
+#line 726 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpNotEquals, (yyvsp[0].expr)); }
-#line 3211 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3211 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 130:
-#line 727 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '<', (yyvsp[0].expr)); }
-#line 3217 "bison_parser.cpp" /* yacc.c:1646  */
+#line 727 "bison_parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLess, (yyvsp[0].expr)); }
+#line 3217 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 131:
-#line 728 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), '>', (yyvsp[0].expr)); }
-#line 3223 "bison_parser.cpp" /* yacc.c:1646  */
+#line 728 "bison_parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreater, (yyvsp[0].expr)); }
+#line 3223 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 132:
-#line 729 "bison_parser.y" /* yacc.c:1646  */
+#line 729 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLessEq, (yyvsp[0].expr)); }
-#line 3229 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3229 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 133:
-#line 730 "bison_parser.y" /* yacc.c:1646  */
+#line 730 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreaterEq, (yyvsp[0].expr)); }
-#line 3235 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3235 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 134:
-#line 734 "bison_parser.y" /* yacc.c:1646  */
+#line 734 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-4].sval), (yyvsp[-1].expr_vec), (yyvsp[-2].bval)); }
-#line 3241 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3241 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 135:
-#line 738 "bison_parser.y" /* yacc.c:1646  */
+#line 738 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeBetween((yyvsp[-4].expr), (yyvsp[-2].expr), (yyvsp[0].expr)); }
-#line 3247 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3247 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 136:
-#line 742 "bison_parser.y" /* yacc.c:1646  */
+#line 742 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeColumnRef((yyvsp[0].sval)); }
-#line 3253 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3253 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 137:
-#line 743 "bison_parser.y" /* yacc.c:1646  */
+#line 743 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeColumnRef((yyvsp[-2].sval), (yyvsp[0].sval)); }
-#line 3259 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3259 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 141:
-#line 753 "bison_parser.y" /* yacc.c:1646  */
+#line 753 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeLiteral((yyvsp[0].sval)); }
-#line 3265 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3265 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 142:
-#line 758 "bison_parser.y" /* yacc.c:1646  */
+#line 758 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeLiteral((yyvsp[0].fval)); }
-#line 3271 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3271 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 144:
-#line 763 "bison_parser.y" /* yacc.c:1646  */
+#line 763 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::makeLiteral((yyvsp[0].ival)); }
-#line 3277 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3277 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 145:
-#line 767 "bison_parser.y" /* yacc.c:1646  */
+#line 767 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.expr) = Expr::make(kExprStar); }
-#line 3283 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3283 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 146:
-#line 771 "bison_parser.y" /* yacc.c:1646  */
+#line 771 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.expr) = Expr::makeParameter(yylloc.total_column);
 			(yyval.expr)->ival2 = yyloc.param_list.size();
 			yyloc.param_list.push_back((yyval.expr));
 		}
-#line 3293 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3293 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 148:
-#line 784 "bison_parser.y" /* yacc.c:1646  */
+#line 784 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyvsp[0].table_vec)->push_back((yyvsp[-2].table));
 			auto tbl = new TableRef(kTableCrossProduct);
 			tbl->list = (yyvsp[0].table_vec);
 			(yyval.table) = tbl;
 		}
-#line 3304 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3304 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 150:
-#line 795 "bison_parser.y" /* yacc.c:1646  */
+#line 795 "bison_parser.y" /* yacc.c:1661  */
     {
 			auto tbl = new TableRef(kTableSelect);
 			tbl->select = (yyvsp[-2].select_stmt);
 			tbl->alias = (yyvsp[0].sval);
 			(yyval.table) = tbl;
 		}
-#line 3315 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3315 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 152:
-#line 806 "bison_parser.y" /* yacc.c:1646  */
+#line 806 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.table_vec) = new std::vector<TableRef*>(); (yyval.table_vec)->push_back((yyvsp[0].table)); }
-#line 3321 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3321 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 153:
-#line 807 "bison_parser.y" /* yacc.c:1646  */
+#line 807 "bison_parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].table_vec)->push_back((yyvsp[0].table)); (yyval.table_vec) = (yyvsp[-2].table_vec); }
-#line 3327 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3327 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 154:
-#line 812 "bison_parser.y" /* yacc.c:1646  */
+#line 812 "bison_parser.y" /* yacc.c:1661  */
     {
 			auto tbl = new TableRef(kTableName);
 			tbl->name = (yyvsp[-1].sval);
 			tbl->alias = (yyvsp[0].sval);
 			(yyval.table) = tbl;
 		}
-#line 3338 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3338 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 155:
-#line 822 "bison_parser.y" /* yacc.c:1646  */
+#line 822 "bison_parser.y" /* yacc.c:1661  */
     {
 			(yyval.table) = new TableRef(kTableName);
 			(yyval.table)->name = (yyvsp[0].sval);
 		}
-#line 3347 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3347 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 157:
-#line 831 "bison_parser.y" /* yacc.c:1646  */
+#line 831 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.sval) = (yyvsp[0].sval); }
-#line 3353 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3353 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 158:
-#line 836 "bison_parser.y" /* yacc.c:1646  */
+#line 836 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.sval) = (yyvsp[0].sval); }
-#line 3359 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3359 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 161:
-#line 842 "bison_parser.y" /* yacc.c:1646  */
+#line 842 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.sval) = nullptr; }
-#line 3365 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3365 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 162:
-#line 851 "bison_parser.y" /* yacc.c:1646  */
+#line 851 "bison_parser.y" /* yacc.c:1661  */
     { 
 			(yyval.table) = new TableRef(kTableJoin);
 			(yyval.table)->join = new JoinDefinition();
@@ -3374,77 +3374,77 @@ yyreduce:
 			(yyval.table)->join->right = (yyvsp[-2].table);
 			(yyval.table)->join->condition = (yyvsp[0].expr);
 		}
-#line 3378 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3378 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 163:
-#line 862 "bison_parser.y" /* yacc.c:1646  */
+#line 862 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = kJoinInner; }
-#line 3384 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3384 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 164:
-#line 863 "bison_parser.y" /* yacc.c:1646  */
+#line 863 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = kJoinOuter; }
-#line 3390 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3390 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 165:
-#line 864 "bison_parser.y" /* yacc.c:1646  */
+#line 864 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = kJoinLeftOuter; }
-#line 3396 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3396 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 166:
-#line 865 "bison_parser.y" /* yacc.c:1646  */
+#line 865 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = kJoinRightOuter; }
-#line 3402 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3402 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 167:
-#line 866 "bison_parser.y" /* yacc.c:1646  */
+#line 866 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = kJoinLeft; }
-#line 3408 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3408 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 168:
-#line 867 "bison_parser.y" /* yacc.c:1646  */
+#line 867 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = kJoinRight; }
-#line 3414 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3414 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 169:
-#line 868 "bison_parser.y" /* yacc.c:1646  */
+#line 868 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = kJoinCross; }
-#line 3420 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3420 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 170:
-#line 869 "bison_parser.y" /* yacc.c:1646  */
+#line 869 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = kJoinNatural; }
-#line 3426 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3426 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 171:
-#line 870 "bison_parser.y" /* yacc.c:1646  */
+#line 870 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.uval) = kJoinInner; }
-#line 3432 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3432 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 175:
-#line 890 "bison_parser.y" /* yacc.c:1646  */
+#line 890 "bison_parser.y" /* yacc.c:1661  */
     { (yyval.str_vec) = new std::vector<char*>(); (yyval.str_vec)->push_back((yyvsp[0].sval)); }
-#line 3438 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3438 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 176:
-#line 891 "bison_parser.y" /* yacc.c:1646  */
+#line 891 "bison_parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].str_vec)->push_back((yyvsp[0].sval)); (yyval.str_vec) = (yyvsp[-2].str_vec); }
-#line 3444 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3444 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
 
-#line 3448 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3448 "bison_parser.cpp" /* yacc.c:1661  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires

--- a/src/parser/bison_parser.cpp
+++ b/src/parser/bison_parser.cpp
@@ -76,7 +76,7 @@
  * bison_parser.y
  * defines bison_parser.h
  * outputs bison_parser.c
- * 
+ *
  * Grammar File Spec: http://dinosaur.compilertools.net/bison/bison_6.html
  *
  */
@@ -138,7 +138,7 @@ extern int hsql_debug;
 /* "%code requires" blocks.  */
 #line 34 "bison_parser.y" /* yacc.c:355  */
 
-// %code requires block	
+// %code requires block
 
 #include "../sql/statements.h"
 #include "../SQLParserResult.h"
@@ -3086,7 +3086,7 @@ yyreduce:
 
   case 108:
 #line 686 "bison_parser.y" /* yacc.c:1661  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpMinus, (yyvsp[0].expr)); }
+    { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
 #line 3091 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
@@ -3098,37 +3098,37 @@ yyreduce:
 
   case 111:
 #line 692 "bison_parser.y" /* yacc.c:1661  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpSubtract, (yyvsp[0].expr)); }
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpMinus, (yyvsp[0].expr)); }
 #line 3103 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 112:
 #line 693 "bison_parser.y" /* yacc.c:1661  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAdd, (yyvsp[0].expr)); }
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPlus, (yyvsp[0].expr)); }
 #line 3109 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 113:
 #line 694 "bison_parser.y" /* yacc.c:1661  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpDivide, (yyvsp[0].expr)); }
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpSlash, (yyvsp[0].expr)); }
 #line 3115 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 114:
 #line 695 "bison_parser.y" /* yacc.c:1661  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpMultiply, (yyvsp[0].expr)); }
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAsterisk, (yyvsp[0].expr)); }
 #line 3121 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 115:
 #line 696 "bison_parser.y" /* yacc.c:1661  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpModulo, (yyvsp[0].expr)); }
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPercentage, (yyvsp[0].expr)); }
 #line 3127 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
   case 116:
 #line 697 "bison_parser.y" /* yacc.c:1661  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPower, (yyvsp[0].expr)); }
+    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpCaret, (yyvsp[0].expr)); }
 #line 3133 "bison_parser.cpp" /* yacc.c:1661  */
     break;
 
@@ -3366,7 +3366,7 @@ yyreduce:
 
   case 162:
 #line 851 "bison_parser.y" /* yacc.c:1661  */
-    { 
+    {
 			(yyval.table) = new TableRef(kTableJoin);
 			(yyval.table)->join = new JoinDefinition();
 			(yyval.table)->join->type = (JoinType) (yyvsp[-4].uval);

--- a/src/parser/bison_parser.h
+++ b/src/parser/bison_parser.h
@@ -50,7 +50,7 @@ extern int hsql_debug;
 /* "%code requires" blocks.  */
 #line 34 "bison_parser.y" /* yacc.c:1915  */
 
-// %code requires block	
+// %code requires block
 
 #include "../sql/statements.h"
 #include "../SQLParserResult.h"

--- a/src/parser/bison_parser.h
+++ b/src/parser/bison_parser.h
@@ -48,7 +48,7 @@
 extern int hsql_debug;
 #endif
 /* "%code requires" blocks.  */
-#line 34 "bison_parser.y" /* yacc.c:1909  */
+#line 34 "bison_parser.y" /* yacc.c:1915  */
 
 // %code requires block	
 
@@ -71,7 +71,7 @@ extern int hsql_debug;
 				} \
 		}
 
-#line 75 "bison_parser.h" /* yacc.c:1909  */
+#line 75 "bison_parser.h" /* yacc.c:1915  */
 
 /* Token type.  */
 #ifndef HSQL_TOKENTYPE
@@ -214,7 +214,7 @@ extern int hsql_debug;
 
 union HSQL_STYPE
 {
-#line 92 "bison_parser.y" /* yacc.c:1909  */
+#line 92 "bison_parser.y" /* yacc.c:1915  */
 
 	double fval;
 	int64_t ival;
@@ -251,7 +251,7 @@ union HSQL_STYPE
 	std::vector<hsql::Expr*>* expr_vec;
 	std::vector<hsql::OrderDescription*>* order_vec;
 
-#line 255 "bison_parser.h" /* yacc.c:1909  */
+#line 255 "bison_parser.h" /* yacc.c:1915  */
 };
 
 typedef union HSQL_STYPE HSQL_STYPE;

--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -689,12 +689,12 @@ unary_expr:
 
 binary_expr:
 		comp_expr
-	|	operand '-' operand			{ $$ = Expr::makeOpBinary($1, '-', $3); }
-	|	operand '+' operand			{ $$ = Expr::makeOpBinary($1, '+', $3); }
-	|	operand '/' operand			{ $$ = Expr::makeOpBinary($1, '/', $3); }
-	|	operand '*' operand			{ $$ = Expr::makeOpBinary($1, '*', $3); }
-	|	operand '%' operand			{ $$ = Expr::makeOpBinary($1, '%', $3); }
-	|	operand '^' operand			{ $$ = Expr::makeOpBinary($1, '^', $3); }
+	|	operand '-' operand			{ $$ = Expr::makeOpBinary($1, kOpSubtract, $3); }
+	|	operand '+' operand			{ $$ = Expr::makeOpBinary($1, kOpAdd, $3); }
+	|	operand '/' operand			{ $$ = Expr::makeOpBinary($1, kOpDivide, $3); }
+	|	operand '*' operand			{ $$ = Expr::makeOpBinary($1, kOpMultiply, $3); }
+	|	operand '%' operand			{ $$ = Expr::makeOpBinary($1, kOpModulo, $3); }
+	|	operand '^' operand			{ $$ = Expr::makeOpBinary($1, kOpPower, $3); }
 	|	operand LIKE operand		{ $$ = Expr::makeOpBinary($1, kOpLike, $3); }
 	|	operand NOT LIKE operand	{ $$ = Expr::makeOpBinary($1, kOpNotLike, $4); }
 	;
@@ -722,10 +722,10 @@ exists_expr:
 	;
 
 comp_expr:
-		operand '=' operand			{ $$ = Expr::makeOpBinary($1, '=', $3); }
+		operand '=' operand			{ $$ = Expr::makeOpBinary($1, kOpEquals, $3); }
 	|	operand NOTEQUALS operand	{ $$ = Expr::makeOpBinary($1, kOpNotEquals, $3); }
-	|	operand '<' operand			{ $$ = Expr::makeOpBinary($1, '<', $3); }
-	|	operand '>' operand			{ $$ = Expr::makeOpBinary($1, '>', $3); }
+	|	operand '<' operand			{ $$ = Expr::makeOpBinary($1, kOpLess, $3); }
+	|	operand '>' operand			{ $$ = Expr::makeOpBinary($1, kOpGreater, $3); }
 	|	operand LESSEQ operand		{ $$ = Expr::makeOpBinary($1, kOpLessEq, $3); }
 	|	operand GREATEREQ operand	{ $$ = Expr::makeOpBinary($1, kOpGreaterEq, $3); }
 	;

--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -683,18 +683,18 @@ scalar_expr:
 	;
 
 unary_expr:
-		'-' operand { $$ = Expr::makeOpUnary(kOpMinus, $2); }
+		'-' operand { $$ = Expr::makeOpUnary(kOpUnaryMinus, $2); }
 	|	NOT operand { $$ = Expr::makeOpUnary(kOpNot, $2); }
 	;
 
 binary_expr:
 		comp_expr
-	|	operand '-' operand			{ $$ = Expr::makeOpBinary($1, kOpSubtract, $3); }
-	|	operand '+' operand			{ $$ = Expr::makeOpBinary($1, kOpAdd, $3); }
-	|	operand '/' operand			{ $$ = Expr::makeOpBinary($1, kOpDivide, $3); }
-	|	operand '*' operand			{ $$ = Expr::makeOpBinary($1, kOpMultiply, $3); }
-	|	operand '%' operand			{ $$ = Expr::makeOpBinary($1, kOpModulo, $3); }
-	|	operand '^' operand			{ $$ = Expr::makeOpBinary($1, kOpPower, $3); }
+	|	operand '-' operand			{ $$ = Expr::makeOpBinary($1, kOpMinus, $3); }
+	|	operand '+' operand			{ $$ = Expr::makeOpBinary($1, kOpPlus, $3); }
+	|	operand '/' operand			{ $$ = Expr::makeOpBinary($1, kOpSlash, $3); }
+	|	operand '*' operand			{ $$ = Expr::makeOpBinary($1, kOpAsterisk, $3); }
+	|	operand '%' operand			{ $$ = Expr::makeOpBinary($1, kOpPercentage, $3); }
+	|	operand '^' operand			{ $$ = Expr::makeOpBinary($1, kOpCaret, $3); }
 	|	operand LIKE operand		{ $$ = Expr::makeOpBinary($1, kOpLike, $3); }
 	|	operand NOT LIKE operand	{ $$ = Expr::makeOpBinary($1, kOpNotLike, $4); }
 	;

--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -3,7 +3,7 @@
  * bison_parser.y
  * defines bison_parser.h
  * outputs bison_parser.c
- * 
+ *
  * Grammar File Spec: http://dinosaur.compilertools.net/bison/bison_6.html
  *
  */
@@ -32,7 +32,7 @@ int yyerror(YYLTYPE* llocp, SQLParserResult* result, yyscan_t scanner, const cha
 
 // Specify code that is included in the generated .h and .c files
 %code requires {
-// %code requires block	
+// %code requires block
 
 #include "../sql/statements.h"
 #include "../SQLParserResult.h"
@@ -639,7 +639,7 @@ opt_limit:
 	;
 
 /******************************
- * Expressions 
+ * Expressions
  ******************************/
 expr_list:
 		expr_alias { $$ = new std::vector<Expr*>(); $$->push_back($1); }
@@ -777,7 +777,7 @@ param_expr:
 
 
 /******************************
- * Table 
+ * Table
  ******************************/
 table_ref:
 		table_ref_atomic
@@ -832,7 +832,7 @@ table_name:
 	;
 
 
-alias:	
+alias:
 		AS IDENTIFIER { $$ = $2; }
 	|	IDENTIFIER
 	;
@@ -848,7 +848,7 @@ opt_alias:
 
 join_clause:
 		table_ref_atomic opt_join_type JOIN table_ref_atomic ON join_condition
-		{ 
+		{
 			$$ = new TableRef(kTableJoin);
 			$$->join = new JoinDefinition();
 			$$->join->type = (JoinType) $2;

--- a/src/parser/flex_lexer.cpp
+++ b/src/parser/flex_lexer.cpp
@@ -1,6 +1,6 @@
-#line 2 "flex_lexer.cpp"
+#line 1 "flex_lexer.cpp"
 
-#line 4 "flex_lexer.cpp"
+#line 3 "flex_lexer.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -9,9 +9,243 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 1
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define hsql__create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer hsql__create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define hsql__delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer hsql__delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define hsql__scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer hsql__scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define hsql__scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string hsql__scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define hsql__scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes hsql__scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define hsql__init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer hsql__init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define hsql__flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer hsql__flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define hsql__load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state hsql__load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define hsql__switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer hsql__switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define hsql_push_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state hsql_push_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define hsql_pop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state hsql_pop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define hsql_ensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack hsql_ensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define hsql_lex_ALREADY_DEFINED
+#else
+#define yylex hsql_lex
+#endif
+
+#ifdef yyrestart
+#define hsql_restart_ALREADY_DEFINED
+#else
+#define yyrestart hsql_restart
+#endif
+
+#ifdef yylex_init
+#define hsql_lex_init_ALREADY_DEFINED
+#else
+#define yylex_init hsql_lex_init
+#endif
+
+#ifdef yylex_init_extra
+#define hsql_lex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra hsql_lex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define hsql_lex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy hsql_lex_destroy
+#endif
+
+#ifdef yyget_debug
+#define hsql_get_debug_ALREADY_DEFINED
+#else
+#define yyget_debug hsql_get_debug
+#endif
+
+#ifdef yyset_debug
+#define hsql_set_debug_ALREADY_DEFINED
+#else
+#define yyset_debug hsql_set_debug
+#endif
+
+#ifdef yyget_extra
+#define hsql_get_extra_ALREADY_DEFINED
+#else
+#define yyget_extra hsql_get_extra
+#endif
+
+#ifdef yyset_extra
+#define hsql_set_extra_ALREADY_DEFINED
+#else
+#define yyset_extra hsql_set_extra
+#endif
+
+#ifdef yyget_in
+#define hsql_get_in_ALREADY_DEFINED
+#else
+#define yyget_in hsql_get_in
+#endif
+
+#ifdef yyset_in
+#define hsql_set_in_ALREADY_DEFINED
+#else
+#define yyset_in hsql_set_in
+#endif
+
+#ifdef yyget_out
+#define hsql_get_out_ALREADY_DEFINED
+#else
+#define yyget_out hsql_get_out
+#endif
+
+#ifdef yyset_out
+#define hsql_set_out_ALREADY_DEFINED
+#else
+#define yyset_out hsql_set_out
+#endif
+
+#ifdef yyget_leng
+#define hsql_get_leng_ALREADY_DEFINED
+#else
+#define yyget_leng hsql_get_leng
+#endif
+
+#ifdef yyget_text
+#define hsql_get_text_ALREADY_DEFINED
+#else
+#define yyget_text hsql_get_text
+#endif
+
+#ifdef yyget_lineno
+#define hsql_get_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno hsql_get_lineno
+#endif
+
+#ifdef yyset_lineno
+#define hsql_set_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno hsql_set_lineno
+#endif
+
+#ifdef yyget_column
+#define hsql_get_column_ALREADY_DEFINED
+#else
+#define yyget_column hsql_get_column
+#endif
+
+#ifdef yyset_column
+#define hsql_set_column_ALREADY_DEFINED
+#else
+#define yyset_column hsql_set_column
+#endif
+
+#ifdef yywrap
+#define hsql_wrap_ALREADY_DEFINED
+#else
+#define yywrap hsql_wrap
+#endif
+
+#ifdef yyget_lval
+#define hsql_get_lval_ALREADY_DEFINED
+#else
+#define yyget_lval hsql_get_lval
+#endif
+
+#ifdef yyset_lval
+#define hsql_set_lval_ALREADY_DEFINED
+#else
+#define yyset_lval hsql_set_lval
+#endif
+
+#ifdef yyget_lloc
+#define hsql_get_lloc_ALREADY_DEFINED
+#else
+#define yyget_lloc hsql_get_lloc
+#endif
+
+#ifdef yyset_lloc
+#define hsql_set_lloc_ALREADY_DEFINED
+#else
+#define yyset_lloc hsql_set_lloc
+#endif
+
+#ifdef yyalloc
+#define hsql_alloc_ALREADY_DEFINED
+#else
+#define yyalloc hsql_alloc
+#endif
+
+#ifdef yyrealloc
+#define hsql_realloc_ALREADY_DEFINED
+#else
+#define yyrealloc hsql_realloc
+#endif
+
+#ifdef yyfree
+#define hsql_free_ALREADY_DEFINED
+#else
+#define yyfree hsql_free
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -84,9 +318,15 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
+
+/* begin standard C++ headers. */
 
 /* TODO: this is always defined, so inline it */
 #define yyconst const
@@ -100,12 +340,10 @@ typedef unsigned int flex_uint32_t;
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* An opaque pointer. */
 #ifndef YY_TYPEDEF_YY_SCANNER_T
@@ -129,20 +367,16 @@ typedef void* yyscan_t;
  * definition of BEGIN.
  */
 #define BEGIN yyg->yy_start = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START ((yyg->yy_start - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE hsql_restart(yyin ,yyscanner )
-
+#define YY_NEW_FILE yyrestart( yyin , yyscanner )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -175,7 +409,7 @@ typedef size_t yy_size_t;
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -192,7 +426,6 @@ typedef size_t yy_size_t;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, yyg->yytext_ptr , yyscanner )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -252,7 +485,7 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via hsql_restart()), so that the user can continue scanning by
+	 * (via yyrestart()), so that the user can continue scanning by
 	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
@@ -269,73 +502,67 @@ struct yy_buffer_state
 #define YY_CURRENT_BUFFER ( yyg->yy_buffer_stack \
                           ? yyg->yy_buffer_stack[yyg->yy_buffer_stack_top] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE yyg->yy_buffer_stack[yyg->yy_buffer_stack_top]
 
-void hsql_restart (FILE *input_file ,yyscan_t yyscanner );
-void hsql__switch_to_buffer (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__create_buffer (FILE *file,int size ,yyscan_t yyscanner );
-void hsql__delete_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void hsql__flush_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void hsql_push_buffer_state (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-void hsql_pop_buffer_state (yyscan_t yyscanner );
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-static void hsql_ensure_buffer_stack (yyscan_t yyscanner );
-static void hsql__load_buffer_state (yyscan_t yyscanner );
-static void hsql__init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanner );
+static void yyensure_buffer_stack ( yyscan_t yyscanner );
+static void yy_load_buffer_state ( yyscan_t yyscanner );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER , yyscanner)
 
-#define YY_FLUSH_BUFFER hsql__flush_buffer(YY_CURRENT_BUFFER ,yyscanner)
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-YY_BUFFER_STATE hsql__scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
-void *hsql_alloc (yy_size_t ,yyscan_t yyscanner );
-void *hsql_realloc (void *,yy_size_t ,yyscan_t yyscanner );
-void hsql_free (void * ,yyscan_t yyscanner );
-
-#define yy_new_buffer hsql__create_buffer
-
+#define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        hsql_ensure_buffer_stack (yyscanner); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            hsql__create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        hsql_ensure_buffer_stack (yyscanner); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            hsql__create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
 
 #define hsql_wrap(yyscanner) (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
-
-typedef unsigned char YY_CHAR;
+typedef flex_uint8_t YY_CHAR;
 
 typedef int yy_state_type;
 
 #define yytext_ptr yytext_r
 
-static yy_state_type yy_get_previous_state (yyscan_t yyscanner );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  ,yyscan_t yyscanner);
-static int yy_get_next_buffer (yyscan_t yyscanner );
-static void yynoreturn yy_fatal_error (yyconst char* msg ,yyscan_t yyscanner );
+static yy_state_type yy_get_previous_state ( yyscan_t yyscanner );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  , yyscan_t yyscanner);
+static int yy_get_next_buffer ( yyscan_t yyscanner );
+static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
@@ -346,7 +573,6 @@ static void yynoreturn yy_fatal_error (yyconst char* msg ,yyscan_t yyscanner );
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
-
 #define YY_NUM_RULES 132
 #define YY_END_OF_BUFFER 133
 /* This struct is not used in this scanner,
@@ -356,7 +582,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[914] =
+static const flex_int16_t yy_accept[914] =
     {   0,
         0,    0,    2,    2,  133,  131,    4,    4,  131,  124,
       131,  124,  124,  127,  124,  124,  129,  129,  129,  129,
@@ -461,7 +687,7 @@ static yyconst flex_int16_t yy_accept[914] =
         2,    2,    0
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -493,7 +719,7 @@ static yyconst YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[66] =
+static const YY_CHAR yy_meta[66] =
     {   0,
         1,    1,    2,    3,    1,    1,    1,    1,    4,    1,
         1,    1,    4,    4,    4,    4,    4,    4,    4,    4,
@@ -504,7 +730,7 @@ static yyconst YY_CHAR yy_meta[66] =
         4,    4,    4,    4,    4
     } ;
 
-static yyconst flex_uint16_t yy_base[921] =
+static const flex_int16_t yy_base[921] =
     {   0,
         0,    0,   65,    0,  400, 3673,  129,  131,    0, 3673,
       361,  128,  351,  130,  129,  346,  126,  119,  134,  180,
@@ -609,7 +835,7 @@ static yyconst flex_uint16_t yy_base[921] =
      3580, 3584, 3673, 3648, 3652,  164, 3656, 3660, 3664, 3668
     } ;
 
-static yyconst flex_int16_t yy_def[921] =
+static const flex_int16_t yy_def[921] =
     {   0,
       913,    1,  913,    3,  913,  913,  913,  913,  914,  913,
       915,  913,  913,  913,  913,  913,  916,  916,  916,  916,
@@ -714,7 +940,7 @@ static yyconst flex_int16_t yy_def[921] =
        52,   52,    0,  913,  913,  913,  913,  913,  913,  913
     } ;
 
-static yyconst flex_uint16_t yy_nxt[3739] =
+static const flex_int16_t yy_nxt[3739] =
     {   0,
         6,    7,    8,    9,   10,   11,   12,   13,   14,   15,
        10,   16,   17,   18,   19,   20,   21,   22,   23,   24,
@@ -1129,7 +1355,7 @@ static yyconst flex_uint16_t yy_nxt[3739] =
       913,  913,  913,  913,  913,  913,  913,  913
     } ;
 
-static yyconst flex_int16_t yy_chk[3739] =
+static const flex_int16_t yy_chk[3739] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -1568,6 +1794,7 @@ static yyconst flex_int16_t yy_chk[3739] =
 
 #define TOKEN(name) { return SQL_##name; }
 
+#line 1797 "flex_lexer.cpp"
 /***************************
  ** Section 2: Rules
  ***************************/
@@ -1580,7 +1807,7 @@ static yyconst flex_int16_t yy_chk[3739] =
 /***************************
  ** Section 3: Rules
  ***************************/
-#line 1584 "flex_lexer.cpp"
+#line 1810 "flex_lexer.cpp"
 
 #define INITIAL 0
 #define COMMENT 1
@@ -1635,7 +1862,7 @@ struct yyguts_t
 
     }; /* end struct yyguts_t */
 
-static int yy_init_globals (yyscan_t yyscanner );
+static int yy_init_globals ( yyscan_t yyscanner );
 
     /* This must go here because YYSTYPE and YYLTYPE are included
      * from bison output in section 1.*/
@@ -1643,50 +1870,50 @@ static int yy_init_globals (yyscan_t yyscanner );
     
     #    define yylloc yyg->yylloc_r
     
-int hsql_lex_init (yyscan_t* scanner);
+int yylex_init (yyscan_t* scanner);
 
-int hsql_lex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int hsql_lex_destroy (yyscan_t yyscanner );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int hsql_get_debug (yyscan_t yyscanner );
+int yyget_debug ( yyscan_t yyscanner );
 
-void hsql_set_debug (int debug_flag ,yyscan_t yyscanner );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE hsql_get_extra (yyscan_t yyscanner );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void hsql_set_extra (YY_EXTRA_TYPE user_defined ,yyscan_t yyscanner );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *hsql_get_in (yyscan_t yyscanner );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void hsql_set_in  (FILE * _in_str ,yyscan_t yyscanner );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *hsql_get_out (yyscan_t yyscanner );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void hsql_set_out  (FILE * _out_str ,yyscan_t yyscanner );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			int hsql_get_leng (yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *hsql_get_text (yyscan_t yyscanner );
+char *yyget_text ( yyscan_t yyscanner );
 
-int hsql_get_lineno (yyscan_t yyscanner );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void hsql_set_lineno (int _line_number ,yyscan_t yyscanner );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-int hsql_get_column  (yyscan_t yyscanner );
+int yyget_column  ( yyscan_t yyscanner );
 
-void hsql_set_column (int _column_no ,yyscan_t yyscanner );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
 
-YYSTYPE * hsql_get_lval (yyscan_t yyscanner );
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
 
-void hsql_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
 
-       YYLTYPE *hsql_get_lloc (yyscan_t yyscanner );
+       YYLTYPE *yyget_lloc ( yyscan_t yyscanner );
     
-        void hsql_set_lloc (YYLTYPE * yylloc_param ,yyscan_t yyscanner );
+        void yyset_lloc ( YYLTYPE * yylloc_param , yyscan_t yyscanner );
     
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -1694,9 +1921,9 @@ void hsql_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int hsql_wrap (yyscan_t yyscanner );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int hsql_wrap (yyscan_t yyscanner );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
 #endif
 
@@ -1705,19 +1932,18 @@ extern int hsql_wrap (yyscan_t yyscanner );
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int ,yyscan_t yyscanner);
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (yyscan_t yyscanner );
+static int yyinput ( yyscan_t yyscanner );
 #else
-static int input (yyscan_t yyscanner );
+static int input ( yyscan_t yyscanner );
 #endif
 
 #endif
@@ -1748,7 +1974,7 @@ static int input (yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -1761,7 +1987,7 @@ static int input (yyscan_t yyscanner );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = (int) fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -1802,10 +2028,10 @@ static int input (yyscan_t yyscanner );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int hsql_lex \
-               (YYSTYPE * yylval_param,YYLTYPE * yylloc_param ,yyscan_t yyscanner);
+extern int yylex \
+               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner);
 
-#define YY_DECL int hsql_lex \
+#define YY_DECL int yylex \
                (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner)
 #endif /* !YY_DECL */
 
@@ -1855,19 +2081,19 @@ YY_DECL
 			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			hsql_ensure_buffer_stack (yyscanner);
+			yyensure_buffer_stack (yyscanner);
 			YY_CURRENT_BUFFER_LVALUE =
-				hsql__create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
+				yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 		}
 
-		hsql__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 		}
 
 	{
 #line 51 "flex_lexer.l"
 
 
-#line 1871 "flex_lexer.cpp"
+#line 2096 "flex_lexer.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1895,9 +2121,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 914 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_current_state != 913 );
@@ -2596,7 +2822,7 @@ YY_RULE_SETUP
 #line 213 "flex_lexer.l"
 ECHO;
 	YY_BREAK
-#line 2600 "flex_lexer.cpp"
+#line 2825 "flex_lexer.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(COMMENT):
 	yyterminate();
@@ -2615,7 +2841,7 @@ case YY_STATE_EOF(COMMENT):
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
 			 * just pointed yyin at a new source and called
-			 * hsql_lex().  If so, then we have to assure
+			 * yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
@@ -2676,7 +2902,7 @@ case YY_STATE_EOF(COMMENT):
 				{
 				yyg->yy_did_buffer_switch_on_eof = 0;
 
-				if ( hsql_wrap(yyscanner ) )
+				if ( yywrap( yyscanner ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -2730,7 +2956,7 @@ case YY_STATE_EOF(COMMENT):
 	} /* end of action switch */
 		} /* end of scanning one token */
 	} /* end of user's declarations */
-} /* end of hsql_lex */
+} /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -2744,7 +2970,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = yyg->yytext_ptr;
-	yy_size_t number_to_move, i;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( yyg->yy_c_buf_p > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars + 1] )
@@ -2773,7 +2999,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (yy_size_t) (yyg->yy_c_buf_p - yyg->yytext_ptr) - 1;
+	number_to_move = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -2809,7 +3035,8 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					hsql_realloc((void *) b->yy_ch_buf,b->yy_buf_size + 2 ,yyscanner );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 				}
 			else
 				/* Can't grow it, we don't own it. */
@@ -2841,7 +3068,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			hsql_restart(yyin  ,yyscanner);
+			yyrestart( yyin  , yyscanner);
 			}
 
 		else
@@ -2855,12 +3082,15 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) hsql_realloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	yyg->yy_n_chars += number_to_move;
@@ -2894,9 +3124,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 914 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -2923,9 +3153,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 914 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 913);
 
 	(void)yyg;
@@ -2961,7 +3191,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			int offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2978,13 +3208,13 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 					 */
 
 					/* Reset buffer status. */
-					hsql_restart(yyin ,yyscanner);
+					yyrestart( yyin , yyscanner);
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( hsql_wrap(yyscanner ) )
+					if ( yywrap( yyscanner ) )
 						return 0;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
@@ -3016,34 +3246,34 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void hsql_restart  (FILE * input_file , yyscan_t yyscanner)
+    void yyrestart  (FILE * input_file , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if ( ! YY_CURRENT_BUFFER ){
-        hsql_ensure_buffer_stack (yyscanner);
+        yyensure_buffer_stack (yyscanner);
 		YY_CURRENT_BUFFER_LVALUE =
-            hsql__create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 	}
 
-	hsql__init_buffer(YY_CURRENT_BUFFER,input_file ,yyscanner);
-	hsql__load_buffer_state(yyscanner );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file , yyscanner);
+	yy_load_buffer_state( yyscanner );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * @param yyscanner The scanner object.
  */
-    void hsql__switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		hsql_pop_buffer_state();
-	 *		hsql_push_buffer_state(new_buffer);
+	 *		yypop_buffer_state();
+	 *		yypush_buffer_state(new_buffer);
      */
-	hsql_ensure_buffer_stack (yyscanner);
+	yyensure_buffer_stack (yyscanner);
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -3056,17 +3286,17 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	hsql__load_buffer_state(yyscanner );
+	yy_load_buffer_state( yyscanner );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (hsql_wrap()) processing, but the only time this flag
-	 * is looked at is after hsql_wrap() is called, so it's safe
+	 * EOF (yywrap()) processing, but the only time this flag
+	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
-static void hsql__load_buffer_state  (yyscan_t yyscanner)
+static void yy_load_buffer_state  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
@@ -3081,35 +3311,35 @@ static void hsql__load_buffer_state  (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE hsql__create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) hsql_alloc(sizeof( struct yy_buffer_state ) ,yyscanner );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in hsql__create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = (yy_size_t)size;
+	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) hsql_alloc(b->yy_buf_size + 2 ,yyscanner );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in hsql__create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	hsql__init_buffer(b,file ,yyscanner);
+	yy_init_buffer( b, file , yyscanner);
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with hsql__create_buffer()
+ * @param b a buffer created with yy_create_buffer()
  * @param yyscanner The scanner object.
  */
-    void hsql__delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
+    void yy_delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
@@ -3120,28 +3350,28 @@ static void hsql__load_buffer_state  (yyscan_t yyscanner)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		hsql_free((void *) b->yy_ch_buf ,yyscanner );
+		yyfree( (void *) b->yy_ch_buf , yyscanner );
 
-	hsql_free((void *) b ,yyscanner );
+	yyfree( (void *) b , yyscanner );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a hsql_restart() or at EOF.
+ * such as during a yyrestart() or at EOF.
  */
-    static void hsql__init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
 
 {
 	int oerrno = errno;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	hsql__flush_buffer(b ,yyscanner);
+	yy_flush_buffer( b , yyscanner);
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then hsql__init_buffer was _probably_
-     * called from hsql_restart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then yy_init_buffer was _probably_
+     * called from yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -3158,7 +3388,7 @@ static void hsql__load_buffer_state  (yyscan_t yyscanner)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * @param yyscanner The scanner object.
  */
-    void hsql__flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
+    void yy_flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if ( ! b )
@@ -3179,7 +3409,7 @@ static void hsql__load_buffer_state  (yyscan_t yyscanner)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		hsql__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -3188,15 +3418,15 @@ static void hsql__load_buffer_state  (yyscan_t yyscanner)
  *  @param new_buffer The new state.
  *  @param yyscanner The scanner object.
  */
-void hsql_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if (new_buffer == NULL)
 		return;
 
-	hsql_ensure_buffer_stack(yyscanner);
+	yyensure_buffer_stack(yyscanner);
 
-	/* This block is copied from hsql__switch_to_buffer. */
+	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -3210,8 +3440,8 @@ void hsql_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 		yyg->yy_buffer_stack_top++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from hsql__switch_to_buffer. */
-	hsql__load_buffer_state(yyscanner );
+	/* copied from yy_switch_to_buffer. */
+	yy_load_buffer_state( yyscanner );
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
@@ -3219,19 +3449,19 @@ void hsql_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
  *  The next element becomes the new top.
  *  @param yyscanner The scanner object.
  */
-void hsql_pop_buffer_state (yyscan_t yyscanner)
+void yypop_buffer_state (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if (!YY_CURRENT_BUFFER)
 		return;
 
-	hsql__delete_buffer(YY_CURRENT_BUFFER ,yyscanner);
+	yy_delete_buffer(YY_CURRENT_BUFFER , yyscanner);
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if (yyg->yy_buffer_stack_top > 0)
 		--yyg->yy_buffer_stack_top;
 
 	if (YY_CURRENT_BUFFER) {
-		hsql__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 		yyg->yy_did_buffer_switch_on_eof = 1;
 	}
 }
@@ -3239,9 +3469,9 @@ void hsql_pop_buffer_state (yyscan_t yyscanner)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void hsql_ensure_buffer_stack (yyscan_t yyscanner)
+static void yyensure_buffer_stack (yyscan_t yyscanner)
 {
-	int num_to_alloc;
+	yy_size_t num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if (!yyg->yy_buffer_stack) {
@@ -3251,11 +3481,11 @@ static void hsql_ensure_buffer_stack (yyscan_t yyscanner)
 		 * immediate realloc on the next call.
          */
       num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		yyg->yy_buffer_stack = (struct yy_buffer_state**)hsql_alloc
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
-			YY_FATAL_ERROR( "out of dynamic memory in hsql_ensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
 
@@ -3270,12 +3500,12 @@ static void hsql_ensure_buffer_stack (yyscan_t yyscanner)
 		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = yyg->yy_buffer_stack_max + grow_size;
-		yyg->yy_buffer_stack = (struct yy_buffer_state**)hsql_realloc
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyrealloc
 								(yyg->yy_buffer_stack,
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
-			YY_FATAL_ERROR( "out of dynamic memory in hsql_ensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset(yyg->yy_buffer_stack + yyg->yy_buffer_stack_max, 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -3289,7 +3519,7 @@ static void hsql_ensure_buffer_stack (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE hsql__scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
@@ -3299,11 +3529,11 @@ YY_BUFFER_STATE hsql__scan_buffer  (char * base, yy_size_t  size , yyscan_t yysc
 		/* They forgot to leave room for the EOB's. */
 		return NULL;
 
-	b = (YY_BUFFER_STATE) hsql_alloc(sizeof( struct yy_buffer_state ) ,yyscanner );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in hsql__scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
 	b->yy_input_file = NULL;
@@ -3313,53 +3543,53 @@ YY_BUFFER_STATE hsql__scan_buffer  (char * base, yy_size_t  size , yyscan_t yysc
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	hsql__switch_to_buffer(b ,yyscanner );
+	yy_switch_to_buffer( b , yyscanner );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to hsql_lex() will
+/** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       hsql__scan_bytes() instead.
+ *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE hsql__scan_string (yyconst char * yystr , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
 {
     
-	return hsql__scan_bytes(yystr,(int) strlen(yystr) ,yyscanner);
+	return yy_scan_bytes( yystr, (int) strlen(yystr) , yyscanner);
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to hsql_lex() will
+/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE hsql__scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = (yy_size_t) _yybytes_len + 2;
-	buf = (char *) hsql_alloc(n ,yyscanner );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n , yyscanner );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in hsql__scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = hsql__scan_buffer(buf,n ,yyscanner);
+	b = yy_scan_buffer( buf, n , yyscanner);
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in hsql__scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -3373,11 +3603,11 @@ YY_BUFFER_STATE hsql__scan_bytes  (yyconst char * yybytes, int  _yybytes_len , y
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yynoreturn yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
+static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	(void) fprintf( stderr, "%s\n", msg );
+	fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -3403,7 +3633,7 @@ static void yynoreturn yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
 /** Get the user-defined data for this scanner.
  * @param yyscanner The scanner object.
  */
-YY_EXTRA_TYPE hsql_get_extra  (yyscan_t yyscanner)
+YY_EXTRA_TYPE yyget_extra  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyextra;
@@ -3412,7 +3642,7 @@ YY_EXTRA_TYPE hsql_get_extra  (yyscan_t yyscanner)
 /** Get the current line number.
  * @param yyscanner The scanner object.
  */
-int hsql_get_lineno  (yyscan_t yyscanner)
+int yyget_lineno  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
@@ -3425,7 +3655,7 @@ int hsql_get_lineno  (yyscan_t yyscanner)
 /** Get the current column number.
  * @param yyscanner The scanner object.
  */
-int hsql_get_column  (yyscan_t yyscanner)
+int yyget_column  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
@@ -3438,7 +3668,7 @@ int hsql_get_column  (yyscan_t yyscanner)
 /** Get the input stream.
  * @param yyscanner The scanner object.
  */
-FILE *hsql_get_in  (yyscan_t yyscanner)
+FILE *yyget_in  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyin;
@@ -3447,7 +3677,7 @@ FILE *hsql_get_in  (yyscan_t yyscanner)
 /** Get the output stream.
  * @param yyscanner The scanner object.
  */
-FILE *hsql_get_out  (yyscan_t yyscanner)
+FILE *yyget_out  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyout;
@@ -3456,7 +3686,7 @@ FILE *hsql_get_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-int hsql_get_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -3466,7 +3696,7 @@ int hsql_get_leng  (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  */
 
-char *hsql_get_text  (yyscan_t yyscanner)
+char *yyget_text  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yytext;
@@ -3476,7 +3706,7 @@ char *hsql_get_text  (yyscan_t yyscanner)
  * @param user_defined The data to be associated with this scanner.
  * @param yyscanner The scanner object.
  */
-void hsql_set_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
+void yyset_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyextra = user_defined ;
@@ -3486,13 +3716,13 @@ void hsql_set_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
  * @param _line_number line number
  * @param yyscanner The scanner object.
  */
-void hsql_set_lineno (int  _line_number , yyscan_t yyscanner)
+void yyset_lineno (int  _line_number , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           YY_FATAL_ERROR( "hsql_set_lineno called with no buffer" );
+           YY_FATAL_ERROR( "yyset_lineno called with no buffer" );
     
     yylineno = _line_number;
 }
@@ -3501,13 +3731,13 @@ void hsql_set_lineno (int  _line_number , yyscan_t yyscanner)
  * @param _column_no column number
  * @param yyscanner The scanner object.
  */
-void hsql_set_column (int  _column_no , yyscan_t yyscanner)
+void yyset_column (int  _column_no , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           YY_FATAL_ERROR( "hsql_set_column called with no buffer" );
+           YY_FATAL_ERROR( "yyset_column called with no buffer" );
     
     yycolumn = _column_no;
 }
@@ -3516,27 +3746,27 @@ void hsql_set_column (int  _column_no , yyscan_t yyscanner)
  * input buffer.
  * @param _in_str A readable stream.
  * @param yyscanner The scanner object.
- * @see hsql__switch_to_buffer
+ * @see yy_switch_to_buffer
  */
-void hsql_set_in (FILE *  _in_str , yyscan_t yyscanner)
+void yyset_in (FILE *  _in_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyin = _in_str ;
 }
 
-void hsql_set_out (FILE *  _out_str , yyscan_t yyscanner)
+void yyset_out (FILE *  _out_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyout = _out_str ;
 }
 
-int hsql_get_debug  (yyscan_t yyscanner)
+int yyget_debug  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yy_flex_debug;
 }
 
-void hsql_set_debug (int  _bdebug , yyscan_t yyscanner)
+void yyset_debug (int  _bdebug , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yy_flex_debug = _bdebug ;
@@ -3544,25 +3774,25 @@ void hsql_set_debug (int  _bdebug , yyscan_t yyscanner)
 
 /* Accessor methods for yylval and yylloc */
 
-YYSTYPE * hsql_get_lval  (yyscan_t yyscanner)
+YYSTYPE * yyget_lval  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yylval;
 }
 
-void hsql_set_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
+void yyset_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yylval = yylval_param;
 }
 
-YYLTYPE *hsql_get_lloc  (yyscan_t yyscanner)
+YYLTYPE *yyget_lloc  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yylloc;
 }
     
-void hsql_set_lloc (YYLTYPE *  yylloc_param , yyscan_t yyscanner)
+void yyset_lloc (YYLTYPE *  yylloc_param , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yylloc = yylloc_param;
@@ -3570,20 +3800,18 @@ void hsql_set_lloc (YYLTYPE *  yylloc_param , yyscan_t yyscanner)
     
 /* User-visible API */
 
-/* hsql_lex_init is special because it creates the scanner itself, so it is
+/* yylex_init is special because it creates the scanner itself, so it is
  * the ONLY reentrant function that doesn't take the scanner as the last argument.
  * That's why we explicitly handle the declaration, instead of using our macros.
  */
-
-int hsql_lex_init(yyscan_t* ptr_yy_globals)
-
+int yylex_init(yyscan_t* ptr_yy_globals)
 {
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
         return 1;
     }
 
-    *ptr_yy_globals = (yyscan_t) hsql_alloc ( sizeof( struct yyguts_t ), NULL );
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), NULL );
 
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
@@ -3596,27 +3824,25 @@ int hsql_lex_init(yyscan_t* ptr_yy_globals)
     return yy_init_globals ( *ptr_yy_globals );
 }
 
-/* hsql_lex_init_extra has the same functionality as hsql_lex_init, but follows the
+/* yylex_init_extra has the same functionality as yylex_init, but follows the
  * convention of taking the scanner as the last argument. Note however, that
  * this is a *pointer* to a scanner, as it will be allocated by this call (and
  * is the reason, too, why this function also must handle its own declaration).
- * The user defined value in the first argument will be available to hsql_alloc in
+ * The user defined value in the first argument will be available to yyalloc in
  * the yyextra field.
  */
-
-int hsql_lex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals )
-
+int yylex_init_extra( YY_EXTRA_TYPE yy_user_defined, yyscan_t* ptr_yy_globals )
 {
     struct yyguts_t dummy_yyguts;
 
-    hsql_set_extra (yy_user_defined, &dummy_yyguts);
+    yyset_extra (yy_user_defined, &dummy_yyguts);
 
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
         return 1;
     }
 
-    *ptr_yy_globals = (yyscan_t) hsql_alloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
 
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
@@ -3627,7 +3853,7 @@ int hsql_lex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals )
     yy_init_globals. Leave at 0x00 for releases. */
     memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
 
-    hsql_set_extra (yy_user_defined, *ptr_yy_globals);
+    yyset_extra (yy_user_defined, *ptr_yy_globals);
 
     return yy_init_globals ( *ptr_yy_globals );
 }
@@ -3636,7 +3862,7 @@ static int yy_init_globals (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from hsql_lex_destroy(), so don't allocate here.
+     * This function is called from yylex_destroy(), so don't allocate here.
      */
 
     yyg->yy_buffer_stack = NULL;
@@ -3660,37 +3886,37 @@ static int yy_init_globals (yyscan_t yyscanner)
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * hsql_lex_init()
+     * yylex_init()
      */
     return 0;
 }
 
-/* hsql_lex_destroy is for both reentrant and non-reentrant scanners. */
-int hsql_lex_destroy  (yyscan_t yyscanner)
+/* yylex_destroy is for both reentrant and non-reentrant scanners. */
+int yylex_destroy  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		hsql__delete_buffer(YY_CURRENT_BUFFER ,yyscanner );
+		yy_delete_buffer( YY_CURRENT_BUFFER , yyscanner );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		hsql_pop_buffer_state(yyscanner);
+		yypop_buffer_state(yyscanner);
 	}
 
 	/* Destroy the stack itself. */
-	hsql_free(yyg->yy_buffer_stack ,yyscanner);
+	yyfree(yyg->yy_buffer_stack , yyscanner);
 	yyg->yy_buffer_stack = NULL;
 
     /* Destroy the start condition stack. */
-        hsql_free(yyg->yy_start_stack ,yyscanner );
+        yyfree( yyg->yy_start_stack , yyscanner );
         yyg->yy_start_stack = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * hsql_lex() is called, initialization will occur. */
+     * yylex() is called, initialization will occur. */
     yy_init_globals( yyscanner);
 
     /* Destroy the main struct (reentrant only). */
-    hsql_free ( yyscanner , yyscanner );
+    yyfree ( yyscanner , yyscanner );
     yyscanner = NULL;
     return 0;
 }
@@ -3700,7 +3926,7 @@ int hsql_lex_destroy  (yyscan_t yyscanner)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n , yyscan_t yyscanner)
+static void yy_flex_strncpy (char* s1, const char * s2, int n , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -3712,7 +3938,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n , yyscan_t yysca
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
+static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -3722,14 +3948,14 @@ static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
 }
 #endif
 
-void *hsql_alloc (yy_size_t  size , yyscan_t yyscanner)
+void *yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
 	return malloc(size);
 }
 
-void *hsql_realloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
+void *yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -3744,17 +3970,16 @@ void *hsql_realloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 	return realloc(ptr, size);
 }
 
-void hsql_free (void * ptr , yyscan_t yyscanner)
+void yyfree (void * ptr , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	free( (char *) ptr );	/* see hsql_realloc() for (char *) cast */
+	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
 #line 213 "flex_lexer.l"
-
 
 /***************************
  ** Section 3: User code

--- a/src/parser/flex_lexer.h
+++ b/src/parser/flex_lexer.h
@@ -2,9 +2,9 @@
 #define hsql_HEADER_H 1
 #define hsql_IN_HEADER 1
 
-#line 6 "flex_lexer.h"
+#line 5 "flex_lexer.h"
 
-#line 8 "flex_lexer.h"
+#line 7 "flex_lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -13,9 +13,243 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 1
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define hsql__create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer hsql__create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define hsql__delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer hsql__delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define hsql__scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer hsql__scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define hsql__scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string hsql__scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define hsql__scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes hsql__scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define hsql__init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer hsql__init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define hsql__flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer hsql__flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define hsql__load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state hsql__load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define hsql__switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer hsql__switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define hsql_push_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state hsql_push_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define hsql_pop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state hsql_pop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define hsql_ensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack hsql_ensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define hsql_lex_ALREADY_DEFINED
+#else
+#define yylex hsql_lex
+#endif
+
+#ifdef yyrestart
+#define hsql_restart_ALREADY_DEFINED
+#else
+#define yyrestart hsql_restart
+#endif
+
+#ifdef yylex_init
+#define hsql_lex_init_ALREADY_DEFINED
+#else
+#define yylex_init hsql_lex_init
+#endif
+
+#ifdef yylex_init_extra
+#define hsql_lex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra hsql_lex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define hsql_lex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy hsql_lex_destroy
+#endif
+
+#ifdef yyget_debug
+#define hsql_get_debug_ALREADY_DEFINED
+#else
+#define yyget_debug hsql_get_debug
+#endif
+
+#ifdef yyset_debug
+#define hsql_set_debug_ALREADY_DEFINED
+#else
+#define yyset_debug hsql_set_debug
+#endif
+
+#ifdef yyget_extra
+#define hsql_get_extra_ALREADY_DEFINED
+#else
+#define yyget_extra hsql_get_extra
+#endif
+
+#ifdef yyset_extra
+#define hsql_set_extra_ALREADY_DEFINED
+#else
+#define yyset_extra hsql_set_extra
+#endif
+
+#ifdef yyget_in
+#define hsql_get_in_ALREADY_DEFINED
+#else
+#define yyget_in hsql_get_in
+#endif
+
+#ifdef yyset_in
+#define hsql_set_in_ALREADY_DEFINED
+#else
+#define yyset_in hsql_set_in
+#endif
+
+#ifdef yyget_out
+#define hsql_get_out_ALREADY_DEFINED
+#else
+#define yyget_out hsql_get_out
+#endif
+
+#ifdef yyset_out
+#define hsql_set_out_ALREADY_DEFINED
+#else
+#define yyset_out hsql_set_out
+#endif
+
+#ifdef yyget_leng
+#define hsql_get_leng_ALREADY_DEFINED
+#else
+#define yyget_leng hsql_get_leng
+#endif
+
+#ifdef yyget_text
+#define hsql_get_text_ALREADY_DEFINED
+#else
+#define yyget_text hsql_get_text
+#endif
+
+#ifdef yyget_lineno
+#define hsql_get_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno hsql_get_lineno
+#endif
+
+#ifdef yyset_lineno
+#define hsql_set_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno hsql_set_lineno
+#endif
+
+#ifdef yyget_column
+#define hsql_get_column_ALREADY_DEFINED
+#else
+#define yyget_column hsql_get_column
+#endif
+
+#ifdef yyset_column
+#define hsql_set_column_ALREADY_DEFINED
+#else
+#define yyset_column hsql_set_column
+#endif
+
+#ifdef yywrap
+#define hsql_wrap_ALREADY_DEFINED
+#else
+#define yywrap hsql_wrap
+#endif
+
+#ifdef yyget_lval
+#define hsql_get_lval_ALREADY_DEFINED
+#else
+#define yyget_lval hsql_get_lval
+#endif
+
+#ifdef yyset_lval
+#define hsql_set_lval_ALREADY_DEFINED
+#else
+#define yyset_lval hsql_set_lval
+#endif
+
+#ifdef yyget_lloc
+#define hsql_get_lloc_ALREADY_DEFINED
+#else
+#define yyget_lloc hsql_get_lloc
+#endif
+
+#ifdef yyset_lloc
+#define hsql_set_lloc_ALREADY_DEFINED
+#else
+#define yyset_lloc hsql_set_lloc
+#endif
+
+#ifdef yyalloc
+#define hsql_alloc_ALREADY_DEFINED
+#else
+#define yyalloc hsql_alloc
+#endif
+
+#ifdef yyrealloc
+#define hsql_realloc_ALREADY_DEFINED
+#else
+#define yyrealloc hsql_realloc
+#endif
+
+#ifdef yyfree
+#define hsql_free_ALREADY_DEFINED
+#else
+#define yyfree hsql_free
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -88,9 +322,15 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
+
+/* begin standard C++ headers. */
 
 /* TODO: this is always defined, so inline it */
 #define yyconst const
@@ -192,21 +432,21 @@ struct yy_buffer_state
 	};
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
-void hsql_restart (FILE *input_file ,yyscan_t yyscanner );
-void hsql__switch_to_buffer (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__create_buffer (FILE *file,int size ,yyscan_t yyscanner );
-void hsql__delete_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void hsql__flush_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void hsql_push_buffer_state (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-void hsql_pop_buffer_state (yyscan_t yyscanner );
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-YY_BUFFER_STATE hsql__scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-void *hsql_alloc (yy_size_t ,yyscan_t yyscanner );
-void *hsql_realloc (void *,yy_size_t ,yyscan_t yyscanner );
-void hsql_free (void * ,yyscan_t yyscanner );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
 /* Begin user sect3 */
 
@@ -233,50 +473,50 @@ void hsql_free (void * ,yyscan_t yyscanner );
 #define YY_EXTRA_TYPE void *
 #endif
 
-int hsql_lex_init (yyscan_t* scanner);
+int yylex_init (yyscan_t* scanner);
 
-int hsql_lex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int hsql_lex_destroy (yyscan_t yyscanner );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int hsql_get_debug (yyscan_t yyscanner );
+int yyget_debug ( yyscan_t yyscanner );
 
-void hsql_set_debug (int debug_flag ,yyscan_t yyscanner );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE hsql_get_extra (yyscan_t yyscanner );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void hsql_set_extra (YY_EXTRA_TYPE user_defined ,yyscan_t yyscanner );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *hsql_get_in (yyscan_t yyscanner );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void hsql_set_in  (FILE * _in_str ,yyscan_t yyscanner );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *hsql_get_out (yyscan_t yyscanner );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void hsql_set_out  (FILE * _out_str ,yyscan_t yyscanner );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			int hsql_get_leng (yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *hsql_get_text (yyscan_t yyscanner );
+char *yyget_text ( yyscan_t yyscanner );
 
-int hsql_get_lineno (yyscan_t yyscanner );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void hsql_set_lineno (int _line_number ,yyscan_t yyscanner );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-int hsql_get_column  (yyscan_t yyscanner );
+int yyget_column  ( yyscan_t yyscanner );
 
-void hsql_set_column (int _column_no ,yyscan_t yyscanner );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
 
-YYSTYPE * hsql_get_lval (yyscan_t yyscanner );
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
 
-void hsql_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
 
-       YYLTYPE *hsql_get_lloc (yyscan_t yyscanner );
+       YYLTYPE *yyget_lloc ( yyscan_t yyscanner );
     
-        void hsql_set_lloc (YYLTYPE * yylloc_param ,yyscan_t yyscanner );
+        void yyset_lloc ( YYLTYPE * yylloc_param , yyscan_t yyscanner );
     
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -284,18 +524,18 @@ void hsql_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int hsql_wrap (yyscan_t yyscanner );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int hsql_wrap (yyscan_t yyscanner );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int ,yyscan_t yyscanner);
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
@@ -323,10 +563,10 @@ static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int hsql_lex \
-               (YYSTYPE * yylval_param,YYLTYPE * yylloc_param ,yyscan_t yyscanner);
+extern int yylex \
+               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner);
 
-#define YY_DECL int hsql_lex \
+#define YY_DECL int yylex \
                (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner)
 #endif /* !YY_DECL */
 
@@ -344,9 +584,154 @@ extern int hsql_lex \
 #undef YY_DECL
 #endif
 
+#ifndef hsql__create_buffer_ALREADY_DEFINED
+#undef yy_create_buffer
+#endif
+#ifndef hsql__delete_buffer_ALREADY_DEFINED
+#undef yy_delete_buffer
+#endif
+#ifndef hsql__scan_buffer_ALREADY_DEFINED
+#undef yy_scan_buffer
+#endif
+#ifndef hsql__scan_string_ALREADY_DEFINED
+#undef yy_scan_string
+#endif
+#ifndef hsql__scan_bytes_ALREADY_DEFINED
+#undef yy_scan_bytes
+#endif
+#ifndef hsql__init_buffer_ALREADY_DEFINED
+#undef yy_init_buffer
+#endif
+#ifndef hsql__flush_buffer_ALREADY_DEFINED
+#undef yy_flush_buffer
+#endif
+#ifndef hsql__load_buffer_state_ALREADY_DEFINED
+#undef yy_load_buffer_state
+#endif
+#ifndef hsql__switch_to_buffer_ALREADY_DEFINED
+#undef yy_switch_to_buffer
+#endif
+#ifndef hsql_push_buffer_state_ALREADY_DEFINED
+#undef yypush_buffer_state
+#endif
+#ifndef hsql_pop_buffer_state_ALREADY_DEFINED
+#undef yypop_buffer_state
+#endif
+#ifndef hsql_ensure_buffer_stack_ALREADY_DEFINED
+#undef yyensure_buffer_stack
+#endif
+#ifndef hsql_lex_ALREADY_DEFINED
+#undef yylex
+#endif
+#ifndef hsql_restart_ALREADY_DEFINED
+#undef yyrestart
+#endif
+#ifndef hsql_lex_init_ALREADY_DEFINED
+#undef yylex_init
+#endif
+#ifndef hsql_lex_init_extra_ALREADY_DEFINED
+#undef yylex_init_extra
+#endif
+#ifndef hsql_lex_destroy_ALREADY_DEFINED
+#undef yylex_destroy
+#endif
+#ifndef hsql_get_debug_ALREADY_DEFINED
+#undef yyget_debug
+#endif
+#ifndef hsql_set_debug_ALREADY_DEFINED
+#undef yyset_debug
+#endif
+#ifndef hsql_get_extra_ALREADY_DEFINED
+#undef yyget_extra
+#endif
+#ifndef hsql_set_extra_ALREADY_DEFINED
+#undef yyset_extra
+#endif
+#ifndef hsql_get_in_ALREADY_DEFINED
+#undef yyget_in
+#endif
+#ifndef hsql_set_in_ALREADY_DEFINED
+#undef yyset_in
+#endif
+#ifndef hsql_get_out_ALREADY_DEFINED
+#undef yyget_out
+#endif
+#ifndef hsql_set_out_ALREADY_DEFINED
+#undef yyset_out
+#endif
+#ifndef hsql_get_leng_ALREADY_DEFINED
+#undef yyget_leng
+#endif
+#ifndef hsql_get_text_ALREADY_DEFINED
+#undef yyget_text
+#endif
+#ifndef hsql_get_lineno_ALREADY_DEFINED
+#undef yyget_lineno
+#endif
+#ifndef hsql_set_lineno_ALREADY_DEFINED
+#undef yyset_lineno
+#endif
+#ifndef hsql_get_column_ALREADY_DEFINED
+#undef yyget_column
+#endif
+#ifndef hsql_set_column_ALREADY_DEFINED
+#undef yyset_column
+#endif
+#ifndef hsql_wrap_ALREADY_DEFINED
+#undef yywrap
+#endif
+#ifndef hsql_get_lval_ALREADY_DEFINED
+#undef yyget_lval
+#endif
+#ifndef hsql_set_lval_ALREADY_DEFINED
+#undef yyset_lval
+#endif
+#ifndef hsql_get_lloc_ALREADY_DEFINED
+#undef yyget_lloc
+#endif
+#ifndef hsql_set_lloc_ALREADY_DEFINED
+#undef yyset_lloc
+#endif
+#ifndef hsql_alloc_ALREADY_DEFINED
+#undef yyalloc
+#endif
+#ifndef hsql_realloc_ALREADY_DEFINED
+#undef yyrealloc
+#endif
+#ifndef hsql_free_ALREADY_DEFINED
+#undef yyfree
+#endif
+#ifndef hsql_text_ALREADY_DEFINED
+#undef yytext
+#endif
+#ifndef hsql_leng_ALREADY_DEFINED
+#undef yyleng
+#endif
+#ifndef hsql_in_ALREADY_DEFINED
+#undef yyin
+#endif
+#ifndef hsql_out_ALREADY_DEFINED
+#undef yyout
+#endif
+#ifndef hsql__flex_debug_ALREADY_DEFINED
+#undef yy_flex_debug
+#endif
+#ifndef hsql_lineno_ALREADY_DEFINED
+#undef yylineno
+#endif
+#ifndef hsql_tables_fload_ALREADY_DEFINED
+#undef yytables_fload
+#endif
+#ifndef hsql_tables_destroy_ALREADY_DEFINED
+#undef yytables_destroy
+#endif
+#ifndef hsql_TABLES_NAME_ALREADY_DEFINED
+#undef yyTABLES_NAME
+#endif
+
 #line 213 "flex_lexer.l"
 
 
-#line 351 "flex_lexer.h"
+#line 735 "flex_lexer.h"
 #undef hsql_IN_HEADER
 #endif /* hsql_HEADER_H */

--- a/src/sql/Expr.cpp
+++ b/src/sql/Expr.cpp
@@ -48,16 +48,6 @@ namespace hsql {
   Expr* Expr::makeOpBinary(Expr* expr1, OperatorType op, Expr* expr2) {
     Expr* e = new Expr(kExprOperator);
     e->opType = op;
-    e->opChar = 0;
-    e->expr = expr1;
-    e->expr2 = expr2;
-    return e;
-  }
-
-  Expr* Expr::makeOpBinary(Expr* expr1, char op, Expr* expr2) {
-    Expr* e = new Expr(kExprOperator);
-    e->opType = kOpSimple;
-    e->opChar = op;
     e->expr = expr1;
     e->expr2 = expr2;
     return e;
@@ -179,14 +169,6 @@ namespace hsql {
   const char* Expr::getName() const {
     if (alias != nullptr) return alias;
     else return name;
-  }
-
-  bool Expr::isSimpleOp() const {
-    return opType == kOpSimple;
-  }
-
-  bool Expr::isSimpleOp(char op) const {
-    return isSimpleOp() && opChar == op;
   }
 
   char* substr(const char* source, int from, int to) {

--- a/src/sql/Expr.h
+++ b/src/sql/Expr.h
@@ -37,11 +37,18 @@ namespace hsql {
     kOpCase,
 
     // Binary operators.
-    // Simple operators are identified by the opChar field (e.g. +, -, =, >, <).
-    kOpSimple,
+    kOpAdd,
+    kOpSubtract,
+    kOpMultiply,
+    kOpDivide,
+    kOpModulo,
+    kOpPower,
 
+    kOpEquals,
     kOpNotEquals,
+    kOpLess,
     kOpLessEq,
+    kOpGreater,
     kOpGreaterEq,
     kOpLike,
     kOpNotLike,
@@ -80,7 +87,6 @@ namespace hsql {
     int64_t ival2;
 
     OperatorType opType;
-    char opChar;
     bool distinct;
 
 
@@ -96,18 +102,11 @@ namespace hsql {
 
     const char* getName() const;
 
-    bool isSimpleOp() const;
-
-    bool isSimpleOp(char op) const;
-
-
     // Static constructors.
 
     static Expr* make(ExprType type);
 
     static Expr* makeOpUnary(OperatorType op, Expr* expr);
-
-    static Expr* makeOpBinary(Expr* expr1, char op, Expr* expr2);
 
     static Expr* makeOpBinary(Expr* expr1, OperatorType op, Expr* expr2);
 

--- a/src/sql/Expr.h
+++ b/src/sql/Expr.h
@@ -37,12 +37,12 @@ namespace hsql {
     kOpCase,
 
     // Binary operators.
-    kOpAdd,
-    kOpSubtract,
-    kOpMultiply,
-    kOpDivide,
-    kOpModulo,
-    kOpPower,
+    kOpPlus,
+    kOpMinus,
+    kOpAsterisk,
+    kOpSlash,
+    kOpPercentage,
+    kOpCaret,
 
     kOpEquals,
     kOpNotEquals,
@@ -58,7 +58,7 @@ namespace hsql {
 
     // Unary operators.
     kOpNot,
-    kOpMinus,
+    kOpUnaryMinus,
     kOpIsNull,
     kOpExists
   };

--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -63,9 +63,6 @@ namespace hsql {
     }
 
     switch (expr->opType) {
-    case kOpSimple:
-      inprintC(expr->opChar, numIndent);
-      break;
     case kOpAnd:
       inprint("AND", numIndent);
       break;

--- a/test/prepare_tests.cpp
+++ b/test/prepare_tests.cpp
@@ -71,14 +71,14 @@ TEST(StatementWithParameters) {
 
   ASSERT_EQ(result.parameters().size(), 2);
 
-  ASSERT(eq1->isSimpleOp('='))
+  ASSERT_EQ(eq1->opType, hsql::kOpEquals)
   ASSERT(eq1->expr->isType(hsql::kExprColumnRef))
   ASSERT(eq1->expr2->isType(kExprParameter))
   ASSERT_EQ(eq1->expr2->ival, 0)
   ASSERT_EQ(result.parameters()[0], eq1->expr2);
 
 
-  ASSERT(eq2->isSimpleOp('='))
+  ASSERT_EQ(eq2->opType, hsql::kOpEquals)
   ASSERT(eq2->expr->isType(hsql::kExprColumnRef))
   ASSERT(eq2->expr2->isType(kExprParameter))
   ASSERT_EQ(eq2->expr2->ival, 1)

--- a/test/select_tests.cpp
+++ b/test/select_tests.cpp
@@ -69,7 +69,7 @@ TEST(SelectHavingTest) {
   GroupByDescription* group = stmt->groupBy;
   ASSERT_NOTNULL(group);
   ASSERT_EQ(group->columns->size(), 1);
-  ASSERT(group->having->isSimpleOp('<'));
+  ASSERT_EQ(group->having->opType, kOpLess);
   ASSERT(group->having->expr->isType(kExprFunctionRef));
   ASSERT(group->having->expr2->isType(kExprLiteralFloat));
   ASSERT_EQ(group->having->expr2->fval, -2.0);
@@ -162,7 +162,7 @@ TEST(SelectConditionalSelectTest) {
   Expr* cond1 = where->expr;
   ASSERT_NOTNULL(cond1);
   ASSERT_NOTNULL(cond1->expr);
-  ASSERT(cond1->isSimpleOp('='));
+  ASSERT_EQ(cond1->opType, kOpEquals);
   ASSERT_STREQ(cond1->expr->getName(), "a");
   ASSERT(cond1->expr->isType(kExprColumnRef));
 
@@ -203,7 +203,7 @@ TEST(SelectCaseWhen) {
   ASSERT(caseExpr->isType(kExprOperator));
   ASSERT_EQ(caseExpr->opType, kOpCase);
   ASSERT(caseExpr->expr->isType(kExprOperator));
-  ASSERT(caseExpr->expr->isSimpleOp('='));
+  ASSERT_EQ(caseExpr->expr->opType, kOpEquals);
   ASSERT_EQ(caseExpr->exprList->size(), 2);
 }
 
@@ -225,7 +225,7 @@ TEST(SelectJoin) {
 
   ASSERT_EQ(outer_join->right->type, kTableName);
   ASSERT_STREQ(outer_join->right->name, "Product");
-  ASSERT(outer_join->condition->isSimpleOp('='));
+  ASSERT_EQ(outer_join->condition->opType, kOpEquals);
   ASSERT_STREQ(outer_join->condition->expr->table, "fact");
   ASSERT_STREQ(outer_join->condition->expr->name, "product_id");
   ASSERT_STREQ(outer_join->condition->expr2->table, "Product");
@@ -242,7 +242,7 @@ TEST(SelectJoin) {
   ASSERT_EQ(inner_join->right->type, kTableName);
   ASSERT_STREQ(inner_join->right->name, "City");
 
-  ASSERT(inner_join->condition->isSimpleOp('='));
+  ASSERT_EQ(inner_join->condition->opType, kOpEquals);
   ASSERT_STREQ(inner_join->condition->expr->table, "fact");
   ASSERT_STREQ(inner_join->condition->expr->name, "city_id");
   ASSERT_STREQ(inner_join->condition->expr2->table, "City");

--- a/test/sql_tests.cpp
+++ b/test/sql_tests.cpp
@@ -75,7 +75,7 @@ TEST(UpdateStatementTest) {
 
   ASSERT_NOTNULL(stmt->where);
   ASSERT(stmt->where->isType(kExprOperator));
-  ASSERT(stmt->where->isSimpleOp('='));
+  ASSERT_EQ(stmt->where->opType, kOpEquals);
   ASSERT_STREQ(stmt->where->expr->name, "name");
   ASSERT_STREQ(stmt->where->expr2->name, "Max Mustermann");
 }


### PR DESCRIPTION
This PR splits up `kOpSimple`, which was being used to describe operators that can be represented as a single char. The advantage of splitting those up is that we can more easily differentiate between them and do not need to compare both the type and the character.