### PR TITLE
Fix bug in print kExprFunctionRef expression.

### DIFF
--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -100,7 +100,7 @@ namespace hsql {
       break;
     case kExprFunctionRef:
       inprint(expr->name, numIndent);
-      inprint(expr->expr->name, numIndent + 1);
+      for (Expr* e : *expr->exprList) inprint(e->name, numIndent + 1);
       break;
     case kExprOperator:
       printOperatorExpression(expr, numIndent);

--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -128,6 +128,14 @@ namespace hsql {
       printExpression(stmt->whereClause, numIndent + 2);
     }
 
+    if (stmt->groupBy != nullptr) {
+      inprint("GroupBy:", numIndent + 1);
+      for (Expr* expr : *stmt->groupBy->columns) printExpression(expr, numIndent + 2);
+      if (stmt->groupBy->having != nullptr) {
+        inprint("Having:", numIndent + 1);
+        printExpression(stmt->groupBy->having, numIndent + 2);
+      }
+    }
 
     if (stmt->unionSelect != nullptr) {
       inprint("Union:", numIndent + 1);


### PR DESCRIPTION
The [Expr::makeFunctionRef](https://github.com/hyrise/sql-parser/blob/fe35651bb5de1e7ca59d22c11359a149a45f19d3/src/sql/Expr.cpp#L108) uses `exprList` not `expr` to store expressions:  

```
Expr* Expr::makeFunctionRef(char* func_name, std::vector<Expr*>* exprList, bool distinct) {
    Expr* e = new Expr(kExprFunctionRef);
    e->name = func_name;
    e->exprList = exprList;
    e->distinct = distinct;
    return e;
  }
```

So during print [kExprFunctionRef expression](https://github.com/hyrise/sql-parser/blob/fe35651bb5de1e7ca59d22c11359a149a45f19d3/src/util/sqlhelper.cpp#L101):  

```
    case kExprFunctionRef:
      inprint(expr->name, numIndent);
      inprint(expr->expr->name, numIndent + 1);
      break;
```

`expr->expr` is a `nullptr`, and will cause program crash.