### PR TITLE
Fix Cloning in CI for Forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.event.repository.pull_request}}"
+          echo "${{github.event.pull_request}}"
           echo "${{github.repository_owner}}/${{github.repository}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.event.repository}}"
+          echo "${{github.event.repository.full_name}}"
           echo "${{github.repository_owner}}/${{github.repository}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,10 @@ jobs:
         # Node.js version. Thus, we have to checkout the code manually.
         run: |
           echo "${GITHUB_REPOSITORY_OWNER}"
+          echo "${GITHUB_REPOSITORY}"
           echo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}:${GITHUB_HEAD_REF}"
           echo "${GITHUB_REF}"
+          echo "${GITHUB_REF_NAME}"
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,18 +56,12 @@ jobs:
         # Recent versions of Github's checkout action do not run on older Ubuntu versions because they use a too recent
         # Node.js version. Thus, we have to checkout the code manually.
         run: |
-          echo "${GITHUB_REPOSITORY_OWNER}"
-          echo "${GITHUB_REPOSITORY}"
-          echo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}:${GITHUB_HEAD_REF}"
-          echo "${GITHUB_REF}"
-          echo "${GITHUB_REF_NAME}"
-          echo "${{github.repositoryUrl}}"
-          echo "${{github.event.pull_request.head.repo.clone_url}}"
-          echo "${{github.repository_owner}}/${{github.repository}}"
+          echo "REPO_URL=$(awk -v a=${github.event.pull_request.head.repo.clone_url} -v b=${github.repositoryUrl} 'BEGIN { if (a == "")  { print b } else { print a } }')" >> $GITHUB_ENV
+          echo $REPO_URL
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'
-          git clone "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" .
+          git clone "${REPO_URL}" .
           git checkout $GITHUB_HEAD_REF
 
       - name: Setup (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,11 @@ jobs:
         # Recent versions of Github's checkout action do not run on older Ubuntu versions because they use a too recent
         # Node.js version. Thus, we have to checkout the code manually.
         run: |
-          echo "REPO_URL=$(awk -v a=${github.event.pull_request.head.repo.clone_url} -v b=${github.repositoryUrl} 'BEGIN { if (a == "")  { print b } else { print a } }')" >> $GITHUB_ENV
-          echo $GITHUB_ENV
-          echo $REPO_URL
+          echo $(awk -v a=${{github.event.pull_request.head.repo.clone_url}} -v b=${{github.repositoryUrl}} 'BEGIN { if (a == "")  { print b } else { print a } }')
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'
-          git clone "${REPO_URL}" .
+          git clone $(awk -v a=${{github.event.pull_request.head.repo.clone_url}} -v b=${{github.repositoryUrl}} 'BEGIN { if (a == "")  { print b } else { print a } }') .
           git checkout $GITHUB_HEAD_REF
 
       - name: Setup (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.event.head}}"
+          echo "${{github.event.head.repo.clone_url}}"
           echo "${{github.repository_owner}}/${{github.repository}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'
-          git clone $(awk -v a=${{github.event.pull_request.head.repo.clone_url}} -v b=${{github.repositoryUrl}} 'BEGIN { if (a == "")  { print b } else { print a } }') .
+          git clone $(awk -v a=${{github.event.pull_request.head.repo.clone_url}} -v b="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" 'BEGIN { if (a == "")  { print b } else { print a } }') .
           git checkout $GITHUB_HEAD_REF
 
       - name: Setup (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repository}}"
+          echo "${{github.context.repo.owner}}/${{github.context.repo.repo}}"
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
+          echo "${{github.workspace}}""
           echo "${{github.context.repo.owner}}/${{github.context.repo.repo}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.event.pull_request.head}}"
+          echo "${{github.event.pull_request.head.repo.clone_url}}"
           echo "${{github.repository_owner}}/${{github.repository}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.workspace}}"
-          echo "${{github.context.repo.owner}}/${{github.context.repo.repo}}"
+          echo "${{github.head_ref}}"
+          echo "${{github.repository_owner}}/${{github.repository}}"
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           echo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}:${GITHUB_HEAD_REF}"
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
-          echo "${{github.repository}}"
+          echo "${{github.repositoryUrl}}"
           echo "${{github.context.repo.owner}}/${{github.context.repo.repo}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,12 @@ jobs:
         # Recent versions of Github's checkout action do not run on older Ubuntu versions because they use a too recent
         # Node.js version. Thus, we have to checkout the code manually.
         run: |
+          echo "${GITHUB_REPOSITORY_OWNER}"
+          echo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}:${GITHUB_HEAD_REF}"
+          echo "${GITHUB_REF}"
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'
-          echo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}:${GITHUB_HEAD_REF}"
           git clone "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" .
           git checkout $GITHUB_HEAD_REF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         # Node.js version. Thus, we have to checkout the code manually.
         run: |
           echo "REPO_URL=$(awk -v a=${github.event.pull_request.head.repo.clone_url} -v b=${github.repositoryUrl} 'BEGIN { if (a == "")  { print b } else { print a } }')" >> $GITHUB_ENV
+          echo $GITHUB_ENV
           echo $REPO_URL
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
         # Recent versions of Github's checkout action do not run on older Ubuntu versions because they use a too recent
         # Node.js version. Thus, we have to checkout the code manually.
         run: |
-          echo $(awk -v a=${{github.event.pull_request.head.repo.clone_url}} -v b=${{github.repositoryUrl}} 'BEGIN { if (a == "")  { print b } else { print a } }')
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.workspace}}""
+          echo "${{github.workspace}}"
           echo "${{github.context.repo.owner}}/${{github.context.repo.repo}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
         if: matrix.name == 'gcc-6'
         # Recent versions of Github's checkout action do not run on older Ubuntu versions because they use a too recent
         # Node.js version. Thus, we have to checkout the code manually.
+        # Doing so is a bit tricky when it comes to PRs from forks (see #249 for details). The general idea here is that
+        # we access Github's context information for the event triggering the action's execution and use some details on
+        # the PR's HEAD if given. Otherwise (for executions due to master updates), we still use the provided
+        # environment variables.
         run: |
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.head_ref}}"
+          echo "${{github.event}}"
           echo "${{github.repository_owner}}/${{github.repository}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.event.repository.full_name}}"
+          echo "${{github.event.repository.pull_request}}"
           echo "${{github.repository_owner}}/${{github.repository}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.event.pull_request}}"
+          echo "${{github.event.pull_request.head}}"
           echo "${{github.repository_owner}}/${{github.repository}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           echo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}:${GITHUB_HEAD_REF}"
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
+          echo "${{github.repository}}"
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           apt-get update
           apt-get install -y git
           git config --global --add safe.directory '*'
+          echo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}:${GITHUB_HEAD_REF}"
           git clone "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" .
           git checkout $GITHUB_HEAD_REF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.event}}"
+          echo "${{github.event.head}}"
           echo "${{github.repository_owner}}/${{github.repository}}"
           apt-get update
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${GITHUB_REF}"
           echo "${GITHUB_REF_NAME}"
           echo "${{github.repositoryUrl}}"
-          echo "${{github.event.head.repo.clone_url}}"
+          echo "${{github.event.repository}}"
           echo "${{github.repository_owner}}/${{github.repository}}"
           apt-get update
           apt-get install -y git


### PR DESCRIPTION
In #248, we noticed that manually retrieving the code in the gcc-6 action stage does not work for PRs from forks. This PR fixes this issue.

The problem is that in general, the repo referenced by GitHub's contexts and environment variables is the (target) repo where the PR is issued. For PRs from forks, this is still our base repo and not the fork. However, we can access a clone's URL from the HEAD information if the event triggering the action is a PR (update).

Still, we keep a version that checks out the main branch if the action is triggered by a branch update because we still want to run the CI workflow for updates on our master branch.

Some helpful documentation:
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context