### PR TITLE
Fixing print ORDER BY bug: only first sort column was printed.

### DIFF
--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -161,6 +161,19 @@ namespace hsql {
     }
   }
 
+  void printOrderBy(const std::vector<OrderDescription*>* expr, uintmax_t numIndent) {
+    if (!expr) return;
+    for (const auto& order_description : *expr) {
+      printExpression(order_description->expr, numIndent);
+      if (order_description->type == kOrderAsc) {
+          inprint("ascending", numIndent);
+      }
+      else {
+          inprint("descending", numIndent);
+      }
+    }
+  }
+
   void printSelectStatementInfo(const SelectStatement* stmt, uintmax_t numIndent) {
     inprint("SelectStatement", numIndent);
     inprint("Fields:", numIndent + 1);
@@ -203,9 +216,7 @@ namespace hsql {
 
         if (setOperation->resultOrder != nullptr) {
           inprint("SetResultOrderBy:", numIndent + 1);
-          printExpression(setOperation->resultOrder->at(0)->expr, numIndent + 2);
-          if (setOperation->resultOrder->at(0)->type == kOrderAsc) inprint("ascending", numIndent + 2);
-          else inprint("descending", numIndent + 2);
+          printOrderBy(setOperation->resultOrder, numIndent + 2);
         }
 
         if (setOperation->resultLimit != nullptr) {
@@ -224,15 +235,7 @@ namespace hsql {
 
     if (stmt->order != nullptr) {
       inprint("OrderBy:", numIndent + 1);
-      for (size_t idx = 0; idx < stmt->order->size(); idx++) {
-          printExpression(stmt->order->at(idx)->expr, numIndent + 2);
-          if (stmt->order->at(idx)->type == kOrderAsc) {
-              inprint("ascending", numIndent + 2);
-          }
-          else {
-              inprint("descending", numIndent + 2);
-          }
-      }
+      printOrderBy(stmt->order, numIndent + 2);
     }
 
     if (stmt->limit != nullptr && stmt->limit->limit != nullptr) {

--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -224,9 +224,15 @@ namespace hsql {
 
     if (stmt->order != nullptr) {
       inprint("OrderBy:", numIndent + 1);
-      printExpression(stmt->order->at(0)->expr, numIndent + 2);
-      if (stmt->order->at(0)->type == kOrderAsc) inprint("ascending", numIndent + 2);
-      else inprint("descending", numIndent + 2);
+      for (size_t idx = 0; idx < stmt->order->size(); idx++) {
+          printExpression(stmt->order->at(idx)->expr, numIndent + 2);
+          if (stmt->order->at(idx)->type == kOrderAsc) {
+              inprint("ascending", numIndent + 2);
+          }
+          else {
+              inprint("descending", numIndent + 2);
+          }
+      }
     }
 
     if (stmt->limit != nullptr && stmt->limit->limit != nullptr) {

--- a/src/util/sqlhelper.h
+++ b/src/util/sqlhelper.h
@@ -24,10 +24,13 @@ namespace hsql {
   void printCreateStatementInfo(const CreateStatement* stmt, uintmax_t num_indent);
 
   // Prints a summary of the given TransactionStatement with the given indentation.
-  void printTransactionStatementInfo(const TransactionStatement* stmt, uintmax_t numIndent);
+  void printTransactionStatementInfo(const TransactionStatement* stmt, uintmax_t num_indent);
 
   // Prints a summary of the given Expression with the given indentation.
   void printExpression(Expr* expr, uintmax_t num_indent);
+
+  // Prints an ORDER BY clause
+  void printOrderBy(const std::vector<OrderDescription*>* expr, uintmax_t num_indent);
 
 } // namespace hsql
 


### PR DESCRIPTION
Issue is in sqlhelper.cpp, method printSelectStatementInfo.

