### PR TITLE
Use awk to check versions

### DIFF
--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -3,13 +3,13 @@ BISON?=bison
 FLEX?=flex
 
 BISON_VERSION=$(shell $(BISON) --version | head -n 1 | grep -o '[0-9]\.[0-9]\+')
-BISON_VERSION_SUPPORTED=$(shell echo $(BISON_VERSION) \>= 3.0 | bc)
+BISON_VERSION_SUPPORTED=$(shell awk -v a=$(BISON_VERSION) -v b="3.0" 'BEGIN { print (a >= b) ? 1 : 0 }')
 ifneq ($(BISON_VERSION_SUPPORTED), 1)
 $(error Bison version $(BISON_VERSION) not supported. If you are using OS X, `bison` uses the system default instead of the brew version. Run BISON=/usr/local/opt/bison/bin/bison make)
 endif
 
 FLEX_VERSION=$(shell $(FLEX) --version | head -n 1 | grep -o '[0-9]\.[0-9]\+')
-FLEX_VERSION_SUPPORTED=$(shell echo $(FLEX_VERSION) \>= 2.6 | bc)
+FLEX_VERSION_SUPPORTED=$(shell awk -v a=$(FLEX_VERSION) -v b="2.6" 'BEGIN { print (a >= b) ? 1 : 0 }')
 ifneq ($(FLEX_VERSION_SUPPORTED), 1)
 $(error Flex version $(FLEX_VERSION) not supported. If you are using OS X, `flex` uses the system default instead of the brew version. Run FLEX=/usr/local/opt/flex/bin/flex make)
 endif


### PR DESCRIPTION
Some Linux distributions (e.g. Centos) don't have bc installed by
default. And some (e.g Centos 8) don't have binary packages for it
available either. It's safer to use awk instead of bc to check
versions of bison and flex in the parser Makefile.

Closes #144