### PR TITLE
Init expr

### DIFF
--- a/src/sql/Expr.cpp
+++ b/src/sql/Expr.cpp
@@ -14,7 +14,12 @@ namespace hsql {
       select(nullptr),
       name(nullptr),
       table(nullptr),
-      alias(nullptr) {};
+      alias(nullptr),
+      fval(0),
+      ival(0),
+      ival2(0),
+      opType(kOpNone),
+      distinct(false) {};
 
   Expr::~Expr() {
     delete expr;


### PR DESCRIPTION
The Expr struct need to be initialized, otherwise, there are random values in `fval`, `ival` etc. And `printExpression` will print messy. 