### PR TITLE
Changing Grammar to extend CASE WHEN statement:

### DIFF
--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -195,7 +195,7 @@ int yyerror(YYLTYPE* llocp, SQLParserResult* result, yyscan_t scanner, const cha
 %type <expr> 		expr operand scalar_expr unary_expr binary_expr logic_expr exists_expr
 %type <expr>		function_expr between_expr expr_alias param_expr
 %type <expr> 		column_name literal int_literal num_literal string_literal
-%type <expr> 		comp_expr opt_where join_condition opt_having case_expr in_expr hint
+%type <expr> 		comp_expr opt_where join_condition opt_having case_expr case_list in_expr hint
 %type <expr> 		array_expr array_index null_literal
 %type <limit>		opt_limit opt_top
 %type <order>		order_desc
@@ -781,11 +781,18 @@ in_expr:
 	|	operand NOT IN '(' select_no_paren ')'	{ $$ = Expr::makeOpUnary(kOpNot, Expr::makeInOperator($1, $5)); }
 	;
 
-// TODO: allow no else specified
+// CASE grammar based on: flex & bison by John Levine 
+// https://www.safaribooksonline.com/library/view/flex-bison/9780596805418/ch04.html#id352665
 case_expr:
-		CASE WHEN expr THEN operand END { $$ = Expr::makeCase($3, $5); }
-	|
-		CASE WHEN expr THEN operand ELSE operand END { $$ = Expr::makeCase($3, $5, $7); }
+		CASE expr case_list END         	{ $$ = Expr::makeCaseExpr($2, $3); }
+	|	CASE expr case_list ELSE expr END	{ $$ = Expr::makeCaseExpr($2, $3, $5); }
+	|	CASE case_list END			{ $$ = Expr::makeCase($2); }
+	|	CASE case_list ELSE expr END		{ $$ = Expr::makeCase($2, $4); }
+	;
+
+case_list:
+		WHEN expr THEN expr              { $$ = Expr::makeCaseCondition($2, $4); }
+	|	case_list WHEN expr THEN expr    { $$ = Expr::joinCaseCondition($1, Expr::makeCaseCondition($3, $5)); }
 	;
 
 exists_expr:

--- a/src/sql/Expr.cpp
+++ b/src/sql/Expr.cpp
@@ -68,22 +68,53 @@ namespace hsql {
     return e;
   }
 
-  Expr* Expr::makeCase(Expr* expr, Expr* then) {
-    Expr* e = new Expr(kExprOperator);
+  Expr* Expr::makeCaseCondition(Expr* expr, Expr* then) {
+    Expr* e = new Expr(kExprWhenCondition);
     e->expr = expr;
-    e->opType = kOpCase;
-    e->exprList = new std::vector<Expr*>();
-    e->exprList->push_back(then);
+    e->expr2 = then;
     return e;
   }
 
-  Expr* Expr::makeCase(Expr* expr, Expr* then, Expr* other) {
+  Expr* Expr::joinCaseCondition(Expr* expr1, Expr* expr2) {
     Expr* e = new Expr(kExprOperator);
-    e->expr = expr;
+    e->opType = kOpPlus;
+    if (expr1->exprList != nullptr) {
+      e->exprList = expr1->exprList;
+    } else {
+      e->exprList = new std::vector<Expr*>();
+      e->exprList->push_back(expr1);
+    }
+    e->exprList->push_back(expr2);
+    return e;
+  }
+
+  Expr* Expr::makeCase(Expr* when) {
+    Expr* e = new Expr(kExprOperator);
     e->opType = kOpCase;
-    e->exprList = new std::vector<Expr*>();
-    e->exprList->push_back(then);
-    e->exprList->push_back(other);
+    if (when->exprList != nullptr) {
+      e->exprList = when->exprList;
+    } else {
+      e->exprList = new std::vector<Expr*>();
+      e->exprList->push_back(when);
+    }
+    return e;
+  }
+
+  Expr* Expr::makeCase(Expr* when, Expr* other) {
+    Expr* e = Expr::makeCase(when);
+    e->expr2 = other;
+    return e;
+  }
+
+  Expr* Expr::makeCaseExpr(Expr* expr, Expr* when) {
+    Expr* e = Expr::makeCase(when);
+    e->expr = expr;
+    return e;
+  }
+
+  Expr* Expr::makeCaseExpr(Expr* expr, Expr* when, Expr* other) {
+    Expr* e = Expr::makeCase(when, other);
+    e->expr = expr;
     return e;
   }
 

--- a/src/sql/Expr.h
+++ b/src/sql/Expr.h
@@ -25,7 +25,8 @@ namespace hsql {
     kExprSelect,
     kExprHint,
     kExprArray,
-    kExprArrayIndex
+    kExprArrayIndex,
+    kExprWhenCondition
   };
 
 // Operator types. These are important for expressions of type kExprOperator.
@@ -113,9 +114,17 @@ namespace hsql {
 
     static Expr* makeBetween(Expr* expr, Expr* left, Expr* right);
 
-    static Expr* makeCase(Expr* expr, Expr* then);
+    static Expr* makeCaseCondition(Expr* expr, Expr* then);
 
-    static Expr* makeCase(Expr* expr, Expr* then, Expr* other);
+    static Expr* joinCaseCondition(Expr* expr, Expr* then);
+
+    static Expr* makeCase(Expr* when);
+
+    static Expr* makeCase(Expr* when, Expr* other);
+
+    static Expr* makeCaseExpr(Expr* expr, Expr* when);
+
+    static Expr* makeCaseExpr(Expr* expr, Expr* when, Expr* other);
 
     static Expr* makeLiteral(int64_t val);
 


### PR DESCRIPTION
Changing Grammar to extend CASE WHEN statement: 
this addresses also #69 

- allow multiple WHEN statements
- allow for syntax like `CASE x WHEN 1 THEN 2 WHEN 3 THEN 4 ELSE 5 END`
NOTE: This changes also the way the CASE operator is stored:
- CASE [expr] exprList [ELSE expr2] END
- exprList holds each of the WHEN statements with:
  expr := WHEN, expr2 := THEN

Added also tests in test/select_tests.cpp
and adapted the existing one to reflect the new storage