### PR TITLE
Fix multi-threaded parsing

### DIFF
--- a/src/parser/flex_lexer.cpp
+++ b/src/parser/flex_lexer.cpp
@@ -1,6 +1,6 @@
-#line 1 "flex_lexer.cpp"
+#line 2 "flex_lexer.cpp"
 
-#line 3 "flex_lexer.cpp"
+#line 4 "flex_lexer.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1923,9 +1923,9 @@ static const flex_int16_t yy_chk[4142] =
 
 #define TOKEN(name) { return SQL_##name; }
 
-static std::stringstream strbuf;
+static thread_local std::stringstream strbuf;
 
-#line 1928 "flex_lexer.cpp"
+#line 1929 "flex_lexer.cpp"
 
 /***************************
  ** Section 2: Rules
@@ -1939,7 +1939,7 @@ static std::stringstream strbuf;
 /***************************
  ** Section 3: Rules
  ***************************/
-#line 1942 "flex_lexer.cpp"
+#line 1943 "flex_lexer.cpp"
 
 #define INITIAL 0
 #define singlequotedstring 1
@@ -2226,7 +2226,7 @@ YY_DECL
 #line 56 "flex_lexer.l"
 
 
-#line 2229 "flex_lexer.cpp"
+#line 2230 "flex_lexer.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -3045,7 +3045,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case YY_STATE_EOF(singlequotedstring):
 #line 231 "flex_lexer.l"
-{ fprintf(stderr, "unterminated string\n"); return 0; }
+{ fprintf(stderr, "[SQL-Lexer-Error] Unterminated string\n"); return 0; }
 	YY_BREAK
 case 151:
 YY_RULE_SETUP
@@ -3057,7 +3057,7 @@ YY_RULE_SETUP
 #line 236 "flex_lexer.l"
 ECHO;
 	YY_BREAK
-#line 3060 "flex_lexer.cpp"
+#line 3061 "flex_lexer.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(COMMENT):
 	yyterminate();

--- a/src/parser/flex_lexer.h
+++ b/src/parser/flex_lexer.h
@@ -2,9 +2,9 @@
 #define hsql_HEADER_H 1
 #define hsql_IN_HEADER 1
 
-#line 5 "flex_lexer.h"
+#line 6 "flex_lexer.h"
 
-#line 7 "flex_lexer.h"
+#line 8 "flex_lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -733,6 +733,6 @@ extern int yylex \
 #line 236 "flex_lexer.l"
 
 
-#line 736 "flex_lexer.h"
+#line 737 "flex_lexer.h"
 #undef hsql_IN_HEADER
 #endif /* hsql_HEADER_H */

--- a/src/parser/flex_lexer.l
+++ b/src/parser/flex_lexer.l
@@ -17,7 +17,7 @@
 
 #define TOKEN(name) { return SQL_##name; }
 
-static std::stringstream strbuf;
+static thread_local std::stringstream strbuf;
 
 %}
 %x singlequotedstring


### PR DESCRIPTION
This should fix multi-threaded parsing. Not a clean solution, I am guessing the following block should be a single, state-less pattern? @mrks

```
\'                          { BEGIN singlequotedstring; strbuf = std::stringstream{}; }
<singlequotedstring>\'\'    { strbuf << '\''; }
<singlequotedstring>[^']*   { strbuf << yytext; }
<singlequotedstring>\'      { BEGIN 0; yylval->sval = strdup(strbuf.str().c_str()); return SQL_STRING; }
<singlequotedstring><<EOF>> { fprintf(stderr, "[SQL-Lexer-Error] Unterminated string\n"); return 0; }
```

Anyway, the following hyrise playground does not crash anymore, so Toni should be able to work with this for the time being.

```c++
#include <iostream>
#include <thread>

#include "types.hpp"
#include "tpch/tpch_queries.hpp"
#include "SQLParser.h"

using namespace opossum;  // NOLINT

int main() {
  std::vector<std::thread> threads;

  for (size_t t = 0; t < 200; ++t) {
    threads.emplace_back([&]() {
      for (size_t p = 0; p < 10'000; ++p) {
        hsql::SQLParserResult result;
        hsql::SQLParser::parse(tpch_queries.at(19), &result);
        std::cout << "Parsing " << p << " is valid: " << result.isValid() << std::endl;
      }
    });
  }

  for (auto& thread : threads) {
    thread.join();
  }

  return 0;
}
```