### PR TITLE
Allow '==' for operator equals

### DIFF
--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -814,6 +814,7 @@ exists_expr:
 
 comp_expr:
 		operand '=' operand			{ $$ = Expr::makeOpBinary($1, kOpEquals, $3); }
+	|	operand EQUALS operand			{ $$ = Expr::makeOpBinary($1, kOpEquals, $3); }
 	|	operand NOTEQUALS operand	{ $$ = Expr::makeOpBinary($1, kOpNotEquals, $3); }
 	|	operand '<' operand			{ $$ = Expr::makeOpBinary($1, kOpLess, $3); }
 	|	operand '>' operand			{ $$ = Expr::makeOpBinary($1, kOpGreater, $3); }

--- a/src/parser/flex_lexer.l
+++ b/src/parser/flex_lexer.l
@@ -175,7 +175,9 @@ ON			TOKEN(ON)
 OR			TOKEN(OR)
 TO			TOKEN(TO)
 
-"!="		TOKEN(NOTEQUALS)
+                /* Allow =/== see https://sqlite.org/lang_expr.html#collateop */
+"=="		TOKEN(EQUALS)             
+"!=" 		TOKEN(NOTEQUALS)
 "<>" 		TOKEN(NOTEQUALS)
 "<="		TOKEN(LESSEQ)
 ">="		TOKEN(GREATEREQ)

--- a/test/select_tests.cpp
+++ b/test/select_tests.cpp
@@ -347,3 +347,42 @@ TEST(SelectColumnOrder) {
   ASSERT_STREQ(stmt->fromTable->list->at(2)->alias, "c");
   ASSERT_STREQ(stmt->fromTable->list->at(3)->alias, "d");
 }
+
+TEST(Operators) {
+  SelectStatement* stmt;
+  SQLParserResult result;
+
+  SQLParser::parse("SELECT * FROM foo where a =  1; \
+		    SELECT * FROM foo where a == 1; \
+		    SELECT * FROM foo where a != 1; \
+		    SELECT * FROM foo where a <> 1; \
+		    SELECT * FROM foo where a >  1; \
+		    SELECT * FROM foo where a <  1; \
+		    SELECT * FROM foo where a >= 1; \
+		    SELECT * FROM foo where a <= 1;", &result);
+
+  stmt = (SelectStatement*) result.getStatement(0);
+  ASSERT_EQ(stmt->whereClause->opType, kOpEquals);
+
+  stmt = (SelectStatement*) result.getStatement(1);
+  ASSERT_EQ(stmt->whereClause->opType, kOpEquals);
+
+  stmt = (SelectStatement*) result.getStatement(2);
+  ASSERT_EQ(stmt->whereClause->opType, kOpNotEquals);
+
+  stmt = (SelectStatement*) result.getStatement(3);
+  ASSERT_EQ(stmt->whereClause->opType, kOpNotEquals);
+
+  stmt = (SelectStatement*) result.getStatement(4);
+  ASSERT_EQ(stmt->whereClause->opType, kOpGreater);
+
+  stmt = (SelectStatement*) result.getStatement(5);
+  ASSERT_EQ(stmt->whereClause->opType, kOpLess);
+
+  stmt = (SelectStatement*) result.getStatement(6);
+  ASSERT_EQ(stmt->whereClause->opType, kOpGreaterEq);
+
+  stmt = (SelectStatement*) result.getStatement(7);
+  ASSERT_EQ(stmt->whereClause->opType, kOpLessEq);
+}
+


### PR DESCRIPTION
This change allows '==' as operator for test of equality, like sqlite allows.
Although this is not according to the standard, it should be allowed here as sqlite is in widespread use.
See also: https://sqlite.org/lang_expr.html#collateop