### PR TITLE
Fix the `'dynamic_cast' not permitted with '-fno-rtti'` error when integrated with LLVM/MLIR.

### DIFF
--- a/src/sql/CreateStatement.cpp
+++ b/src/sql/CreateStatement.cpp
@@ -1,0 +1,19 @@
+
+#include "CreateStatement.h"
+
+namespace hsql {
+
+void CreateStatement::setColumnDefsAndConstraints(std::vector<TableElement*>* tableElements) {
+  columns = new std::vector<ColumnDefinition*>();
+  tableConstraints = new std::vector<TableConstraint*>();
+
+  for (auto tableElem : *tableElements) {
+    if (auto* colDef = dynamic_cast<ColumnDefinition*>(tableElem)) {
+      columns->emplace_back(colDef);
+    } else if (auto* tableConstraint = dynamic_cast<TableConstraint*>(tableElem)) {
+      tableConstraints->emplace_back(tableConstraint);
+    }
+  }
+}
+
+}  // namespace hsql

--- a/src/sql/CreateStatement.cpp
+++ b/src/sql/CreateStatement.cpp
@@ -1,4 +1,3 @@
-
 #include "SelectStatement.h"
 #include "CreateStatement.h"
 

--- a/src/sql/CreateStatement.cpp
+++ b/src/sql/CreateStatement.cpp
@@ -1,7 +1,59 @@
 
+#include "SelectStatement.h"
 #include "CreateStatement.h"
 
 namespace hsql {
+
+// CreateStatemnet
+CreateStatement::CreateStatement(CreateType type)
+    : SQLStatement(kStmtCreate),
+      type(type),
+      ifNotExists(false),
+      filePath(nullptr),
+      schema(nullptr),
+      tableName(nullptr),
+      indexName(nullptr),
+      indexColumns(nullptr),
+      columns(nullptr),
+      tableConstraints(nullptr),
+      viewColumns(nullptr),
+      select(nullptr){};
+
+CreateStatement::~CreateStatement() {
+  free(filePath);
+  free(schema);
+  free(tableName);
+  free(indexName);
+  delete select;
+
+  if (columns != nullptr) {
+    for (ColumnDefinition* def : *columns) {
+      delete def;
+    }
+    delete columns;
+  }
+
+  if (tableConstraints != nullptr) {
+    for (TableConstraint* def : *tableConstraints) {
+      delete def;
+    }
+    delete tableConstraints;
+  }
+
+  if (indexColumns != nullptr) {
+    for (char* column : *indexColumns) {
+      free(column);
+    }
+    delete indexColumns;
+  }
+
+  if (viewColumns != nullptr) {
+    for (char* column : *viewColumns) {
+      free(column);
+    }
+    delete viewColumns;
+  }
+}
 
 void CreateStatement::setColumnDefsAndConstraints(std::vector<TableElement*>* tableElements) {
   columns = new std::vector<ColumnDefinition*>();

--- a/src/sql/CreateStatement.h
+++ b/src/sql/CreateStatement.h
@@ -43,7 +43,7 @@ struct ColumnDefinition : TableElement {
       }
       nullable = false;
     }
-    
+
     return true;
   }
 
@@ -66,18 +66,7 @@ struct CreateStatement : SQLStatement {
   CreateStatement(CreateType type);
   ~CreateStatement() override;
 
-  void setColumnDefsAndConstraints(std::vector<TableElement*>* tableElements) {
-    columns = new std::vector<ColumnDefinition*>();
-    tableConstraints = new std::vector<TableConstraint*>();
-
-    for (auto tableElem : *tableElements) {
-      if (auto* colDef = dynamic_cast<ColumnDefinition*>(tableElem)) {
-        columns->emplace_back(colDef);
-      } else if (auto* tableConstraint = dynamic_cast<TableConstraint*>(tableElem)) {
-        tableConstraints->emplace_back(tableConstraint);
-      }
-    }
-  }
+  void setColumnDefsAndConstraints(std::vector<TableElement*>* tableElements);
 
   CreateType type;
   bool ifNotExists;                                 // default: false

--- a/src/sql/statements.cpp
+++ b/src/sql/statements.cpp
@@ -138,19 +138,6 @@ CreateStatement::~CreateStatement() {
   }
 }
 
-void CreateStatement::setColumnDefsAndConstraints(std::vector<TableElement*>* tableElements) {
-  columns = new std::vector<ColumnDefinition*>();
-  tableConstraints = new std::vector<TableConstraint*>();
-
-  for (auto tableElem : *tableElements) {
-    if (auto* colDef = dynamic_cast<ColumnDefinition*>(tableElem)) {
-      columns->emplace_back(colDef);
-    } else if (auto* tableConstraint = dynamic_cast<TableConstraint*>(tableElem)) {
-      tableConstraints->emplace_back(tableConstraint);
-    }
-  }
-}
-
 // DeleteStatement
 DeleteStatement::DeleteStatement() : SQLStatement(kStmtDelete), schema(nullptr), tableName(nullptr), expr(nullptr){};
 

--- a/src/sql/statements.cpp
+++ b/src/sql/statements.cpp
@@ -87,57 +87,6 @@ std::ostream& operator<<(std::ostream& stream, const ColumnType& column_type) {
   return stream;
 }
 
-// CreateStatemnet
-CreateStatement::CreateStatement(CreateType type)
-    : SQLStatement(kStmtCreate),
-      type(type),
-      ifNotExists(false),
-      filePath(nullptr),
-      schema(nullptr),
-      tableName(nullptr),
-      indexName(nullptr),
-      indexColumns(nullptr),
-      columns(nullptr),
-      tableConstraints(nullptr),
-      viewColumns(nullptr),
-      select(nullptr){};
-
-CreateStatement::~CreateStatement() {
-  free(filePath);
-  free(schema);
-  free(tableName);
-  free(indexName);
-  delete select;
-
-  if (columns != nullptr) {
-    for (ColumnDefinition* def : *columns) {
-      delete def;
-    }
-    delete columns;
-  }
-
-  if (tableConstraints != nullptr) {
-    for (TableConstraint* def : *tableConstraints) {
-      delete def;
-    }
-    delete tableConstraints;
-  }
-
-  if (indexColumns != nullptr) {
-    for (char* column : *indexColumns) {
-      free(column);
-    }
-    delete indexColumns;
-  }
-
-  if (viewColumns != nullptr) {
-    for (char* column : *viewColumns) {
-      free(column);
-    }
-    delete viewColumns;
-  }
-}
-
 // DeleteStatement
 DeleteStatement::DeleteStatement() : SQLStatement(kStmtDelete), schema(nullptr), tableName(nullptr), expr(nullptr){};
 

--- a/src/sql/statements.cpp
+++ b/src/sql/statements.cpp
@@ -138,6 +138,19 @@ CreateStatement::~CreateStatement() {
   }
 }
 
+void CreateStatement::setColumnDefsAndConstraints(std::vector<TableElement*>* tableElements) {
+  columns = new std::vector<ColumnDefinition*>();
+  tableConstraints = new std::vector<TableConstraint*>();
+
+  for (auto tableElem : *tableElements) {
+    if (auto* colDef = dynamic_cast<ColumnDefinition*>(tableElem)) {
+      columns->emplace_back(colDef);
+    } else if (auto* tableConstraint = dynamic_cast<TableConstraint*>(tableElem)) {
+      tableConstraints->emplace_back(tableConstraint);
+    }
+  }
+}
+
 // DeleteStatement
 DeleteStatement::DeleteStatement() : SQLStatement(kStmtDelete), schema(nullptr), tableName(nullptr), expr(nullptr){};
 


### PR DESCRIPTION
A compile error occurs when including the `"SQLParser.h"` in another project. (sql_parser as third-party)

```
/thirdparty/sql-parser/src/sql/CreateStatement.h:74:67: error: 'dynamic_cast' not permitted with '-fno-rtti'
   74 | ynamic_cast<ColumnDefinition*>(tableElem)) {
      |                                         ^

/thirdparty/sql-parser/src/sql/CreateStatement.h:76:82: error: 'dynamic_cast' not permitted with '-fno-rtti'
   76 | dynamic_cast<TableConstraint*>(tableElem)) {
      |                                         ^
```

Separate the declaration and definition of the `setColumnDefsAndConstraints` should fix this.
