### PR TITLE
Fix compiler version requirements in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In March 2015 we've also written a short paper outlining discussing some develop
 **Note:** You can also find a detailed usage description at this [blog post](http://torpedro.github.io/tech/c++/sql/parser/2016/02/27/c++-sql-parser.html).
 
 **Requirements:**
- * gcc 4.8+ (or clang 3.4+)
+ * gcc 5+ (or clang 5+)
 
 To use the SQL parser in your own projects you simply have to follow these few steps. The only requirement for is gcc 4.8+. Older versions of gcc/clang might also work, but are untested.
 


### PR DESCRIPTION
c++17 is required to build the project. The minimum versions of gcc
and clang that support c++17 are 5 (for both compilers).

Closes #148