### PR TITLE
Sort the input file list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ else
 	LIB_CFLAGS  +=  -fPIC
 	LIB_LFLAGS = -shared -o
 endif
-LIB_CPP    = $(shell find $(SRC) -name '*.cpp' -not -path "$(SRCPARSER)/*") $(PARSER_CPP)
+LIB_CPP    = $(sort $(shell find $(SRC) -name '*.cpp' -not -path "$(SRCPARSER)/*") $(PARSER_CPP))
 LIB_H      = $(shell find $(SRC) -name '*.h' -not -path "$(SRCPARSER)/*") $(PARSER_H)
 LIB_ALL    = $(shell find $(SRC) -name '*.cpp' -not -path "$(SRCPARSER)/*") $(shell find $(SRC) -name '*.h' -not -path "$(SRCPARSER)/*")
 LIB_OBJ    = $(LIB_CPP:%.cpp=%.o)


### PR DESCRIPTION
Sort the input file list
so that `libsqlparser.so.1` builds in a reproducible way
in spite of indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

I tested that the other `find` result orders do not matter. Only .o file order in `LIB_OBJ` matters for the result.

This PR was done while working on reproducible builds for openSUSE.

also filed at https://github.com/envoyproxy/sql-parser/pull/1