### PR TITLE
Fix segfault on printing cast/extract exprs

### DIFF
--- a/src/sql/Expr.cpp
+++ b/src/sql/Expr.cpp
@@ -218,7 +218,7 @@ Expr* Expr::makeInOperator(Expr* expr, SelectStatement* select) {
 }
 
 Expr* Expr::makeExtract(DatetimeField datetimeField, Expr* expr) {
-    Expr* e = new Expr(kExprFunctionRef);
+    Expr* e = new Expr(kExprExtract);
     e->name = strdup("EXTRACT");
     e->datetimeField = datetimeField;
     e->expr = expr;
@@ -226,7 +226,7 @@ Expr* Expr::makeExtract(DatetimeField datetimeField, Expr* expr) {
 }
 
 Expr* Expr::makeCast(Expr* expr, ColumnType columnType) {
-    Expr* e = new Expr(kExprFunctionRef);
+    Expr* e = new Expr(kExprCast);
     e->name = strdup("CAST");
     e->columnType = columnType;
     e->expr = expr;

--- a/src/sql/Expr.h
+++ b/src/sql/Expr.h
@@ -27,7 +27,8 @@ enum ExprType {
     kExprHint,
     kExprArray,
     kExprArrayIndex,
-    kExprDatetimeField
+    kExprExtract,
+    kExprCast    
 };
 
 // Operator types. These are important for expressions of type kExprOperator.

--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -10,6 +10,7 @@ namespace hsql {
   void printAlias(Alias* alias, uintmax_t numIndent);
 
   std::ostream& operator<<(std::ostream& os, const OperatorType& op);
+  std::ostream& operator<<(std::ostream& os, const DatetimeField& op);
 
   std::string indent(uintmax_t numIndent) {
     return std::string(numIndent, '\t');
@@ -31,6 +32,12 @@ namespace hsql {
   }
   void inprint(const OperatorType& op, uintmax_t numIndent) {
     std::cout << indent(numIndent) << op << std::endl;
+  }
+  void inprint(const ColumnType& colType, uintmax_t numIndent) {
+    std::cout << indent(numIndent) << colType << std::endl;
+  }
+  void inprint(const DatetimeField& colType, uintmax_t numIndent) {
+    std::cout << indent(numIndent) << colType << std::endl;
   }
 
   void printTableRefInfo(TableRef* table, uintmax_t numIndent) {
@@ -117,6 +124,16 @@ namespace hsql {
     case kExprFunctionRef:
       inprint(expr->name, numIndent);
       for (Expr* e : *expr->exprList) printExpression(e, numIndent + 1);
+      break;
+    case kExprExtract:
+      inprint(expr->name, numIndent);
+      inprint(expr->datetimeField, numIndent + 1);
+      printExpression(expr->expr, numIndent + 1);
+      break;
+    case kExprCast:
+      inprint(expr->name, numIndent);
+      inprint(expr->columnType, numIndent + 1);
+      printExpression(expr->expr, numIndent + 1);
       break;
     case kExprOperator:
       printOperatorExpression(expr, numIndent);
@@ -367,6 +384,25 @@ namespace hsql {
     const auto found = operatorToToken.find(op);
     if (found == operatorToToken.cend()) {
       return os << static_cast<uint64_t>(op);
+    } else {
+      return os << (*found).second;
+    }
+  }
+
+  std::ostream& operator<<(std::ostream& os, const DatetimeField& datetime) {
+    static const std::map<const DatetimeField, const std::string> operatorToToken = {
+      {kDatetimeNone, "None"},
+      {kDatetimeSecond, "SECOND"},
+      {kDatetimeMinute, "MINUTE"},
+      {kDatetimeHour, "HOUR"},
+      {kDatetimeDay, "DAY"},
+      {kDatetimeMonth, "MONTH"},
+      {kDatetimeYear, "YEAR"}
+    };
+
+    const auto found = operatorToToken.find(datetime);
+    if (found == operatorToToken.cend()) {
+      return os << static_cast<uint64_t>(datetime);
     } else {
       return os << (*found).second;
     }

--- a/test/select_tests.cpp
+++ b/test/select_tests.cpp
@@ -638,7 +638,7 @@ TEST(Extract) {
   stmt = (SelectStatement*) result.getStatement(0);
   ASSERT_TRUE(stmt->selectList);
   ASSERT_EQ(stmt->selectList->size(), 1u);
-  ASSERT_EQ(stmt->selectList->at(0)->type, kExprFunctionRef);
+  ASSERT_EQ(stmt->selectList->at(0)->type, kExprExtract);
   ASSERT_EQ(stmt->selectList->at(0)->name, std::string("EXTRACT"));
   ASSERT_EQ(stmt->selectList->at(0)->datetimeField, kDatetimeYear);
   ASSERT_TRUE(stmt->selectList->at(0)->expr);
@@ -647,7 +647,7 @@ TEST(Extract) {
   stmt = (SelectStatement*) result.getStatement(1);
   ASSERT_TRUE(stmt->selectList);
   ASSERT_EQ(stmt->selectList->size(), 2u);
-  ASSERT_EQ(stmt->selectList->at(1)->type, kExprFunctionRef);
+  ASSERT_EQ(stmt->selectList->at(1)->type, kExprExtract);
   ASSERT_EQ(stmt->selectList->at(1)->name, std::string("EXTRACT"));
   ASSERT_EQ(stmt->selectList->at(1)->datetimeField, kDatetimeMonth);
   ASSERT_TRUE(stmt->selectList->at(1)->expr);
@@ -658,9 +658,29 @@ TEST(Extract) {
   stmt = (SelectStatement*) result.getStatement(2);
   ASSERT_TRUE(stmt->whereClause);
   ASSERT_TRUE(stmt->whereClause->expr);
-  ASSERT_EQ(stmt->whereClause->expr->type, kExprFunctionRef);
+  ASSERT_EQ(stmt->whereClause->expr->type, kExprExtract);
   ASSERT_EQ(stmt->whereClause->expr->name, std::string("EXTRACT"));
   ASSERT_EQ(stmt->whereClause->expr->datetimeField, kDatetimeMinute);
+}
+
+TEST(CastExpression) {
+  TEST_PARSE_SINGLE_SQL(
+    "SELECT CAST(10 AS INT);",
+    kStmtSelect,
+    SelectStatement,
+    result,
+    stmt);
+
+  ASSERT_TRUE(stmt->selectList);
+  ASSERT_FALSE(stmt->fromTable);
+  ASSERT_FALSE(stmt->whereClause);
+  ASSERT_FALSE(stmt->groupBy);
+
+  ASSERT_EQ(stmt->selectList->size(), 1u);
+  ASSERT_EQ(stmt->selectList->at(0)->type, kExprCast);
+  ASSERT_EQ(stmt->selectList->at(0)->name, std::string("CAST"));
+  ASSERT_EQ(stmt->selectList->at(0)->columnType, ColumnType(DataType::INT));
+  ASSERT_EQ(stmt->selectList->at(0)->expr->type, kExprLiteralInt);
 }
 
 TEST(NoFromClause) {


### PR DESCRIPTION
Previously, printing a cast/extract expression caused a segfault as the logic for `kExprFunctionRef` prints the `exprList` field which is not set for those types. Fixed this by adding customized printing logic for those expression types.