### PR TITLE
Fix CI build for Ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'
-          git clone https://github.com/hyrise/sql-parser .
+          git clone "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" .
           echo "checkout ${GITHUB_HEAD_REF}"
           git checkout $GITHUB_HEAD_REF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        if: matrix.name != 'gcc-6'
+
+      - name: Checkout (Ubuntu 18.04)
+        if: matrix.name == 'gcc-6'
+        run: |
+          apt-get update
+          apt-get install -y git
+          git config --global --add safe.directory '*'
+          git clone https://github.com/hyrise/sql-parser .
+          git checkout $GITHUB_HEAD_REF
 
       - name: Setup (macOS)
         if: matrix.name == 'clang-macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           apt-get install -y git
           git config --global --add safe.directory '*'
           git clone https://github.com/hyrise/sql-parser .
+          echo "checkout ${GITHUB_HEAD_REF}"
           git checkout $GITHUB_HEAD_REF
 
       - name: Setup (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             os: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup (macOS)
         if: matrix.name == 'clang-macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
           apt-get install -y git
           git config --global --add safe.directory '*'
           git clone "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" .
-          echo "checkout ${GITHUB_HEAD_REF}"
           git checkout $GITHUB_HEAD_REF
 
       - name: Setup (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,14 @@ jobs:
             os: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         if: matrix.name != 'gcc-6'
 
       - name: Checkout (Ubuntu 18.04)
         if: matrix.name == 'gcc-6'
+        # Recent versions of Github's checkout action do not run on older Ubuntu versions because they use a too recent
+        # Node.js version. Thus, we have to checkout the code manually.
         run: |
           apt-get update
           apt-get install -y git


### PR DESCRIPTION
In #245, we noticed that the Github checkout action now uses a Node.js version that is incompatible with our gcc-6/Ubuntu-18.04 stage. Thus, we pull the code manually for this stage.