### PR TITLE
Add description for quickly running/testing custom SQL statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ To use the SQL parser in your own projects you simply have to follow these few s
     }
 }
 ```
+  7. The corresponding `example` executable can be used to test/parse specific custom SQL statements:
+     
+     Running, for example, `./example/example "SELECT * FROM test;"` produces:
+```
+Parsed successfully!
+Number of statements: 1
+SelectStatement
+	Fields:
+		*
+	Sources:
+		test
+```     
 
 Quick Links:
 


### PR DESCRIPTION
The possibility for quickly running/testing SQL statements with the parser is not documented in the README.

Some issues, such as #243, could, for example, described and tested with the command line executable `./example/example`.

This pull request documents this feature.