### PR TITLE
Update Travis CI batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 C++ SQL Parser
 =========================
-[![Build Status](https://img.shields.io/travis/hyrise/sql-parser/master.svg?maxAge=2592000)](https://travis-ci.org/hyrise/sql-parser)
+[![Build Status](https://app.travis-ci.com/hyrise/sql-parser.svg?branch=master)](https://app.travis-ci.com/github/hyrise/sql-parser)
 
 
 This is a SQL Parser for C++. It parses the given SQL query into C++ objects.


### PR DESCRIPTION
Update the batch. It currently directs to travis-ci.org, which is no longer the active Travis site, and the redirect does not work.