### PR TITLE
Add DxL checks

### DIFF
--- a/src/sql/SQLStatement.cpp
+++ b/src/sql/SQLStatement.cpp
@@ -1,4 +1,3 @@
-
 #include "SQLStatement.h"
 
 namespace hsql {
@@ -27,6 +26,41 @@ namespace hsql {
 
   bool SQLStatement::is(StatementType type) const {
     return isType(type);
+  }
+
+  bool SQLStatement::isDataDefinitionStatement() const {
+    switch (type_) {
+      case kStmtImport:
+      case kStmtExport:
+      case kStmtCreate:
+      case kStmtDrop:
+      case kStmtAlter:
+      case kStmtRename:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  bool SQLStatement::isDataManipulationStatement() const {
+    switch (type_) {
+      case kStmtDelete:
+      case kStmtInsert:
+      case kStmtUpdate:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  bool SQLStatement::isDataQueryStatement() const {
+    switch (type_) {
+      case kStmtSelect:
+      case kStmtShow:
+        return true;
+      default:
+        return false;
+    }
   }
 
 }

--- a/src/sql/SQLStatement.h
+++ b/src/sql/SQLStatement.h
@@ -37,6 +37,11 @@ namespace hsql {
     // Shorthand for isType(type).
     bool is(StatementType type) const;
 
+    // Check is statement is DDL, DML or DQL
+    bool isDataDefinitionStatement() const;
+    bool isDataManipulationStatement() const;
+    bool isDataQueryStatement() const;
+
     // Length of the string in the SQL query string
     size_t stringLength;
 

--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -197,19 +197,19 @@ namespace hsql {
 
 
   void printImportStatementInfo(const ImportStatement* stmt, uintmax_t numIndent) {
-    inprint("ImportStatment", numIndent);
+    inprint("ImportStatement", numIndent);
     inprint(stmt->filePath, numIndent + 1);
     inprint(stmt->tableName, numIndent + 1);
   }
 
   void printCreateStatementInfo(const CreateStatement* stmt, uintmax_t numIndent) {
-    inprint("CreateStatment", numIndent);
+    inprint("CreateStatement", numIndent);
     inprint(stmt->tableName, numIndent + 1);
     inprint(stmt->filePath, numIndent + 1);
   }
 
   void printInsertStatementInfo(const InsertStatement* stmt, uintmax_t numIndent) {
-    inprint("InsertStatment", numIndent);
+    inprint("InsertStatement", numIndent);
     inprint(stmt->tableName, numIndent + 1);
     if (stmt->columns != nullptr) {
       inprint("Columns", numIndent + 1);

--- a/test/sql_tests.cpp
+++ b/test/sql_tests.cpp
@@ -224,4 +224,35 @@ TEST(StringLengthTest) {
   ASSERT_EQ(result.getStatement(2)->stringLength, 21);
 }
 
+TEST(StatementTypeTest) {
+  // DQL
+  TEST_PARSE_SQL_QUERY("SELECT * FROM foo", resultSelect, 1);
+  ASSERT_TRUE(resultSelect.getStatement(0)->isDataQueryStatement());
+
+  TEST_PARSE_SQL_QUERY("SHOW TABLES", resultShow, 1);
+  ASSERT_TRUE(resultShow.getStatement(0)->isDataQueryStatement());
+
+  // DDL
+  TEST_PARSE_SQL_QUERY("IMPORT FROM CSV FILE 'foo.csv' INTO foo", resultImport, 1);
+  ASSERT_TRUE(resultImport.getStatement(0)->isDataDefinitionStatement());
+
+  TEST_PARSE_SQL_QUERY("CREATE TABLE foo (bar INT)", resultCreate, 1);
+  ASSERT_TRUE(resultCreate.getStatement(0)->isDataDefinitionStatement());
+
+  TEST_PARSE_SQL_QUERY("DROP TABLE foo", resultDrop, 1);
+  ASSERT_TRUE(resultDrop.getStatement(0)->isDataDefinitionStatement());
+
+  // ALTER, RENAME, EXPORT not supported yet
+
+  // DML
+  TEST_PARSE_SQL_QUERY("INSERT INTO foo VALUES (1)", resultInsert, 1);
+  ASSERT_TRUE(resultInsert.getStatement(0)->isDataManipulationStatement());
+
+  TEST_PARSE_SQL_QUERY("DELETE FROM foo WHERE bar = 1", resultDelete, 1);
+  ASSERT_TRUE(resultDelete.getStatement(0)->isDataManipulationStatement());
+
+  TEST_PARSE_SQL_QUERY("UPDATE foo SET a = 2 WHERE a = 1", resultUpdate, 1);
+  ASSERT_TRUE(resultUpdate.getStatement(0)->isDataManipulationStatement());
+}
+
 TEST_MAIN();


### PR DESCRIPTION
This PR adds simple checks for DataDefinition-, DataManipulation-, and DataQueryStatements. 

This can be used, e.g. in caching, when certain behaviour is needed only for certain types of queries. 