### PR TITLE
Add PostgreSQL $N and SQLite :name placeholder syntaxes (#263)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,12 @@ $(LIB_BUILD): $(LIB_OBJ)
 	$(LIBLINKER) $(LIB_LFLAGS) $(LIB_BUILD) $(LIB_OBJ)
 
 # The auto-generated code from bison and flex contains some parts the compiler complains about with -Wall.
+# bison_parser.cpp #includes flex_lexer.h, so bison_parser.o must wait for flex_lexer.cpp regeneration
+# to finish (which also produces flex_lexer.h). Without this dep, parallel make races and bison_parser.o
+# can start before hsql_lex is declared, producing 'hsql_lex was not declared' errors.
 $(SRCPARSER)/flex_lexer.o: $(SRCPARSER)/flex_lexer.cpp $(SRCPARSER)/bison_parser.cpp
 	$(CXX) $(LIB_CFLAGS) -c -o $@ $< -Wno-sign-compare -Wno-unneeded-internal-declaration -Wno-register
-$(SRCPARSER)/bison_parser.o: $(SRCPARSER)/bison_parser.cpp
+$(SRCPARSER)/bison_parser.o: $(SRCPARSER)/bison_parser.cpp $(SRCPARSER)/flex_lexer.cpp
 	$(CXX) $(LIB_CFLAGS) -c -o $@ $< -Wno-unused-but-set-variable
 
 %.o: %.cpp $(PARSER_CPP) $(LIB_H)

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,9 @@ $(LIB_BUILD): $(LIB_OBJ)
 # to finish (which also produces flex_lexer.h). Without this dep, parallel make races and bison_parser.o
 # can start before hsql_lex is declared, producing 'hsql_lex was not declared' errors.
 $(SRCPARSER)/flex_lexer.o: $(SRCPARSER)/flex_lexer.cpp $(SRCPARSER)/bison_parser.cpp
-	$(CXX) $(LIB_CFLAGS) -c -o $@ $< -Wno-sign-compare -Wno-unneeded-internal-declaration -Wno-register
+	$(CXX) $(LIB_CFLAGS) -c -o $@ $< -Wno-sign-compare -Wno-register
 $(SRCPARSER)/bison_parser.o: $(SRCPARSER)/bison_parser.cpp $(SRCPARSER)/flex_lexer.cpp
-	$(CXX) $(LIB_CFLAGS) -c -o $@ $< -Wno-unused-but-set-variable
+	$(CXX) $(LIB_CFLAGS) -c -o $@ $<
 
 %.o: %.cpp $(PARSER_CPP) $(LIB_H)
 	$(CXX) $(LIB_CFLAGS) -c -o $@ $<

--- a/src/SQLParser.cpp
+++ b/src/SQLParser.cpp
@@ -54,14 +54,19 @@ bool SQLParser::tokenize(const std::string& sql, std::vector<int16_t>* tokens) {
   YYSTYPE yylval;
   YYLTYPE yylloc;
 
-  // Step through the string until EOF is read.
-  // Note: hsql_lex returns int, but we know that its range is within 16 bit.
-  int16_t token = hsql_lex(&yylval, &yylloc, scanner);
-  while (token != 0) {
+  // Step through the string until EOF is read. Each lex pass that returns
+  // an sval-bearing token (SQL_IDENTIFIER, SQL_STRING, SQL_NAMED_PARAM)
+  // allocates yylval.sval via strdup / hsql::substr; free it before the
+  // next lex call overwrites yylval. The previous loop shape lexed twice
+  // before freeing, which leaked the first sval-bearing token and missed
+  // SQL_NAMED_PARAM entirely. The set mirrors bison's `%destructor
+  // { free($$); } <sval>` for the same tokens.
+  // Note: hsql_lex returns int, but we know its range is within 16 bit.
+  while (true) {
+    int16_t token = hsql_lex(&yylval, &yylloc, scanner);
+    if (token == 0) break;
     tokens->push_back(token);
-    token = hsql_lex(&yylval, &yylloc, scanner);
-
-    if (token == SQL_IDENTIFIER || token == SQL_STRING) {
+    if (token == SQL_IDENTIFIER || token == SQL_STRING || token == SQL_NAMED_PARAM) {
       free(yylval.sval);
     }
   }

--- a/src/parser/bison_parser.cpp
+++ b/src/parser/bison_parser.cpp
@@ -63,6 +63,14 @@
 /* Pull parsers.  */
 #define YYPULL 1
 
+/* "%code top" blocks.  */
+#line 48 "bison_parser.y"
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+
+#line 74 "bison_parser.cpp"
 /* Substitute the type names.  */
 #define YYSTYPE         HSQL_STYPE
 #define YYLTYPE         HSQL_LTYPE
@@ -105,7 +113,7 @@
   }
   // clang-format off
 
-#line 109 "bison_parser.cpp"
+#line 117 "bison_parser.cpp"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -876,42 +884,42 @@ static const yytype_uint8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   362,   362,   382,   388,   395,   399,   403,   404,   405,
-     407,   408,   409,   410,   411,   412,   413,   414,   415,   416,
-     422,   423,   425,   429,   434,   438,   448,   449,   450,   452,
-     452,   458,   464,   466,   470,   482,   488,   505,   520,   522,
-     523,   524,   526,   540,   544,   554,   558,   582,   590,   603,
-     610,   625,   645,   646,   651,   662,   675,   687,   694,   701,
-     710,   711,   713,   717,   722,   723,   725,   733,   734,   735,
-     736,   737,   738,   739,   743,   744,   745,   746,   747,   748,
-     749,   750,   751,   752,   753,   755,   756,   758,   759,   760,
-     762,   763,   765,   769,   773,   778,   786,   787,   788,   789,
-     791,   792,   793,   795,   803,   809,   815,   821,   827,   828,
-     835,   841,   843,   853,   860,   871,   878,   886,   887,   894,
-     901,   905,   910,   920,   924,   928,   940,   940,   942,   943,
-     952,   953,   955,   969,   981,   986,   990,   994,   999,  1000,
-    1002,  1012,  1013,  1015,  1017,  1018,  1020,  1022,  1023,  1025,
-    1030,  1032,  1033,  1035,  1036,  1038,  1042,  1047,  1049,  1050,
-    1051,  1053,  1054,  1076,  1077,  1079,  1080,  1081,  1082,  1083,
-    1084,  1089,  1093,  1099,  1100,  1102,  1106,  1111,  1111,  1115,
-    1116,  1117,  1119,  1128,  1128,  1128,  1128,  1128,  1130,  1131,
-    1131,  1131,  1131,  1131,  1131,  1131,  1131,  1132,  1132,  1136,
-    1136,  1138,  1139,  1140,  1141,  1142,  1144,  1144,  1145,  1146,
-    1147,  1148,  1149,  1150,  1151,  1152,  1153,  1155,  1156,  1158,
-    1159,  1160,  1161,  1165,  1166,  1167,  1168,  1170,  1171,  1173,
-    1174,  1176,  1177,  1178,  1179,  1180,  1181,  1182,  1186,  1187,
-    1188,  1191,  1197,  1198,  1200,  1201,  1206,  1207,  1208,  1212,
-    1213,  1214,  1216,  1217,  1218,  1219,  1220,  1222,  1224,  1226,
-    1227,  1228,  1229,  1230,  1231,  1233,  1234,  1235,  1236,  1237,
-    1238,  1240,  1240,  1242,  1244,  1246,  1248,  1249,  1250,  1251,
-    1253,  1253,  1253,  1253,  1253,  1253,  1253,  1255,  1257,  1258,
-    1260,  1261,  1263,  1265,  1267,  1278,  1279,  1290,  1322,  1327,
-    1339,  1348,  1348,  1355,  1355,  1357,  1357,  1364,  1368,  1373,
-    1381,  1387,  1391,  1396,  1397,  1399,  1399,  1401,  1401,  1403,
-    1404,  1406,  1406,  1412,  1413,  1415,  1419,  1424,  1430,  1437,
-    1438,  1439,  1440,  1442,  1443,  1444,  1450,  1450,  1452,  1454,
-    1458,  1463,  1473,  1480,  1488,  1497,  1498,  1499,  1500,  1501,
-    1502,  1503,  1504,  1505,  1506,  1508,  1514,  1514,  1517,  1521
+       0,   377,   377,   397,   403,   410,   414,   418,   419,   420,
+     422,   423,   424,   425,   426,   427,   428,   429,   430,   431,
+     437,   438,   440,   444,   449,   453,   463,   464,   465,   467,
+     467,   473,   479,   481,   485,   497,   503,   520,   535,   537,
+     538,   539,   541,   555,   559,   569,   573,   597,   605,   618,
+     625,   640,   660,   661,   666,   677,   690,   702,   709,   716,
+     725,   726,   728,   732,   737,   738,   740,   748,   749,   750,
+     751,   752,   753,   754,   758,   759,   760,   761,   762,   763,
+     764,   765,   766,   767,   768,   770,   771,   773,   774,   775,
+     777,   778,   780,   784,   788,   793,   801,   802,   803,   804,
+     806,   807,   808,   810,   818,   824,   830,   836,   842,   843,
+     850,   856,   858,   868,   875,   886,   893,   901,   902,   909,
+     916,   920,   925,   935,   939,   943,   955,   955,   957,   958,
+     967,   968,   970,   984,   996,  1001,  1005,  1009,  1014,  1015,
+    1017,  1027,  1028,  1030,  1032,  1033,  1035,  1037,  1038,  1040,
+    1045,  1047,  1048,  1050,  1051,  1053,  1057,  1062,  1064,  1065,
+    1066,  1068,  1069,  1091,  1092,  1094,  1095,  1096,  1097,  1098,
+    1099,  1104,  1108,  1114,  1115,  1117,  1121,  1126,  1126,  1130,
+    1131,  1132,  1134,  1143,  1143,  1143,  1143,  1143,  1145,  1146,
+    1146,  1146,  1146,  1146,  1146,  1146,  1146,  1147,  1147,  1151,
+    1151,  1153,  1154,  1155,  1156,  1157,  1159,  1159,  1160,  1161,
+    1162,  1163,  1164,  1165,  1166,  1167,  1168,  1170,  1171,  1173,
+    1174,  1175,  1176,  1180,  1181,  1182,  1183,  1185,  1186,  1188,
+    1189,  1191,  1192,  1193,  1194,  1195,  1196,  1197,  1201,  1202,
+    1203,  1206,  1212,  1213,  1215,  1216,  1221,  1222,  1223,  1227,
+    1228,  1229,  1231,  1232,  1233,  1234,  1235,  1237,  1239,  1241,
+    1242,  1243,  1244,  1245,  1246,  1248,  1249,  1250,  1251,  1252,
+    1253,  1255,  1255,  1257,  1259,  1261,  1263,  1264,  1265,  1266,
+    1268,  1268,  1268,  1268,  1268,  1268,  1268,  1270,  1272,  1273,
+    1275,  1276,  1278,  1280,  1282,  1293,  1294,  1305,  1337,  1342,
+    1354,  1363,  1363,  1370,  1370,  1372,  1372,  1379,  1383,  1388,
+    1396,  1402,  1406,  1411,  1412,  1414,  1414,  1416,  1416,  1418,
+    1419,  1421,  1421,  1427,  1428,  1430,  1434,  1439,  1445,  1452,
+    1453,  1454,  1455,  1457,  1458,  1459,  1465,  1465,  1467,  1469,
+    1473,  1478,  1488,  1495,  1503,  1512,  1513,  1514,  1515,  1516,
+    1517,  1518,  1519,  1520,  1521,  1523,  1529,  1529,  1532,  1536
 };
 #endif
 
@@ -2106,43 +2114,43 @@ yydestruct (const char *yymsg,
   switch (yykind)
     {
     case YYSYMBOL_IDENTIFIER: /* IDENTIFIER  */
-#line 194 "bison_parser.y"
+#line 209 "bison_parser.y"
             { free(((*yyvaluep).sval)); }
-#line 2112 "bison_parser.cpp"
+#line 2120 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_STRING: /* STRING  */
-#line 194 "bison_parser.y"
+#line 209 "bison_parser.y"
             { free(((*yyvaluep).sval)); }
-#line 2118 "bison_parser.cpp"
+#line 2126 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_FLOATVAL: /* FLOATVAL  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2124 "bison_parser.cpp"
+#line 2132 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_INTVAL: /* INTVAL  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2130 "bison_parser.cpp"
+#line 2138 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_DOLLAR_PARAM: /* DOLLAR_PARAM  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2136 "bison_parser.cpp"
+#line 2144 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_NAMED_PARAM: /* NAMED_PARAM  */
-#line 194 "bison_parser.y"
+#line 209 "bison_parser.y"
             { free(((*yyvaluep).sval)); }
-#line 2142 "bison_parser.cpp"
+#line 2150 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_statement_list: /* statement_list  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).stmt_vec)) {
     for (auto ptr : *(((*yyvaluep).stmt_vec))) {
@@ -2151,23 +2159,23 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).stmt_vec));
 }
-#line 2155 "bison_parser.cpp"
+#line 2163 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_statement: /* statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).statement)); }
-#line 2161 "bison_parser.cpp"
+#line 2169 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_preparable_statement: /* preparable_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).statement)); }
-#line 2167 "bison_parser.cpp"
+#line 2175 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_hints: /* opt_hints  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
@@ -2176,11 +2184,11 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2180 "bison_parser.cpp"
+#line 2188 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_hint_list: /* hint_list  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
@@ -2189,104 +2197,104 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2193 "bison_parser.cpp"
+#line 2201 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_hint: /* hint  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2199 "bison_parser.cpp"
+#line 2207 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_transaction_statement: /* transaction_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).transaction_stmt)); }
-#line 2205 "bison_parser.cpp"
+#line 2213 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_prepare_statement: /* prepare_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).prep_stmt)); }
-#line 2211 "bison_parser.cpp"
+#line 2219 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_prepare_target_query: /* prepare_target_query  */
-#line 194 "bison_parser.y"
+#line 209 "bison_parser.y"
             { free(((*yyvaluep).sval)); }
-#line 2217 "bison_parser.cpp"
+#line 2225 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_execute_statement: /* execute_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).exec_stmt)); }
-#line 2223 "bison_parser.cpp"
+#line 2231 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_import_statement: /* import_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).import_stmt)); }
-#line 2229 "bison_parser.cpp"
+#line 2237 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_file_type: /* file_type  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2235 "bison_parser.cpp"
+#line 2243 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_file_path: /* file_path  */
-#line 194 "bison_parser.y"
+#line 209 "bison_parser.y"
             { free(((*yyvaluep).sval)); }
-#line 2241 "bison_parser.cpp"
+#line 2249 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_import_export_options: /* opt_import_export_options  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).import_export_option_t)); }
-#line 2247 "bison_parser.cpp"
+#line 2255 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_import_export_options: /* import_export_options  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).import_export_option_t)); }
-#line 2253 "bison_parser.cpp"
+#line 2261 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_csv_option: /* csv_option  */
-#line 203 "bison_parser.y"
+#line 218 "bison_parser.y"
             {
   free(((*yyvaluep).csv_option_t)->second);
   delete (((*yyvaluep).csv_option_t));
 }
-#line 2262 "bison_parser.cpp"
+#line 2270 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_export_statement: /* export_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).export_stmt)); }
-#line 2268 "bison_parser.cpp"
+#line 2276 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_show_statement: /* show_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).show_stmt)); }
-#line 2274 "bison_parser.cpp"
+#line 2282 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_create_statement: /* create_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).create_stmt)); }
-#line 2280 "bison_parser.cpp"
+#line 2288 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_not_exists: /* opt_not_exists  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2286 "bison_parser.cpp"
+#line 2294 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_elem_commalist: /* table_elem_commalist  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).table_element_vec)) {
     for (auto ptr : *(((*yyvaluep).table_element_vec))) {
@@ -2295,41 +2303,41 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).table_element_vec));
 }
-#line 2299 "bison_parser.cpp"
+#line 2307 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_elem: /* table_elem  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).table_element_t)); }
-#line 2305 "bison_parser.cpp"
+#line 2313 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_column_def: /* column_def  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).column_t)); }
-#line 2311 "bison_parser.cpp"
+#line 2319 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_column_type: /* column_type  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2317 "bison_parser.cpp"
+#line 2325 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_time_precision: /* opt_time_precision  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2323 "bison_parser.cpp"
+#line 2331 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_decimal_specification: /* opt_decimal_specification  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).ival_pair)); }
-#line 2329 "bison_parser.cpp"
+#line 2337 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_column_constraints: /* opt_column_constraints  */
-#line 207 "bison_parser.y"
+#line 222 "bison_parser.y"
             {
   // ColumnConstraints owns heap-allocated members (constraints, references).
   // The happy path transfers those pointers into a ColumnDefinition and then
@@ -2347,11 +2355,11 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).column_constraints_t));
 }
-#line 2351 "bison_parser.cpp"
+#line 2359 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_column_constraints: /* column_constraints  */
-#line 207 "bison_parser.y"
+#line 222 "bison_parser.y"
             {
   // ColumnConstraints owns heap-allocated members (constraints, references).
   // The happy path transfers those pointers into a ColumnDefinition and then
@@ -2369,77 +2377,77 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).column_constraints_t));
 }
-#line 2373 "bison_parser.cpp"
+#line 2381 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_column_constraint: /* column_constraint  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2379 "bison_parser.cpp"
+#line 2387 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_constraint: /* table_constraint  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).table_constraint_t)); }
-#line 2385 "bison_parser.cpp"
+#line 2393 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_references_spec: /* references_spec  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).references_spec_t)); }
-#line 2391 "bison_parser.cpp"
+#line 2399 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_drop_statement: /* drop_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).drop_stmt)); }
-#line 2397 "bison_parser.cpp"
+#line 2405 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_exists: /* opt_exists  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2403 "bison_parser.cpp"
+#line 2411 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_alter_statement: /* alter_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).alter_stmt)); }
-#line 2409 "bison_parser.cpp"
+#line 2417 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_alter_action: /* alter_action  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).alter_action_t)); }
-#line 2415 "bison_parser.cpp"
+#line 2423 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_drop_action: /* drop_action  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).drop_action_t)); }
-#line 2421 "bison_parser.cpp"
+#line 2429 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_delete_statement: /* delete_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).delete_stmt)); }
-#line 2427 "bison_parser.cpp"
+#line 2435 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_truncate_statement: /* truncate_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).delete_stmt)); }
-#line 2433 "bison_parser.cpp"
+#line 2441 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_insert_statement: /* insert_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).insert_stmt)); }
-#line 2439 "bison_parser.cpp"
+#line 2447 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_column_list: /* opt_column_list  */
-#line 186 "bison_parser.y"
+#line 201 "bison_parser.y"
             {
   if (((*yyvaluep).str_vec)) {
     for (auto ptr : *(((*yyvaluep).str_vec))) {
@@ -2448,17 +2456,17 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).str_vec));
 }
-#line 2452 "bison_parser.cpp"
+#line 2460 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_update_statement: /* update_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).update_stmt)); }
-#line 2458 "bison_parser.cpp"
+#line 2466 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_update_clause_commalist: /* update_clause_commalist  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).update_vec)) {
     for (auto ptr : *(((*yyvaluep).update_vec))) {
@@ -2467,77 +2475,77 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).update_vec));
 }
-#line 2471 "bison_parser.cpp"
+#line 2479 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_update_clause: /* update_clause  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).update_t)); }
-#line 2477 "bison_parser.cpp"
+#line 2485 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_statement: /* select_statement  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2483 "bison_parser.cpp"
+#line 2491 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_within_set_operation: /* select_within_set_operation  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2489 "bison_parser.cpp"
+#line 2497 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_within_set_operation_no_parentheses: /* select_within_set_operation_no_parentheses  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2495 "bison_parser.cpp"
+#line 2503 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_with_paren: /* select_with_paren  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2501 "bison_parser.cpp"
+#line 2509 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_no_paren: /* select_no_paren  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2507 "bison_parser.cpp"
+#line 2515 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_set_operator: /* set_operator  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).set_operator_t)); }
-#line 2513 "bison_parser.cpp"
+#line 2521 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_set_type: /* set_type  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).set_operator_t)); }
-#line 2519 "bison_parser.cpp"
+#line 2527 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_all: /* opt_all  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2525 "bison_parser.cpp"
+#line 2533 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_clause: /* select_clause  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2531 "bison_parser.cpp"
+#line 2539 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_distinct: /* opt_distinct  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2537 "bison_parser.cpp"
+#line 2545 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_list: /* select_list  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
@@ -2546,41 +2554,41 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2550 "bison_parser.cpp"
+#line 2558 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_from_clause: /* opt_from_clause  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2556 "bison_parser.cpp"
+#line 2564 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_from_clause: /* from_clause  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2562 "bison_parser.cpp"
+#line 2570 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_where: /* opt_where  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2568 "bison_parser.cpp"
+#line 2576 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_group: /* opt_group  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).group_t)); }
-#line 2574 "bison_parser.cpp"
+#line 2582 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_having: /* opt_having  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2580 "bison_parser.cpp"
+#line 2588 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_order: /* opt_order  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).order_vec)) {
     for (auto ptr : *(((*yyvaluep).order_vec))) {
@@ -2589,11 +2597,11 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).order_vec));
 }
-#line 2593 "bison_parser.cpp"
+#line 2601 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_order_list: /* order_list  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).order_vec)) {
     for (auto ptr : *(((*yyvaluep).order_vec))) {
@@ -2602,41 +2610,41 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).order_vec));
 }
-#line 2606 "bison_parser.cpp"
+#line 2614 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_order_desc: /* order_desc  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).order)); }
-#line 2612 "bison_parser.cpp"
+#line 2620 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_order_type: /* opt_order_type  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2618 "bison_parser.cpp"
+#line 2626 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_null_ordering: /* opt_null_ordering  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2624 "bison_parser.cpp"
+#line 2632 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_top: /* opt_top  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).limit)); }
-#line 2630 "bison_parser.cpp"
+#line 2638 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_limit: /* opt_limit  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).limit)); }
-#line 2636 "bison_parser.cpp"
+#line 2644 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_expr_list: /* expr_list  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
@@ -2645,11 +2653,11 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2649 "bison_parser.cpp"
+#line 2657 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_extended_literal_list: /* opt_extended_literal_list  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
@@ -2658,11 +2666,11 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2662 "bison_parser.cpp"
+#line 2670 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_extended_literal_list: /* extended_literal_list  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
@@ -2671,107 +2679,107 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2675 "bison_parser.cpp"
+#line 2683 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_casted_extended_literal: /* casted_extended_literal  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2681 "bison_parser.cpp"
+#line 2689 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_extended_literal: /* extended_literal  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2687 "bison_parser.cpp"
+#line 2695 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_expr_alias: /* expr_alias  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2693 "bison_parser.cpp"
+#line 2701 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_expr: /* expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2699 "bison_parser.cpp"
+#line 2707 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_operand: /* operand  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2705 "bison_parser.cpp"
+#line 2713 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_scalar_expr: /* scalar_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2711 "bison_parser.cpp"
+#line 2719 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_unary_expr: /* unary_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2717 "bison_parser.cpp"
+#line 2725 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_binary_expr: /* binary_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2723 "bison_parser.cpp"
+#line 2731 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_logic_expr: /* logic_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2729 "bison_parser.cpp"
+#line 2737 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_in_expr: /* in_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2735 "bison_parser.cpp"
+#line 2743 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_case_expr: /* case_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2741 "bison_parser.cpp"
+#line 2749 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_case_list: /* case_list  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2747 "bison_parser.cpp"
+#line 2755 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_exists_expr: /* exists_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2753 "bison_parser.cpp"
+#line 2761 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_comp_expr: /* comp_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2759 "bison_parser.cpp"
+#line 2767 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_function_expr: /* function_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2765 "bison_parser.cpp"
+#line 2773 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_window: /* opt_window  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).window_description)); }
-#line 2771 "bison_parser.cpp"
+#line 2779 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_partition: /* opt_partition  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
@@ -2780,155 +2788,155 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2784 "bison_parser.cpp"
+#line 2792 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_frame_clause: /* opt_frame_clause  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).frame_description)); }
-#line 2790 "bison_parser.cpp"
+#line 2798 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_frame_type: /* frame_type  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2796 "bison_parser.cpp"
+#line 2804 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_frame_bound: /* frame_bound  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).frame_bound)); }
-#line 2802 "bison_parser.cpp"
+#line 2810 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_extract_expr: /* extract_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2808 "bison_parser.cpp"
+#line 2816 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_cast_expr: /* cast_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2814 "bison_parser.cpp"
+#line 2822 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_datetime_field: /* datetime_field  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2820 "bison_parser.cpp"
+#line 2828 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_datetime_field_plural: /* datetime_field_plural  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2826 "bison_parser.cpp"
+#line 2834 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_duration_field: /* duration_field  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 2832 "bison_parser.cpp"
+#line 2840 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_array_expr: /* array_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2838 "bison_parser.cpp"
+#line 2846 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_array_index: /* array_index  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2844 "bison_parser.cpp"
+#line 2852 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_between_expr: /* between_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2850 "bison_parser.cpp"
+#line 2858 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_column_name: /* column_name  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2856 "bison_parser.cpp"
+#line 2864 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_literal: /* literal  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2862 "bison_parser.cpp"
+#line 2870 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_string_literal: /* string_literal  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2868 "bison_parser.cpp"
+#line 2876 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_bool_literal: /* bool_literal  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2874 "bison_parser.cpp"
+#line 2882 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_num_literal: /* num_literal  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2880 "bison_parser.cpp"
+#line 2888 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_int_literal: /* int_literal  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2886 "bison_parser.cpp"
+#line 2894 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_null_literal: /* null_literal  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2892 "bison_parser.cpp"
+#line 2900 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_date_literal: /* date_literal  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2898 "bison_parser.cpp"
+#line 2906 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_interval_literal: /* interval_literal  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2904 "bison_parser.cpp"
+#line 2912 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_param_expr: /* param_expr  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2910 "bison_parser.cpp"
+#line 2918 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_ref: /* table_ref  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2916 "bison_parser.cpp"
+#line 2924 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_ref_atomic: /* table_ref_atomic  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2922 "bison_parser.cpp"
+#line 2930 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_nonjoin_table_ref_atomic: /* nonjoin_table_ref_atomic  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2928 "bison_parser.cpp"
+#line 2936 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_ref_commalist: /* table_ref_commalist  */
-#line 195 "bison_parser.y"
+#line 210 "bison_parser.y"
             {
   if (((*yyvaluep).table_vec)) {
     for (auto ptr : *(((*yyvaluep).table_vec))) {
@@ -2937,134 +2945,134 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).table_vec));
 }
-#line 2941 "bison_parser.cpp"
+#line 2949 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_ref_name: /* table_ref_name  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2947 "bison_parser.cpp"
+#line 2955 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_ref_name_no_alias: /* table_ref_name_no_alias  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2953 "bison_parser.cpp"
+#line 2961 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_name: /* table_name  */
-#line 182 "bison_parser.y"
+#line 197 "bison_parser.y"
             {
   free(((*yyvaluep).table_name).name);
   free(((*yyvaluep).table_name).schema);
 }
-#line 2962 "bison_parser.cpp"
+#line 2970 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_index_name: /* opt_index_name  */
-#line 194 "bison_parser.y"
+#line 209 "bison_parser.y"
             { free(((*yyvaluep).sval)); }
-#line 2968 "bison_parser.cpp"
+#line 2976 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_alias: /* table_alias  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).alias_t)); }
-#line 2974 "bison_parser.cpp"
+#line 2982 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_table_alias: /* opt_table_alias  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).alias_t)); }
-#line 2980 "bison_parser.cpp"
+#line 2988 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_alias: /* alias  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).alias_t)); }
-#line 2986 "bison_parser.cpp"
+#line 2994 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_alias: /* opt_alias  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).alias_t)); }
-#line 2992 "bison_parser.cpp"
+#line 3000 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_locking_clause: /* opt_locking_clause  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).locking_clause_vec)); }
-#line 2998 "bison_parser.cpp"
+#line 3006 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_locking_clause_list: /* opt_locking_clause_list  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).locking_clause_vec)); }
-#line 3004 "bison_parser.cpp"
+#line 3012 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_locking_clause: /* locking_clause  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).locking_t)); }
-#line 3010 "bison_parser.cpp"
+#line 3018 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_row_lock_mode: /* row_lock_mode  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 3016 "bison_parser.cpp"
+#line 3024 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_row_lock_policy: /* opt_row_lock_policy  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 3022 "bison_parser.cpp"
+#line 3030 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_with_clause: /* opt_with_clause  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).with_description_vec)); }
-#line 3028 "bison_parser.cpp"
+#line 3036 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_with_clause: /* with_clause  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).with_description_vec)); }
-#line 3034 "bison_parser.cpp"
+#line 3042 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_with_description_list: /* with_description_list  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).with_description_vec)); }
-#line 3040 "bison_parser.cpp"
+#line 3048 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_with_description: /* with_description  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).with_description_t)); }
-#line 3046 "bison_parser.cpp"
+#line 3054 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_join_clause: /* join_clause  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 3052 "bison_parser.cpp"
+#line 3060 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_join_type: /* opt_join_type  */
-#line 181 "bison_parser.y"
+#line 196 "bison_parser.y"
             { }
-#line 3058 "bison_parser.cpp"
+#line 3066 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_join_condition: /* join_condition  */
-#line 224 "bison_parser.y"
+#line 239 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 3064 "bison_parser.cpp"
+#line 3072 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_ident_commalist: /* ident_commalist  */
-#line 186 "bison_parser.y"
+#line 201 "bison_parser.y"
             {
   if (((*yyvaluep).str_vec)) {
     for (auto ptr : *(((*yyvaluep).str_vec))) {
@@ -3073,7 +3081,7 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).str_vec));
 }
-#line 3077 "bison_parser.cpp"
+#line 3085 "bison_parser.cpp"
         break;
 
       default:
@@ -3170,7 +3178,7 @@ YYLTYPE yylloc = yyloc_default;
 
 
 /* User initialization code.  */
-#line 81 "bison_parser.y"
+#line 96 "bison_parser.y"
 {
   // Initialize
   yylloc.first_column = 0;
@@ -3181,7 +3189,7 @@ YYLTYPE yylloc = yyloc_default;
   yylloc.string_length = 0;
 }
 
-#line 3185 "bison_parser.cpp"
+#line 3193 "bison_parser.cpp"
 
   yylsp[0] = yylloc;
   goto yysetstate;
@@ -3392,7 +3400,7 @@ yyreduce:
   switch (yyn)
     {
   case 2: /* input: statement_list opt_semicolon  */
-#line 362 "bison_parser.y"
+#line 377 "bison_parser.y"
                                      {
   for (SQLStatement* stmt : *(yyvsp[-1].stmt_vec)) {
     // Transfers ownership of the statement.
@@ -3411,236 +3419,236 @@ yyreduce:
   }
     delete (yyvsp[-1].stmt_vec);
   }
-#line 3415 "bison_parser.cpp"
+#line 3423 "bison_parser.cpp"
     break;
 
   case 3: /* statement_list: statement  */
-#line 382 "bison_parser.y"
+#line 397 "bison_parser.y"
                            {
   (yyvsp[0].statement)->stringLength = yylloc.string_length;
   yylloc.string_length = 0;
   (yyval.stmt_vec) = new std::vector<SQLStatement*>();
   (yyval.stmt_vec)->push_back((yyvsp[0].statement));
 }
-#line 3426 "bison_parser.cpp"
+#line 3434 "bison_parser.cpp"
     break;
 
   case 4: /* statement_list: statement_list ';' statement  */
-#line 388 "bison_parser.y"
+#line 403 "bison_parser.y"
                                {
   (yyvsp[0].statement)->stringLength = yylloc.string_length;
   yylloc.string_length = 0;
   (yyvsp[-2].stmt_vec)->push_back((yyvsp[0].statement));
   (yyval.stmt_vec) = (yyvsp[-2].stmt_vec);
 }
-#line 3437 "bison_parser.cpp"
+#line 3445 "bison_parser.cpp"
     break;
 
   case 5: /* statement: prepare_statement opt_hints  */
-#line 395 "bison_parser.y"
+#line 410 "bison_parser.y"
                                         {
   (yyval.statement) = (yyvsp[-1].prep_stmt);
   (yyval.statement)->hints = (yyvsp[0].expr_vec);
 }
-#line 3446 "bison_parser.cpp"
+#line 3454 "bison_parser.cpp"
     break;
 
   case 6: /* statement: preparable_statement opt_hints  */
-#line 399 "bison_parser.y"
+#line 414 "bison_parser.y"
                                  {
   (yyval.statement) = (yyvsp[-1].statement);
   (yyval.statement)->hints = (yyvsp[0].expr_vec);
 }
-#line 3455 "bison_parser.cpp"
+#line 3463 "bison_parser.cpp"
     break;
 
   case 7: /* statement: show_statement  */
-#line 403 "bison_parser.y"
+#line 418 "bison_parser.y"
                  { (yyval.statement) = (yyvsp[0].show_stmt); }
-#line 3461 "bison_parser.cpp"
+#line 3469 "bison_parser.cpp"
     break;
 
   case 8: /* statement: import_statement  */
-#line 404 "bison_parser.y"
+#line 419 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].import_stmt); }
-#line 3467 "bison_parser.cpp"
+#line 3475 "bison_parser.cpp"
     break;
 
   case 9: /* statement: export_statement  */
-#line 405 "bison_parser.y"
+#line 420 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].export_stmt); }
-#line 3473 "bison_parser.cpp"
+#line 3481 "bison_parser.cpp"
     break;
 
   case 10: /* preparable_statement: select_statement  */
-#line 407 "bison_parser.y"
+#line 422 "bison_parser.y"
                                         { (yyval.statement) = (yyvsp[0].select_stmt); }
-#line 3479 "bison_parser.cpp"
+#line 3487 "bison_parser.cpp"
     break;
 
   case 11: /* preparable_statement: create_statement  */
-#line 408 "bison_parser.y"
+#line 423 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].create_stmt); }
-#line 3485 "bison_parser.cpp"
+#line 3493 "bison_parser.cpp"
     break;
 
   case 12: /* preparable_statement: insert_statement  */
-#line 409 "bison_parser.y"
+#line 424 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].insert_stmt); }
-#line 3491 "bison_parser.cpp"
+#line 3499 "bison_parser.cpp"
     break;
 
   case 13: /* preparable_statement: delete_statement  */
-#line 410 "bison_parser.y"
+#line 425 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 3497 "bison_parser.cpp"
+#line 3505 "bison_parser.cpp"
     break;
 
   case 14: /* preparable_statement: truncate_statement  */
-#line 411 "bison_parser.y"
+#line 426 "bison_parser.y"
                      { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 3503 "bison_parser.cpp"
+#line 3511 "bison_parser.cpp"
     break;
 
   case 15: /* preparable_statement: update_statement  */
-#line 412 "bison_parser.y"
+#line 427 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].update_stmt); }
-#line 3509 "bison_parser.cpp"
+#line 3517 "bison_parser.cpp"
     break;
 
   case 16: /* preparable_statement: drop_statement  */
-#line 413 "bison_parser.y"
+#line 428 "bison_parser.y"
                  { (yyval.statement) = (yyvsp[0].drop_stmt); }
-#line 3515 "bison_parser.cpp"
+#line 3523 "bison_parser.cpp"
     break;
 
   case 17: /* preparable_statement: alter_statement  */
-#line 414 "bison_parser.y"
+#line 429 "bison_parser.y"
                   { (yyval.statement) = (yyvsp[0].alter_stmt); }
-#line 3521 "bison_parser.cpp"
+#line 3529 "bison_parser.cpp"
     break;
 
   case 18: /* preparable_statement: execute_statement  */
-#line 415 "bison_parser.y"
+#line 430 "bison_parser.y"
                     { (yyval.statement) = (yyvsp[0].exec_stmt); }
-#line 3527 "bison_parser.cpp"
+#line 3535 "bison_parser.cpp"
     break;
 
   case 19: /* preparable_statement: transaction_statement  */
-#line 416 "bison_parser.y"
+#line 431 "bison_parser.y"
                         { (yyval.statement) = (yyvsp[0].transaction_stmt); }
-#line 3533 "bison_parser.cpp"
+#line 3541 "bison_parser.cpp"
     break;
 
   case 20: /* opt_hints: WITH HINT '(' hint_list ')'  */
-#line 422 "bison_parser.y"
+#line 437 "bison_parser.y"
                                         { (yyval.expr_vec) = (yyvsp[-1].expr_vec); }
-#line 3539 "bison_parser.cpp"
+#line 3547 "bison_parser.cpp"
     break;
 
   case 21: /* opt_hints: %empty  */
-#line 423 "bison_parser.y"
+#line 438 "bison_parser.y"
               { (yyval.expr_vec) = nullptr; }
-#line 3545 "bison_parser.cpp"
+#line 3553 "bison_parser.cpp"
     break;
 
   case 22: /* hint_list: hint  */
-#line 425 "bison_parser.y"
+#line 440 "bison_parser.y"
                  {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 3554 "bison_parser.cpp"
+#line 3562 "bison_parser.cpp"
     break;
 
   case 23: /* hint_list: hint_list ',' hint  */
-#line 429 "bison_parser.y"
+#line 444 "bison_parser.y"
                      {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 3563 "bison_parser.cpp"
+#line 3571 "bison_parser.cpp"
     break;
 
   case 24: /* hint: IDENTIFIER  */
-#line 434 "bison_parser.y"
+#line 449 "bison_parser.y"
                   {
   (yyval.expr) = Expr::make(kExprHint);
   (yyval.expr)->name = (yyvsp[0].sval);
 }
-#line 3572 "bison_parser.cpp"
+#line 3580 "bison_parser.cpp"
     break;
 
   case 25: /* hint: IDENTIFIER '(' extended_literal_list ')'  */
-#line 438 "bison_parser.y"
+#line 453 "bison_parser.y"
                                            {
   (yyval.expr) = Expr::make(kExprHint);
   (yyval.expr)->name = (yyvsp[-3].sval);
   (yyval.expr)->exprList = (yyvsp[-1].expr_vec);
 }
-#line 3582 "bison_parser.cpp"
+#line 3590 "bison_parser.cpp"
     break;
 
   case 26: /* transaction_statement: BEGIN opt_transaction_keyword  */
-#line 448 "bison_parser.y"
+#line 463 "bison_parser.y"
                                                       { (yyval.transaction_stmt) = new TransactionStatement(kBeginTransaction); }
-#line 3588 "bison_parser.cpp"
+#line 3596 "bison_parser.cpp"
     break;
 
   case 27: /* transaction_statement: ROLLBACK opt_transaction_keyword  */
-#line 449 "bison_parser.y"
+#line 464 "bison_parser.y"
                                    { (yyval.transaction_stmt) = new TransactionStatement(kRollbackTransaction); }
-#line 3594 "bison_parser.cpp"
+#line 3602 "bison_parser.cpp"
     break;
 
   case 28: /* transaction_statement: COMMIT opt_transaction_keyword  */
-#line 450 "bison_parser.y"
+#line 465 "bison_parser.y"
                                  { (yyval.transaction_stmt) = new TransactionStatement(kCommitTransaction); }
-#line 3600 "bison_parser.cpp"
+#line 3608 "bison_parser.cpp"
     break;
 
   case 31: /* prepare_statement: PREPARE IDENTIFIER FROM prepare_target_query  */
-#line 458 "bison_parser.y"
+#line 473 "bison_parser.y"
                                                                  {
   (yyval.prep_stmt) = new PrepareStatement();
   (yyval.prep_stmt)->name = (yyvsp[-2].sval);
   (yyval.prep_stmt)->query = (yyvsp[0].sval);
 }
-#line 3610 "bison_parser.cpp"
+#line 3618 "bison_parser.cpp"
     break;
 
   case 33: /* execute_statement: EXECUTE IDENTIFIER  */
-#line 466 "bison_parser.y"
+#line 481 "bison_parser.y"
                                        {
   (yyval.exec_stmt) = new ExecuteStatement();
   (yyval.exec_stmt)->name = (yyvsp[0].sval);
 }
-#line 3619 "bison_parser.cpp"
+#line 3627 "bison_parser.cpp"
     break;
 
   case 34: /* execute_statement: EXECUTE IDENTIFIER '(' opt_extended_literal_list ')'  */
-#line 470 "bison_parser.y"
+#line 485 "bison_parser.y"
                                                        {
   (yyval.exec_stmt) = new ExecuteStatement();
   (yyval.exec_stmt)->name = (yyvsp[-3].sval);
   (yyval.exec_stmt)->parameters = (yyvsp[-1].expr_vec);
 }
-#line 3629 "bison_parser.cpp"
+#line 3637 "bison_parser.cpp"
     break;
 
   case 35: /* import_statement: IMPORT FROM file_type FILE file_path INTO table_name  */
-#line 482 "bison_parser.y"
+#line 497 "bison_parser.y"
                                                                         {
   (yyval.import_stmt) = new ImportStatement((yyvsp[-4].import_type_t));
   (yyval.import_stmt)->filePath = (yyvsp[-2].sval);
   (yyval.import_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.import_stmt)->tableName = (yyvsp[0].table_name).name;
 }
-#line 3640 "bison_parser.cpp"
+#line 3648 "bison_parser.cpp"
     break;
 
   case 36: /* import_statement: COPY table_name FROM file_path opt_import_export_options opt_where  */
-#line 488 "bison_parser.y"
+#line 503 "bison_parser.y"
                                                                      {
   (yyval.import_stmt) = new ImportStatement((yyvsp[-1].import_export_option_t)->format);
   (yyval.import_stmt)->filePath = (yyvsp[-2].sval);
@@ -3657,11 +3665,11 @@ yyreduce:
   }
   delete (yyvsp[-1].import_export_option_t);
 }
-#line 3661 "bison_parser.cpp"
+#line 3669 "bison_parser.cpp"
     break;
 
   case 37: /* file_type: IDENTIFIER  */
-#line 505 "bison_parser.y"
+#line 520 "bison_parser.y"
                        {
   if (strcasecmp((yyvsp[0].sval), "csv") == 0) {
     (yyval.import_type_t) = kImportCSV;
@@ -3676,35 +3684,35 @@ yyreduce:
   }
   free((yyvsp[0].sval));
 }
-#line 3680 "bison_parser.cpp"
+#line 3688 "bison_parser.cpp"
     break;
 
   case 38: /* file_path: STRING  */
-#line 520 "bison_parser.y"
+#line 535 "bison_parser.y"
                    { (yyval.sval) = (yyvsp[0].sval); }
-#line 3686 "bison_parser.cpp"
+#line 3694 "bison_parser.cpp"
     break;
 
   case 39: /* opt_import_export_options: WITH '(' import_export_options ')'  */
-#line 522 "bison_parser.y"
+#line 537 "bison_parser.y"
                                                                { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
-#line 3692 "bison_parser.cpp"
+#line 3700 "bison_parser.cpp"
     break;
 
   case 40: /* opt_import_export_options: '(' import_export_options ')'  */
-#line 523 "bison_parser.y"
+#line 538 "bison_parser.y"
                                 { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
-#line 3698 "bison_parser.cpp"
+#line 3706 "bison_parser.cpp"
     break;
 
   case 41: /* opt_import_export_options: %empty  */
-#line 524 "bison_parser.y"
+#line 539 "bison_parser.y"
               { (yyval.import_export_option_t) = new ImportExportOptions{}; }
-#line 3704 "bison_parser.cpp"
+#line 3712 "bison_parser.cpp"
     break;
 
   case 42: /* import_export_options: import_export_options ',' FORMAT file_type  */
-#line 526 "bison_parser.y"
+#line 541 "bison_parser.y"
                                                                    {
   if ((yyvsp[-3].import_export_option_t)->format != kImportAuto) {
     delete (yyvsp[-3].import_export_option_t);
@@ -3719,20 +3727,20 @@ yyreduce:
   (yyvsp[-3].import_export_option_t)->format = (yyvsp[0].import_type_t);
   (yyval.import_export_option_t) = (yyvsp[-3].import_export_option_t);
 }
-#line 3723 "bison_parser.cpp"
+#line 3731 "bison_parser.cpp"
     break;
 
   case 43: /* import_export_options: FORMAT file_type  */
-#line 540 "bison_parser.y"
+#line 555 "bison_parser.y"
                    {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->format = (yyvsp[0].import_type_t);
 }
-#line 3732 "bison_parser.cpp"
+#line 3740 "bison_parser.cpp"
     break;
 
   case 44: /* import_export_options: import_export_options ',' ENCODING STRING  */
-#line 544 "bison_parser.y"
+#line 559 "bison_parser.y"
                                             {
   if ((yyvsp[-3].import_export_option_t)->encoding) {
     delete (yyvsp[-3].import_export_option_t);
@@ -3743,20 +3751,20 @@ yyreduce:
   (yyvsp[-3].import_export_option_t)->encoding = (yyvsp[0].sval);
   (yyval.import_export_option_t) = (yyvsp[-3].import_export_option_t);
 }
-#line 3747 "bison_parser.cpp"
+#line 3755 "bison_parser.cpp"
     break;
 
   case 45: /* import_export_options: ENCODING STRING  */
-#line 554 "bison_parser.y"
+#line 569 "bison_parser.y"
                   {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->encoding = (yyvsp[0].sval);
 }
-#line 3756 "bison_parser.cpp"
+#line 3764 "bison_parser.cpp"
     break;
 
   case 46: /* import_export_options: import_export_options ',' csv_option  */
-#line 558 "bison_parser.y"
+#line 573 "bison_parser.y"
                                        {
   if ((yyvsp[-2].import_export_option_t)->format != kImportAuto && (yyvsp[-2].import_export_option_t)->format != kImportCSV) {
     delete (yyvsp[-2].import_export_option_t);
@@ -3781,11 +3789,11 @@ yyreduce:
   delete (yyvsp[0].csv_option_t);
   (yyval.import_export_option_t) = (yyvsp[-2].import_export_option_t);
 }
-#line 3785 "bison_parser.cpp"
+#line 3793 "bison_parser.cpp"
     break;
 
   case 47: /* import_export_options: csv_option  */
-#line 582 "bison_parser.y"
+#line 597 "bison_parser.y"
              {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->csv_options = new CsvOptions{};
@@ -3793,11 +3801,11 @@ yyreduce:
 
   delete (yyvsp[0].csv_option_t);
 }
-#line 3797 "bison_parser.cpp"
+#line 3805 "bison_parser.cpp"
     break;
 
   case 48: /* csv_option: IDENTIFIER STRING  */
-#line 590 "bison_parser.y"
+#line 605 "bison_parser.y"
                                {
   if (strcasecmp((yyvsp[-1].sval), "DELIMITER") == 0) {
     (yyval.csv_option_t) = new std::pair<CsvOptionType, char*>(CsvOptionType::Delimiter, (yyvsp[0].sval));
@@ -3811,17 +3819,17 @@ yyreduce:
   }
   free((yyvsp[-1].sval));
 }
-#line 3815 "bison_parser.cpp"
+#line 3823 "bison_parser.cpp"
     break;
 
   case 49: /* csv_option: NULL STRING  */
-#line 603 "bison_parser.y"
+#line 618 "bison_parser.y"
               { (yyval.csv_option_t) = new std::pair<CsvOptionType, char*>(CsvOptionType::Null, (yyvsp[0].sval)); }
-#line 3821 "bison_parser.cpp"
+#line 3829 "bison_parser.cpp"
     break;
 
   case 50: /* export_statement: COPY table_name TO file_path opt_import_export_options  */
-#line 610 "bison_parser.y"
+#line 625 "bison_parser.y"
                                                                           {
   (yyval.export_stmt) = new ExportStatement((yyvsp[0].import_export_option_t)->format);
   (yyval.export_stmt)->filePath = (yyvsp[-1].sval);
@@ -3837,11 +3845,11 @@ yyreduce:
   }
   delete (yyvsp[0].import_export_option_t);
 }
-#line 3841 "bison_parser.cpp"
+#line 3849 "bison_parser.cpp"
     break;
 
   case 51: /* export_statement: COPY select_with_paren TO file_path opt_import_export_options  */
-#line 625 "bison_parser.y"
+#line 640 "bison_parser.y"
                                                                 {
   (yyval.export_stmt) = new ExportStatement((yyvsp[0].import_export_option_t)->format);
   (yyval.export_stmt)->filePath = (yyvsp[-1].sval);
@@ -3856,37 +3864,37 @@ yyreduce:
   }
   delete (yyvsp[0].import_export_option_t);
 }
-#line 3860 "bison_parser.cpp"
+#line 3868 "bison_parser.cpp"
     break;
 
   case 52: /* show_statement: SHOW TABLES  */
-#line 645 "bison_parser.y"
+#line 660 "bison_parser.y"
                              { (yyval.show_stmt) = new ShowStatement(kShowTables); }
-#line 3866 "bison_parser.cpp"
+#line 3874 "bison_parser.cpp"
     break;
 
   case 53: /* show_statement: SHOW COLUMNS table_name  */
-#line 646 "bison_parser.y"
+#line 661 "bison_parser.y"
                           {
   (yyval.show_stmt) = new ShowStatement(kShowColumns);
   (yyval.show_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.show_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 3876 "bison_parser.cpp"
+#line 3884 "bison_parser.cpp"
     break;
 
   case 54: /* show_statement: DESCRIBE table_name  */
-#line 651 "bison_parser.y"
+#line 666 "bison_parser.y"
                       {
   (yyval.show_stmt) = new ShowStatement(kShowColumns);
   (yyval.show_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.show_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 3886 "bison_parser.cpp"
+#line 3894 "bison_parser.cpp"
     break;
 
   case 55: /* create_statement: CREATE TABLE opt_not_exists table_name FROM IDENTIFIER FILE file_path  */
-#line 662 "bison_parser.y"
+#line 677 "bison_parser.y"
                                                                                          {
   (yyval.create_stmt) = new CreateStatement(kCreateTableFromTbl);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-5].bval);
@@ -3900,11 +3908,11 @@ yyreduce:
   free((yyvsp[-2].sval));
   (yyval.create_stmt)->filePath = (yyvsp[0].sval);
 }
-#line 3904 "bison_parser.cpp"
+#line 3912 "bison_parser.cpp"
     break;
 
   case 56: /* create_statement: CREATE TABLE opt_not_exists table_name '(' table_elem_commalist ')'  */
-#line 675 "bison_parser.y"
+#line 690 "bison_parser.y"
                                                                       {
   (yyval.create_stmt) = new CreateStatement(kCreateTable);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
@@ -3917,11 +3925,11 @@ yyreduce:
     YYERROR;
   }
 }
-#line 3921 "bison_parser.cpp"
+#line 3929 "bison_parser.cpp"
     break;
 
   case 57: /* create_statement: CREATE TABLE opt_not_exists table_name AS select_statement  */
-#line 687 "bison_parser.y"
+#line 702 "bison_parser.y"
                                                              {
   (yyval.create_stmt) = new CreateStatement(kCreateTable);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-3].bval);
@@ -3929,11 +3937,11 @@ yyreduce:
   (yyval.create_stmt)->tableName = (yyvsp[-2].table_name).name;
   (yyval.create_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 3933 "bison_parser.cpp"
+#line 3941 "bison_parser.cpp"
     break;
 
   case 58: /* create_statement: CREATE INDEX opt_not_exists opt_index_name ON table_name '(' ident_commalist ')'  */
-#line 694 "bison_parser.y"
+#line 709 "bison_parser.y"
                                                                                    {
   (yyval.create_stmt) = new CreateStatement(kCreateIndex);
   (yyval.create_stmt)->indexName = (yyvsp[-5].sval);
@@ -3941,11 +3949,11 @@ yyreduce:
   (yyval.create_stmt)->tableName = (yyvsp[-3].table_name).name;
   (yyval.create_stmt)->indexColumns = (yyvsp[-1].str_vec);
 }
-#line 3945 "bison_parser.cpp"
+#line 3953 "bison_parser.cpp"
     break;
 
   case 59: /* create_statement: CREATE VIEW opt_not_exists table_name opt_column_list AS select_statement  */
-#line 701 "bison_parser.y"
+#line 716 "bison_parser.y"
                                                                             {
   (yyval.create_stmt) = new CreateStatement(kCreateView);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
@@ -3954,53 +3962,53 @@ yyreduce:
   (yyval.create_stmt)->viewColumns = (yyvsp[-2].str_vec);
   (yyval.create_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 3958 "bison_parser.cpp"
+#line 3966 "bison_parser.cpp"
     break;
 
   case 60: /* opt_not_exists: IF NOT EXISTS  */
-#line 710 "bison_parser.y"
+#line 725 "bison_parser.y"
                                { (yyval.bval) = true; }
-#line 3964 "bison_parser.cpp"
+#line 3972 "bison_parser.cpp"
     break;
 
   case 61: /* opt_not_exists: %empty  */
-#line 711 "bison_parser.y"
+#line 726 "bison_parser.y"
               { (yyval.bval) = false; }
-#line 3970 "bison_parser.cpp"
+#line 3978 "bison_parser.cpp"
     break;
 
   case 62: /* table_elem_commalist: table_elem  */
-#line 713 "bison_parser.y"
+#line 728 "bison_parser.y"
                                   {
   (yyval.table_element_vec) = new std::vector<TableElement*>();
   (yyval.table_element_vec)->push_back((yyvsp[0].table_element_t));
 }
-#line 3979 "bison_parser.cpp"
+#line 3987 "bison_parser.cpp"
     break;
 
   case 63: /* table_elem_commalist: table_elem_commalist ',' table_elem  */
-#line 717 "bison_parser.y"
+#line 732 "bison_parser.y"
                                       {
   (yyvsp[-2].table_element_vec)->push_back((yyvsp[0].table_element_t));
   (yyval.table_element_vec) = (yyvsp[-2].table_element_vec);
 }
-#line 3988 "bison_parser.cpp"
+#line 3996 "bison_parser.cpp"
     break;
 
   case 64: /* table_elem: column_def  */
-#line 722 "bison_parser.y"
+#line 737 "bison_parser.y"
                         { (yyval.table_element_t) = (yyvsp[0].column_t); }
-#line 3994 "bison_parser.cpp"
+#line 4002 "bison_parser.cpp"
     break;
 
   case 65: /* table_elem: table_constraint  */
-#line 723 "bison_parser.y"
+#line 738 "bison_parser.y"
                    { (yyval.table_element_t) = (yyvsp[0].table_constraint_t); }
-#line 4000 "bison_parser.cpp"
+#line 4008 "bison_parser.cpp"
     break;
 
   case 66: /* column_def: IDENTIFIER column_type opt_column_constraints  */
-#line 725 "bison_parser.y"
+#line 740 "bison_parser.y"
                                                            {
   (yyval.column_t) = new ColumnDefinition((yyvsp[-2].sval), (yyvsp[-1].column_type_t), (yyvsp[0].column_constraints_t)->constraints, (yyvsp[0].column_constraints_t)->references);
   if (!(yyval.column_t)->trySetNullableExplicit()) {
@@ -4008,192 +4016,192 @@ yyreduce:
   }
   delete (yyvsp[0].column_constraints_t);
 }
-#line 4012 "bison_parser.cpp"
+#line 4020 "bison_parser.cpp"
     break;
 
   case 67: /* column_type: BIGINT  */
-#line 733 "bison_parser.y"
+#line 748 "bison_parser.y"
                      { (yyval.column_type_t) = ColumnType{DataType::BIGINT}; }
-#line 4018 "bison_parser.cpp"
+#line 4026 "bison_parser.cpp"
     break;
 
   case 68: /* column_type: BOOLEAN  */
-#line 734 "bison_parser.y"
+#line 749 "bison_parser.y"
           { (yyval.column_type_t) = ColumnType{DataType::BOOLEAN}; }
-#line 4024 "bison_parser.cpp"
+#line 4032 "bison_parser.cpp"
     break;
 
   case 69: /* column_type: CHAR '(' INTVAL ')'  */
-#line 735 "bison_parser.y"
+#line 750 "bison_parser.y"
                       { (yyval.column_type_t) = ColumnType{DataType::CHAR, (yyvsp[-1].ival)}; }
-#line 4030 "bison_parser.cpp"
+#line 4038 "bison_parser.cpp"
     break;
 
   case 70: /* column_type: CHARACTER_VARYING '(' INTVAL ')'  */
-#line 736 "bison_parser.y"
+#line 751 "bison_parser.y"
                                    { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
-#line 4036 "bison_parser.cpp"
+#line 4044 "bison_parser.cpp"
     break;
 
   case 71: /* column_type: DATE  */
-#line 737 "bison_parser.y"
+#line 752 "bison_parser.y"
        { (yyval.column_type_t) = ColumnType{DataType::DATE}; }
-#line 4042 "bison_parser.cpp"
+#line 4050 "bison_parser.cpp"
     break;
 
   case 72: /* column_type: DATETIME  */
-#line 738 "bison_parser.y"
+#line 753 "bison_parser.y"
            { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
-#line 4048 "bison_parser.cpp"
+#line 4056 "bison_parser.cpp"
     break;
 
   case 73: /* column_type: DECIMAL opt_decimal_specification  */
-#line 739 "bison_parser.y"
+#line 754 "bison_parser.y"
                                     {
   (yyval.column_type_t) = ColumnType{DataType::DECIMAL, 0, (yyvsp[0].ival_pair)->first, (yyvsp[0].ival_pair)->second};
   delete (yyvsp[0].ival_pair);
 }
-#line 4057 "bison_parser.cpp"
+#line 4065 "bison_parser.cpp"
     break;
 
   case 74: /* column_type: DOUBLE  */
-#line 743 "bison_parser.y"
+#line 758 "bison_parser.y"
          { (yyval.column_type_t) = ColumnType{DataType::DOUBLE}; }
-#line 4063 "bison_parser.cpp"
+#line 4071 "bison_parser.cpp"
     break;
 
   case 75: /* column_type: FLOAT  */
-#line 744 "bison_parser.y"
+#line 759 "bison_parser.y"
         { (yyval.column_type_t) = ColumnType{DataType::FLOAT}; }
-#line 4069 "bison_parser.cpp"
+#line 4077 "bison_parser.cpp"
     break;
 
   case 76: /* column_type: INT  */
-#line 745 "bison_parser.y"
+#line 760 "bison_parser.y"
       { (yyval.column_type_t) = ColumnType{DataType::INT}; }
-#line 4075 "bison_parser.cpp"
+#line 4083 "bison_parser.cpp"
     break;
 
   case 77: /* column_type: INTEGER  */
-#line 746 "bison_parser.y"
+#line 761 "bison_parser.y"
           { (yyval.column_type_t) = ColumnType{DataType::INT}; }
-#line 4081 "bison_parser.cpp"
+#line 4089 "bison_parser.cpp"
     break;
 
   case 78: /* column_type: LONG  */
-#line 747 "bison_parser.y"
+#line 762 "bison_parser.y"
        { (yyval.column_type_t) = ColumnType{DataType::LONG}; }
-#line 4087 "bison_parser.cpp"
+#line 4095 "bison_parser.cpp"
     break;
 
   case 79: /* column_type: REAL  */
-#line 748 "bison_parser.y"
+#line 763 "bison_parser.y"
        { (yyval.column_type_t) = ColumnType{DataType::REAL}; }
-#line 4093 "bison_parser.cpp"
+#line 4101 "bison_parser.cpp"
     break;
 
   case 80: /* column_type: SMALLINT  */
-#line 749 "bison_parser.y"
+#line 764 "bison_parser.y"
            { (yyval.column_type_t) = ColumnType{DataType::SMALLINT}; }
-#line 4099 "bison_parser.cpp"
+#line 4107 "bison_parser.cpp"
     break;
 
   case 81: /* column_type: TEXT  */
-#line 750 "bison_parser.y"
+#line 765 "bison_parser.y"
        { (yyval.column_type_t) = ColumnType{DataType::TEXT}; }
-#line 4105 "bison_parser.cpp"
+#line 4113 "bison_parser.cpp"
     break;
 
   case 82: /* column_type: TIME opt_time_precision  */
-#line 751 "bison_parser.y"
+#line 766 "bison_parser.y"
                           { (yyval.column_type_t) = ColumnType{DataType::TIME, 0, (yyvsp[0].ival)}; }
-#line 4111 "bison_parser.cpp"
+#line 4119 "bison_parser.cpp"
     break;
 
   case 83: /* column_type: TIMESTAMP  */
-#line 752 "bison_parser.y"
+#line 767 "bison_parser.y"
             { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
-#line 4117 "bison_parser.cpp"
+#line 4125 "bison_parser.cpp"
     break;
 
   case 84: /* column_type: VARCHAR '(' INTVAL ')'  */
-#line 753 "bison_parser.y"
+#line 768 "bison_parser.y"
                          { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
-#line 4123 "bison_parser.cpp"
+#line 4131 "bison_parser.cpp"
     break;
 
   case 85: /* opt_time_precision: '(' INTVAL ')'  */
-#line 755 "bison_parser.y"
+#line 770 "bison_parser.y"
                                     { (yyval.ival) = (yyvsp[-1].ival); }
-#line 4129 "bison_parser.cpp"
+#line 4137 "bison_parser.cpp"
     break;
 
   case 86: /* opt_time_precision: %empty  */
-#line 756 "bison_parser.y"
+#line 771 "bison_parser.y"
               { (yyval.ival) = 0; }
-#line 4135 "bison_parser.cpp"
+#line 4143 "bison_parser.cpp"
     break;
 
   case 87: /* opt_decimal_specification: '(' INTVAL ',' INTVAL ')'  */
-#line 758 "bison_parser.y"
+#line 773 "bison_parser.y"
                                                       { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-3].ival), (yyvsp[-1].ival)}; }
-#line 4141 "bison_parser.cpp"
+#line 4149 "bison_parser.cpp"
     break;
 
   case 88: /* opt_decimal_specification: '(' INTVAL ')'  */
-#line 759 "bison_parser.y"
+#line 774 "bison_parser.y"
                  { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-1].ival), 0}; }
-#line 4147 "bison_parser.cpp"
+#line 4155 "bison_parser.cpp"
     break;
 
   case 89: /* opt_decimal_specification: %empty  */
-#line 760 "bison_parser.y"
+#line 775 "bison_parser.y"
               { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{0, 0}; }
-#line 4153 "bison_parser.cpp"
+#line 4161 "bison_parser.cpp"
     break;
 
   case 90: /* opt_column_constraints: column_constraints  */
-#line 762 "bison_parser.y"
+#line 777 "bison_parser.y"
                                             { (yyval.column_constraints_t) = (yyvsp[0].column_constraints_t); }
-#line 4159 "bison_parser.cpp"
+#line 4167 "bison_parser.cpp"
     break;
 
   case 91: /* opt_column_constraints: %empty  */
-#line 763 "bison_parser.y"
+#line 778 "bison_parser.y"
               { (yyval.column_constraints_t) = new ColumnConstraints(); }
-#line 4165 "bison_parser.cpp"
+#line 4173 "bison_parser.cpp"
     break;
 
   case 92: /* column_constraints: column_constraint  */
-#line 765 "bison_parser.y"
+#line 780 "bison_parser.y"
                                        {
   (yyval.column_constraints_t) = new ColumnConstraints();
   (yyval.column_constraints_t)->constraints->insert((yyvsp[0].column_constraint_t));
 }
-#line 4174 "bison_parser.cpp"
+#line 4182 "bison_parser.cpp"
     break;
 
   case 93: /* column_constraints: column_constraints column_constraint  */
-#line 769 "bison_parser.y"
+#line 784 "bison_parser.y"
                                        {
   (yyvsp[-1].column_constraints_t)->constraints->insert((yyvsp[0].column_constraint_t));
   (yyval.column_constraints_t) = (yyvsp[-1].column_constraints_t);
 }
-#line 4183 "bison_parser.cpp"
+#line 4191 "bison_parser.cpp"
     break;
 
   case 94: /* column_constraints: references_spec  */
-#line 773 "bison_parser.y"
+#line 788 "bison_parser.y"
                   {
   (yyval.column_constraints_t) = new ColumnConstraints();
   (yyval.column_constraints_t)->constraints->insert(ConstraintType::ForeignKey);
   (yyval.column_constraints_t)->references->emplace_back((yyvsp[0].references_spec_t));
 }
-#line 4193 "bison_parser.cpp"
+#line 4201 "bison_parser.cpp"
     break;
 
   case 95: /* column_constraints: column_constraints references_spec  */
-#line 778 "bison_parser.y"
+#line 793 "bison_parser.y"
                                      {
   // Multiple foreign keys for the same column could be possible, so we do not raise an error in that case.
   // Think of foreign keys referenced on multiple levels (returned item references sold item references items).
@@ -4201,159 +4209,159 @@ yyreduce:
   (yyvsp[-1].column_constraints_t)->references->emplace_back((yyvsp[0].references_spec_t));
   (yyval.column_constraints_t) = (yyvsp[-1].column_constraints_t);
 }
-#line 4205 "bison_parser.cpp"
+#line 4213 "bison_parser.cpp"
     break;
 
   case 96: /* column_constraint: PRIMARY KEY  */
-#line 786 "bison_parser.y"
+#line 801 "bison_parser.y"
                                 { (yyval.column_constraint_t) = ConstraintType::PrimaryKey; }
-#line 4211 "bison_parser.cpp"
+#line 4219 "bison_parser.cpp"
     break;
 
   case 97: /* column_constraint: UNIQUE  */
-#line 787 "bison_parser.y"
+#line 802 "bison_parser.y"
          { (yyval.column_constraint_t) = ConstraintType::Unique; }
-#line 4217 "bison_parser.cpp"
+#line 4225 "bison_parser.cpp"
     break;
 
   case 98: /* column_constraint: NULL  */
-#line 788 "bison_parser.y"
+#line 803 "bison_parser.y"
        { (yyval.column_constraint_t) = ConstraintType::Null; }
-#line 4223 "bison_parser.cpp"
+#line 4231 "bison_parser.cpp"
     break;
 
   case 99: /* column_constraint: NOT NULL  */
-#line 789 "bison_parser.y"
+#line 804 "bison_parser.y"
            { (yyval.column_constraint_t) = ConstraintType::NotNull; }
-#line 4229 "bison_parser.cpp"
+#line 4237 "bison_parser.cpp"
     break;
 
   case 100: /* table_constraint: PRIMARY KEY '(' ident_commalist ')'  */
-#line 791 "bison_parser.y"
+#line 806 "bison_parser.y"
                                                        { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::PrimaryKey, (yyvsp[-1].str_vec)); }
-#line 4235 "bison_parser.cpp"
+#line 4243 "bison_parser.cpp"
     break;
 
   case 101: /* table_constraint: UNIQUE '(' ident_commalist ')'  */
-#line 792 "bison_parser.y"
+#line 807 "bison_parser.y"
                                  { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::Unique, (yyvsp[-1].str_vec)); }
-#line 4241 "bison_parser.cpp"
+#line 4249 "bison_parser.cpp"
     break;
 
   case 102: /* table_constraint: FOREIGN KEY '(' ident_commalist ')' references_spec  */
-#line 793 "bison_parser.y"
+#line 808 "bison_parser.y"
                                                       { (yyval.table_constraint_t) = new ForeignKeyConstraint((yyvsp[-2].str_vec), (yyvsp[0].references_spec_t)); }
-#line 4247 "bison_parser.cpp"
+#line 4255 "bison_parser.cpp"
     break;
 
   case 103: /* references_spec: REFERENCES table_name opt_column_list  */
-#line 795 "bison_parser.y"
+#line 810 "bison_parser.y"
                                                         { (yyval.references_spec_t) = new ReferencesSpecification((yyvsp[-1].table_name).schema, (yyvsp[-1].table_name).name, (yyvsp[0].str_vec)); }
-#line 4253 "bison_parser.cpp"
+#line 4261 "bison_parser.cpp"
     break;
 
   case 104: /* drop_statement: DROP TABLE opt_exists table_name  */
-#line 803 "bison_parser.y"
+#line 818 "bison_parser.y"
                                                   {
   (yyval.drop_stmt) = new DropStatement(kDropTable);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.drop_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 4264 "bison_parser.cpp"
+#line 4272 "bison_parser.cpp"
     break;
 
   case 105: /* drop_statement: DROP VIEW opt_exists table_name  */
-#line 809 "bison_parser.y"
+#line 824 "bison_parser.y"
                                   {
   (yyval.drop_stmt) = new DropStatement(kDropView);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.drop_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 4275 "bison_parser.cpp"
+#line 4283 "bison_parser.cpp"
     break;
 
   case 106: /* drop_statement: DEALLOCATE PREPARE IDENTIFIER  */
-#line 815 "bison_parser.y"
+#line 830 "bison_parser.y"
                                 {
   (yyval.drop_stmt) = new DropStatement(kDropPreparedStatement);
   (yyval.drop_stmt)->ifExists = false;
   (yyval.drop_stmt)->name = (yyvsp[0].sval);
 }
-#line 4285 "bison_parser.cpp"
+#line 4293 "bison_parser.cpp"
     break;
 
   case 107: /* drop_statement: DROP INDEX opt_exists IDENTIFIER  */
-#line 821 "bison_parser.y"
+#line 836 "bison_parser.y"
                                    {
   (yyval.drop_stmt) = new DropStatement(kDropIndex);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->indexName = (yyvsp[0].sval);
 }
-#line 4295 "bison_parser.cpp"
+#line 4303 "bison_parser.cpp"
     break;
 
   case 108: /* opt_exists: IF EXISTS  */
-#line 827 "bison_parser.y"
+#line 842 "bison_parser.y"
                        { (yyval.bval) = true; }
-#line 4301 "bison_parser.cpp"
+#line 4309 "bison_parser.cpp"
     break;
 
   case 109: /* opt_exists: %empty  */
-#line 828 "bison_parser.y"
+#line 843 "bison_parser.y"
               { (yyval.bval) = false; }
-#line 4307 "bison_parser.cpp"
+#line 4315 "bison_parser.cpp"
     break;
 
   case 110: /* alter_statement: ALTER TABLE opt_exists table_name alter_action  */
-#line 835 "bison_parser.y"
+#line 850 "bison_parser.y"
                                                                  {
   (yyval.alter_stmt) = new AlterStatement((yyvsp[-1].table_name).name, (yyvsp[0].alter_action_t));
   (yyval.alter_stmt)->ifTableExists = (yyvsp[-2].bval);
   (yyval.alter_stmt)->schema = (yyvsp[-1].table_name).schema;
 }
-#line 4317 "bison_parser.cpp"
+#line 4325 "bison_parser.cpp"
     break;
 
   case 111: /* alter_action: drop_action  */
-#line 841 "bison_parser.y"
+#line 856 "bison_parser.y"
                            { (yyval.alter_action_t) = (yyvsp[0].drop_action_t); }
-#line 4323 "bison_parser.cpp"
+#line 4331 "bison_parser.cpp"
     break;
 
   case 112: /* drop_action: DROP COLUMN opt_exists IDENTIFIER  */
-#line 843 "bison_parser.y"
+#line 858 "bison_parser.y"
                                                 {
   (yyval.drop_action_t) = new DropColumnAction((yyvsp[0].sval));
   (yyval.drop_action_t)->ifExists = (yyvsp[-1].bval);
 }
-#line 4332 "bison_parser.cpp"
+#line 4340 "bison_parser.cpp"
     break;
 
   case 113: /* delete_statement: DELETE FROM table_name opt_where  */
-#line 853 "bison_parser.y"
+#line 868 "bison_parser.y"
                                                     {
   (yyval.delete_stmt) = new DeleteStatement();
   (yyval.delete_stmt)->schema = (yyvsp[-1].table_name).schema;
   (yyval.delete_stmt)->tableName = (yyvsp[-1].table_name).name;
   (yyval.delete_stmt)->expr = (yyvsp[0].expr);
 }
-#line 4343 "bison_parser.cpp"
+#line 4351 "bison_parser.cpp"
     break;
 
   case 114: /* truncate_statement: TRUNCATE table_name  */
-#line 860 "bison_parser.y"
+#line 875 "bison_parser.y"
                                          {
   (yyval.delete_stmt) = new DeleteStatement();
   (yyval.delete_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.delete_stmt)->tableName = (yyvsp[0].table_name).name;
 }
-#line 4353 "bison_parser.cpp"
+#line 4361 "bison_parser.cpp"
     break;
 
   case 115: /* insert_statement: INSERT INTO table_name opt_column_list VALUES '(' extended_literal_list ')'  */
-#line 871 "bison_parser.y"
+#line 886 "bison_parser.y"
                                                                                                {
   (yyval.insert_stmt) = new InsertStatement(kInsertValues);
   (yyval.insert_stmt)->schema = (yyvsp[-5].table_name).schema;
@@ -4361,11 +4369,11 @@ yyreduce:
   (yyval.insert_stmt)->columns = (yyvsp[-4].str_vec);
   (yyval.insert_stmt)->values = (yyvsp[-1].expr_vec);
 }
-#line 4365 "bison_parser.cpp"
+#line 4373 "bison_parser.cpp"
     break;
 
   case 116: /* insert_statement: INSERT INTO table_name opt_column_list select_no_paren  */
-#line 878 "bison_parser.y"
+#line 893 "bison_parser.y"
                                                          {
   (yyval.insert_stmt) = new InsertStatement(kInsertSelect);
   (yyval.insert_stmt)->schema = (yyvsp[-2].table_name).schema;
@@ -4373,80 +4381,80 @@ yyreduce:
   (yyval.insert_stmt)->columns = (yyvsp[-1].str_vec);
   (yyval.insert_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 4377 "bison_parser.cpp"
+#line 4385 "bison_parser.cpp"
     break;
 
   case 117: /* opt_column_list: '(' ident_commalist ')'  */
-#line 886 "bison_parser.y"
+#line 901 "bison_parser.y"
                                           { (yyval.str_vec) = (yyvsp[-1].str_vec); }
-#line 4383 "bison_parser.cpp"
+#line 4391 "bison_parser.cpp"
     break;
 
   case 118: /* opt_column_list: %empty  */
-#line 887 "bison_parser.y"
+#line 902 "bison_parser.y"
               { (yyval.str_vec) = nullptr; }
-#line 4389 "bison_parser.cpp"
+#line 4397 "bison_parser.cpp"
     break;
 
   case 119: /* update_statement: UPDATE table_ref_name_no_alias SET update_clause_commalist opt_where  */
-#line 894 "bison_parser.y"
+#line 909 "bison_parser.y"
                                                                                         {
   (yyval.update_stmt) = new UpdateStatement();
   (yyval.update_stmt)->table = (yyvsp[-3].table);
   (yyval.update_stmt)->updates = (yyvsp[-1].update_vec);
   (yyval.update_stmt)->where = (yyvsp[0].expr);
 }
-#line 4400 "bison_parser.cpp"
+#line 4408 "bison_parser.cpp"
     break;
 
   case 120: /* update_clause_commalist: update_clause  */
-#line 901 "bison_parser.y"
+#line 916 "bison_parser.y"
                                         {
   (yyval.update_vec) = new std::vector<UpdateClause*>();
   (yyval.update_vec)->push_back((yyvsp[0].update_t));
 }
-#line 4409 "bison_parser.cpp"
+#line 4417 "bison_parser.cpp"
     break;
 
   case 121: /* update_clause_commalist: update_clause_commalist ',' update_clause  */
-#line 905 "bison_parser.y"
+#line 920 "bison_parser.y"
                                             {
   (yyvsp[-2].update_vec)->push_back((yyvsp[0].update_t));
   (yyval.update_vec) = (yyvsp[-2].update_vec);
 }
-#line 4418 "bison_parser.cpp"
+#line 4426 "bison_parser.cpp"
     break;
 
   case 122: /* update_clause: IDENTIFIER '=' expr  */
-#line 910 "bison_parser.y"
+#line 925 "bison_parser.y"
                                     {
   (yyval.update_t) = new UpdateClause();
   (yyval.update_t)->column = (yyvsp[-2].sval);
   (yyval.update_t)->value = (yyvsp[0].expr);
 }
-#line 4428 "bison_parser.cpp"
+#line 4436 "bison_parser.cpp"
     break;
 
   case 123: /* select_statement: opt_with_clause select_with_paren  */
-#line 920 "bison_parser.y"
+#line 935 "bison_parser.y"
                                                      {
   (yyval.select_stmt) = (yyvsp[0].select_stmt);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-1].with_description_vec);
 }
-#line 4437 "bison_parser.cpp"
+#line 4445 "bison_parser.cpp"
     break;
 
   case 124: /* select_statement: opt_with_clause select_no_paren  */
-#line 924 "bison_parser.y"
+#line 939 "bison_parser.y"
                                   {
   (yyval.select_stmt) = (yyvsp[0].select_stmt);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-1].with_description_vec);
 }
-#line 4446 "bison_parser.cpp"
+#line 4454 "bison_parser.cpp"
     break;
 
   case 125: /* select_statement: opt_with_clause select_with_paren set_operator select_within_set_operation opt_order opt_limit  */
-#line 928 "bison_parser.y"
+#line 943 "bison_parser.y"
                                                                                                  {
   (yyval.select_stmt) = (yyvsp[-4].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
@@ -4458,17 +4466,17 @@ yyreduce:
   (yyval.select_stmt)->setOperations->back()->resultLimit = (yyvsp[0].limit);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-5].with_description_vec);
 }
-#line 4462 "bison_parser.cpp"
+#line 4470 "bison_parser.cpp"
     break;
 
   case 128: /* select_within_set_operation_no_parentheses: select_clause  */
-#line 942 "bison_parser.y"
+#line 957 "bison_parser.y"
                                                            { (yyval.select_stmt) = (yyvsp[0].select_stmt); }
-#line 4468 "bison_parser.cpp"
+#line 4476 "bison_parser.cpp"
     break;
 
   case 129: /* select_within_set_operation_no_parentheses: select_clause set_operator select_within_set_operation  */
-#line 943 "bison_parser.y"
+#line 958 "bison_parser.y"
                                                          {
   (yyval.select_stmt) = (yyvsp[-2].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
@@ -4477,23 +4485,23 @@ yyreduce:
   (yyval.select_stmt)->setOperations->push_back((yyvsp[-1].set_operator_t));
   (yyval.select_stmt)->setOperations->back()->nestedSelectStatement = (yyvsp[0].select_stmt);
 }
-#line 4481 "bison_parser.cpp"
+#line 4489 "bison_parser.cpp"
     break;
 
   case 130: /* select_with_paren: '(' select_no_paren ')'  */
-#line 952 "bison_parser.y"
+#line 967 "bison_parser.y"
                                             { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 4487 "bison_parser.cpp"
+#line 4495 "bison_parser.cpp"
     break;
 
   case 131: /* select_with_paren: '(' select_with_paren ')'  */
-#line 953 "bison_parser.y"
+#line 968 "bison_parser.y"
                             { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 4493 "bison_parser.cpp"
+#line 4501 "bison_parser.cpp"
     break;
 
   case 132: /* select_no_paren: select_clause opt_order opt_limit opt_locking_clause  */
-#line 955 "bison_parser.y"
+#line 970 "bison_parser.y"
                                                                        {
   (yyval.select_stmt) = (yyvsp[-3].select_stmt);
   (yyval.select_stmt)->order = (yyvsp[-2].order_vec);
@@ -4508,11 +4516,11 @@ yyreduce:
     (yyval.select_stmt)->lockings = (yyvsp[0].locking_clause_vec);
   }
 }
-#line 4512 "bison_parser.cpp"
+#line 4520 "bison_parser.cpp"
     break;
 
   case 133: /* select_no_paren: select_clause set_operator select_within_set_operation opt_order opt_limit opt_locking_clause  */
-#line 969 "bison_parser.y"
+#line 984 "bison_parser.y"
                                                                                                 {
   (yyval.select_stmt) = (yyvsp[-5].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
@@ -4524,59 +4532,59 @@ yyreduce:
   (yyval.select_stmt)->setOperations->back()->resultLimit = (yyvsp[-1].limit);
   (yyval.select_stmt)->lockings = (yyvsp[0].locking_clause_vec);
 }
-#line 4528 "bison_parser.cpp"
+#line 4536 "bison_parser.cpp"
     break;
 
   case 134: /* set_operator: set_type opt_all  */
-#line 981 "bison_parser.y"
+#line 996 "bison_parser.y"
                                 {
   (yyval.set_operator_t) = (yyvsp[-1].set_operator_t);
   (yyval.set_operator_t)->isAll = (yyvsp[0].bval);
 }
-#line 4537 "bison_parser.cpp"
+#line 4545 "bison_parser.cpp"
     break;
 
   case 135: /* set_type: UNION  */
-#line 986 "bison_parser.y"
+#line 1001 "bison_parser.y"
                  {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetUnion;
 }
-#line 4546 "bison_parser.cpp"
+#line 4554 "bison_parser.cpp"
     break;
 
   case 136: /* set_type: INTERSECT  */
-#line 990 "bison_parser.y"
+#line 1005 "bison_parser.y"
             {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetIntersect;
 }
-#line 4555 "bison_parser.cpp"
+#line 4563 "bison_parser.cpp"
     break;
 
   case 137: /* set_type: EXCEPT  */
-#line 994 "bison_parser.y"
+#line 1009 "bison_parser.y"
          {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetExcept;
 }
-#line 4564 "bison_parser.cpp"
+#line 4572 "bison_parser.cpp"
     break;
 
   case 138: /* opt_all: ALL  */
-#line 999 "bison_parser.y"
+#line 1014 "bison_parser.y"
               { (yyval.bval) = true; }
-#line 4570 "bison_parser.cpp"
+#line 4578 "bison_parser.cpp"
     break;
 
   case 139: /* opt_all: %empty  */
-#line 1000 "bison_parser.y"
+#line 1015 "bison_parser.y"
               { (yyval.bval) = false; }
-#line 4576 "bison_parser.cpp"
+#line 4584 "bison_parser.cpp"
     break;
 
   case 140: /* select_clause: SELECT opt_top opt_distinct select_list opt_from_clause opt_where opt_group  */
-#line 1002 "bison_parser.y"
+#line 1017 "bison_parser.y"
                                                                                             {
   (yyval.select_stmt) = new SelectStatement();
   (yyval.select_stmt)->limit = (yyvsp[-5].limit);
@@ -4586,141 +4594,141 @@ yyreduce:
   (yyval.select_stmt)->whereClause = (yyvsp[-1].expr);
   (yyval.select_stmt)->groupBy = (yyvsp[0].group_t);
 }
-#line 4590 "bison_parser.cpp"
+#line 4598 "bison_parser.cpp"
     break;
 
   case 141: /* opt_distinct: DISTINCT  */
-#line 1012 "bison_parser.y"
+#line 1027 "bison_parser.y"
                         { (yyval.bval) = true; }
-#line 4596 "bison_parser.cpp"
+#line 4604 "bison_parser.cpp"
     break;
 
   case 142: /* opt_distinct: %empty  */
-#line 1013 "bison_parser.y"
+#line 1028 "bison_parser.y"
               { (yyval.bval) = false; }
-#line 4602 "bison_parser.cpp"
+#line 4610 "bison_parser.cpp"
     break;
 
   case 144: /* opt_from_clause: from_clause  */
-#line 1017 "bison_parser.y"
+#line 1032 "bison_parser.y"
                               { (yyval.table) = (yyvsp[0].table); }
-#line 4608 "bison_parser.cpp"
+#line 4616 "bison_parser.cpp"
     break;
 
   case 145: /* opt_from_clause: %empty  */
-#line 1018 "bison_parser.y"
+#line 1033 "bison_parser.y"
               { (yyval.table) = nullptr; }
-#line 4614 "bison_parser.cpp"
+#line 4622 "bison_parser.cpp"
     break;
 
   case 146: /* from_clause: FROM table_ref  */
-#line 1020 "bison_parser.y"
+#line 1035 "bison_parser.y"
                              { (yyval.table) = (yyvsp[0].table); }
-#line 4620 "bison_parser.cpp"
+#line 4628 "bison_parser.cpp"
     break;
 
   case 147: /* opt_where: WHERE expr  */
-#line 1022 "bison_parser.y"
+#line 1037 "bison_parser.y"
                        { (yyval.expr) = (yyvsp[0].expr); }
-#line 4626 "bison_parser.cpp"
+#line 4634 "bison_parser.cpp"
     break;
 
   case 148: /* opt_where: %empty  */
-#line 1023 "bison_parser.y"
+#line 1038 "bison_parser.y"
               { (yyval.expr) = nullptr; }
-#line 4632 "bison_parser.cpp"
+#line 4640 "bison_parser.cpp"
     break;
 
   case 149: /* opt_group: GROUP BY expr_list opt_having  */
-#line 1025 "bison_parser.y"
+#line 1040 "bison_parser.y"
                                           {
   (yyval.group_t) = new GroupByDescription();
   (yyval.group_t)->columns = (yyvsp[-1].expr_vec);
   (yyval.group_t)->having = (yyvsp[0].expr);
 }
-#line 4642 "bison_parser.cpp"
+#line 4650 "bison_parser.cpp"
     break;
 
   case 150: /* opt_group: %empty  */
-#line 1030 "bison_parser.y"
+#line 1045 "bison_parser.y"
               { (yyval.group_t) = nullptr; }
-#line 4648 "bison_parser.cpp"
+#line 4656 "bison_parser.cpp"
     break;
 
   case 151: /* opt_having: HAVING expr  */
-#line 1032 "bison_parser.y"
+#line 1047 "bison_parser.y"
                          { (yyval.expr) = (yyvsp[0].expr); }
-#line 4654 "bison_parser.cpp"
+#line 4662 "bison_parser.cpp"
     break;
 
   case 152: /* opt_having: %empty  */
-#line 1033 "bison_parser.y"
+#line 1048 "bison_parser.y"
               { (yyval.expr) = nullptr; }
-#line 4660 "bison_parser.cpp"
+#line 4668 "bison_parser.cpp"
     break;
 
   case 153: /* opt_order: ORDER BY order_list  */
-#line 1035 "bison_parser.y"
+#line 1050 "bison_parser.y"
                                 { (yyval.order_vec) = (yyvsp[0].order_vec); }
-#line 4666 "bison_parser.cpp"
+#line 4674 "bison_parser.cpp"
     break;
 
   case 154: /* opt_order: %empty  */
-#line 1036 "bison_parser.y"
+#line 1051 "bison_parser.y"
               { (yyval.order_vec) = nullptr; }
-#line 4672 "bison_parser.cpp"
+#line 4680 "bison_parser.cpp"
     break;
 
   case 155: /* order_list: order_desc  */
-#line 1038 "bison_parser.y"
+#line 1053 "bison_parser.y"
                         {
   (yyval.order_vec) = new std::vector<OrderDescription*>();
   (yyval.order_vec)->push_back((yyvsp[0].order));
 }
-#line 4681 "bison_parser.cpp"
+#line 4689 "bison_parser.cpp"
     break;
 
   case 156: /* order_list: order_list ',' order_desc  */
-#line 1042 "bison_parser.y"
+#line 1057 "bison_parser.y"
                             {
   (yyvsp[-2].order_vec)->push_back((yyvsp[0].order));
   (yyval.order_vec) = (yyvsp[-2].order_vec);
 }
-#line 4690 "bison_parser.cpp"
+#line 4698 "bison_parser.cpp"
     break;
 
   case 157: /* order_desc: expr opt_order_type opt_null_ordering  */
-#line 1047 "bison_parser.y"
+#line 1062 "bison_parser.y"
                                                    { (yyval.order) = new OrderDescription((yyvsp[-1].order_type), (yyvsp[-2].expr), (yyvsp[0].null_ordering_t)); }
-#line 4696 "bison_parser.cpp"
+#line 4704 "bison_parser.cpp"
     break;
 
   case 158: /* opt_order_type: ASC  */
-#line 1049 "bison_parser.y"
+#line 1064 "bison_parser.y"
                      { (yyval.order_type) = kOrderAsc; }
-#line 4702 "bison_parser.cpp"
+#line 4710 "bison_parser.cpp"
     break;
 
   case 159: /* opt_order_type: DESC  */
-#line 1050 "bison_parser.y"
+#line 1065 "bison_parser.y"
        { (yyval.order_type) = kOrderDesc; }
-#line 4708 "bison_parser.cpp"
+#line 4716 "bison_parser.cpp"
     break;
 
   case 160: /* opt_order_type: %empty  */
-#line 1051 "bison_parser.y"
+#line 1066 "bison_parser.y"
               { (yyval.order_type) = kOrderAsc; }
-#line 4714 "bison_parser.cpp"
+#line 4722 "bison_parser.cpp"
     break;
 
   case 161: /* opt_null_ordering: %empty  */
-#line 1053 "bison_parser.y"
+#line 1068 "bison_parser.y"
                                 { (yyval.null_ordering_t) = NullOrdering::Undefined; }
-#line 4720 "bison_parser.cpp"
+#line 4728 "bison_parser.cpp"
     break;
 
   case 162: /* opt_null_ordering: IDENTIFIER IDENTIFIER  */
-#line 1054 "bison_parser.y"
+#line 1069 "bison_parser.y"
                         {
   auto null_ordering = NullOrdering::Undefined;
   if (strcasecmp((yyvsp[-1].sval), "nulls") == 0) {
@@ -4740,133 +4748,133 @@ yyreduce:
 
   (yyval.null_ordering_t) = null_ordering;
 }
-#line 4744 "bison_parser.cpp"
+#line 4752 "bison_parser.cpp"
     break;
 
   case 163: /* opt_top: TOP int_literal  */
-#line 1076 "bison_parser.y"
+#line 1091 "bison_parser.y"
                           { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
-#line 4750 "bison_parser.cpp"
+#line 4758 "bison_parser.cpp"
     break;
 
   case 164: /* opt_top: %empty  */
-#line 1077 "bison_parser.y"
+#line 1092 "bison_parser.y"
               { (yyval.limit) = nullptr; }
-#line 4756 "bison_parser.cpp"
+#line 4764 "bison_parser.cpp"
     break;
 
   case 165: /* opt_limit: LIMIT expr  */
-#line 1079 "bison_parser.y"
+#line 1094 "bison_parser.y"
                        { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
-#line 4762 "bison_parser.cpp"
+#line 4770 "bison_parser.cpp"
     break;
 
   case 166: /* opt_limit: OFFSET expr  */
-#line 1080 "bison_parser.y"
+#line 1095 "bison_parser.y"
               { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
-#line 4768 "bison_parser.cpp"
+#line 4776 "bison_parser.cpp"
     break;
 
   case 167: /* opt_limit: LIMIT expr OFFSET expr  */
-#line 1081 "bison_parser.y"
+#line 1096 "bison_parser.y"
                          { (yyval.limit) = new LimitDescription((yyvsp[-2].expr), (yyvsp[0].expr)); }
-#line 4774 "bison_parser.cpp"
+#line 4782 "bison_parser.cpp"
     break;
 
   case 168: /* opt_limit: LIMIT ALL  */
-#line 1082 "bison_parser.y"
+#line 1097 "bison_parser.y"
             { (yyval.limit) = new LimitDescription(nullptr, nullptr); }
-#line 4780 "bison_parser.cpp"
+#line 4788 "bison_parser.cpp"
     break;
 
   case 169: /* opt_limit: LIMIT ALL OFFSET expr  */
-#line 1083 "bison_parser.y"
+#line 1098 "bison_parser.y"
                         { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
-#line 4786 "bison_parser.cpp"
+#line 4794 "bison_parser.cpp"
     break;
 
   case 170: /* opt_limit: %empty  */
-#line 1084 "bison_parser.y"
+#line 1099 "bison_parser.y"
               { (yyval.limit) = nullptr; }
-#line 4792 "bison_parser.cpp"
+#line 4800 "bison_parser.cpp"
     break;
 
   case 171: /* expr_list: expr_alias  */
-#line 1089 "bison_parser.y"
+#line 1104 "bison_parser.y"
                        {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 4801 "bison_parser.cpp"
+#line 4809 "bison_parser.cpp"
     break;
 
   case 172: /* expr_list: expr_list ',' expr_alias  */
-#line 1093 "bison_parser.y"
+#line 1108 "bison_parser.y"
                            {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 4810 "bison_parser.cpp"
+#line 4818 "bison_parser.cpp"
     break;
 
   case 173: /* opt_extended_literal_list: extended_literal_list  */
-#line 1099 "bison_parser.y"
+#line 1114 "bison_parser.y"
                                                   { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
-#line 4816 "bison_parser.cpp"
+#line 4824 "bison_parser.cpp"
     break;
 
   case 174: /* opt_extended_literal_list: %empty  */
-#line 1100 "bison_parser.y"
+#line 1115 "bison_parser.y"
               { (yyval.expr_vec) = nullptr; }
-#line 4822 "bison_parser.cpp"
+#line 4830 "bison_parser.cpp"
     break;
 
   case 175: /* extended_literal_list: casted_extended_literal  */
-#line 1102 "bison_parser.y"
+#line 1117 "bison_parser.y"
                                                 {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 4831 "bison_parser.cpp"
+#line 4839 "bison_parser.cpp"
     break;
 
   case 176: /* extended_literal_list: extended_literal_list ',' casted_extended_literal  */
-#line 1106 "bison_parser.y"
+#line 1121 "bison_parser.y"
                                                     {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 4840 "bison_parser.cpp"
-    break;
-
-  case 178: /* casted_extended_literal: CAST '(' extended_literal AS column_type ')'  */
-#line 1111 "bison_parser.y"
-                                                                                          {
-  (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t));
-}
 #line 4848 "bison_parser.cpp"
     break;
 
+  case 178: /* casted_extended_literal: CAST '(' extended_literal AS column_type ')'  */
+#line 1126 "bison_parser.y"
+                                                                                          {
+  (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t));
+}
+#line 4856 "bison_parser.cpp"
+    break;
+
   case 179: /* extended_literal: literal  */
-#line 1115 "bison_parser.y"
+#line 1130 "bison_parser.y"
                            { (yyval.expr) = (yyvsp[0].expr); }
-#line 4854 "bison_parser.cpp"
+#line 4862 "bison_parser.cpp"
     break;
 
   case 180: /* extended_literal: '-' num_literal  */
-#line 1116 "bison_parser.y"
+#line 1131 "bison_parser.y"
                   { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4860 "bison_parser.cpp"
+#line 4868 "bison_parser.cpp"
     break;
 
   case 181: /* extended_literal: '-' interval_literal  */
-#line 1117 "bison_parser.y"
+#line 1132 "bison_parser.y"
                        { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4866 "bison_parser.cpp"
+#line 4874 "bison_parser.cpp"
     break;
 
   case 182: /* expr_alias: expr opt_alias  */
-#line 1119 "bison_parser.y"
+#line 1134 "bison_parser.y"
                             {
   (yyval.expr) = (yyvsp[-1].expr);
   if ((yyvsp[0].alias_t)) {
@@ -4875,523 +4883,523 @@ yyreduce:
     delete (yyvsp[0].alias_t);
   }
 }
-#line 4879 "bison_parser.cpp"
+#line 4887 "bison_parser.cpp"
     break;
 
   case 188: /* operand: '(' expr ')'  */
-#line 1130 "bison_parser.y"
+#line 1145 "bison_parser.y"
                        { (yyval.expr) = (yyvsp[-1].expr); }
-#line 4885 "bison_parser.cpp"
-    break;
-
-  case 198: /* operand: '(' select_no_paren ')'  */
-#line 1132 "bison_parser.y"
-                                         {
-  (yyval.expr) = Expr::makeSelect((yyvsp[-1].select_stmt));
-}
 #line 4893 "bison_parser.cpp"
     break;
 
+  case 198: /* operand: '(' select_no_paren ')'  */
+#line 1147 "bison_parser.y"
+                                         {
+  (yyval.expr) = Expr::makeSelect((yyvsp[-1].select_stmt));
+}
+#line 4901 "bison_parser.cpp"
+    break;
+
   case 201: /* unary_expr: '-' operand  */
-#line 1138 "bison_parser.y"
+#line 1153 "bison_parser.y"
                          { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4899 "bison_parser.cpp"
+#line 4907 "bison_parser.cpp"
     break;
 
   case 202: /* unary_expr: NOT operand  */
-#line 1139 "bison_parser.y"
+#line 1154 "bison_parser.y"
               { (yyval.expr) = Expr::makeOpUnary(kOpNot, (yyvsp[0].expr)); }
-#line 4905 "bison_parser.cpp"
+#line 4913 "bison_parser.cpp"
     break;
 
   case 203: /* unary_expr: operand ISNULL  */
-#line 1140 "bison_parser.y"
+#line 1155 "bison_parser.y"
                  { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-1].expr)); }
-#line 4911 "bison_parser.cpp"
+#line 4919 "bison_parser.cpp"
     break;
 
   case 204: /* unary_expr: operand IS NULL  */
-#line 1141 "bison_parser.y"
+#line 1156 "bison_parser.y"
                   { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-2].expr)); }
-#line 4917 "bison_parser.cpp"
+#line 4925 "bison_parser.cpp"
     break;
 
   case 205: /* unary_expr: operand IS NOT NULL  */
-#line 1142 "bison_parser.y"
+#line 1157 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeOpUnary(kOpIsNull, (yyvsp[-3].expr))); }
-#line 4923 "bison_parser.cpp"
+#line 4931 "bison_parser.cpp"
     break;
 
   case 207: /* binary_expr: operand '-' operand  */
-#line 1144 "bison_parser.y"
+#line 1159 "bison_parser.y"
                                               { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpMinus, (yyvsp[0].expr)); }
-#line 4929 "bison_parser.cpp"
+#line 4937 "bison_parser.cpp"
     break;
 
   case 208: /* binary_expr: operand '+' operand  */
-#line 1145 "bison_parser.y"
+#line 1160 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPlus, (yyvsp[0].expr)); }
-#line 4935 "bison_parser.cpp"
+#line 4943 "bison_parser.cpp"
     break;
 
   case 209: /* binary_expr: operand '/' operand  */
-#line 1146 "bison_parser.y"
+#line 1161 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpSlash, (yyvsp[0].expr)); }
-#line 4941 "bison_parser.cpp"
+#line 4949 "bison_parser.cpp"
     break;
 
   case 210: /* binary_expr: operand '*' operand  */
-#line 1147 "bison_parser.y"
+#line 1162 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAsterisk, (yyvsp[0].expr)); }
-#line 4947 "bison_parser.cpp"
+#line 4955 "bison_parser.cpp"
     break;
 
   case 211: /* binary_expr: operand '%' operand  */
-#line 1148 "bison_parser.y"
+#line 1163 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPercentage, (yyvsp[0].expr)); }
-#line 4953 "bison_parser.cpp"
+#line 4961 "bison_parser.cpp"
     break;
 
   case 212: /* binary_expr: operand '^' operand  */
-#line 1149 "bison_parser.y"
+#line 1164 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpCaret, (yyvsp[0].expr)); }
-#line 4959 "bison_parser.cpp"
+#line 4967 "bison_parser.cpp"
     break;
 
   case 213: /* binary_expr: operand LIKE operand  */
-#line 1150 "bison_parser.y"
+#line 1165 "bison_parser.y"
                        { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLike, (yyvsp[0].expr)); }
-#line 4965 "bison_parser.cpp"
+#line 4973 "bison_parser.cpp"
     break;
 
   case 214: /* binary_expr: operand NOT LIKE operand  */
-#line 1151 "bison_parser.y"
+#line 1166 "bison_parser.y"
                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-3].expr), kOpNotLike, (yyvsp[0].expr)); }
-#line 4971 "bison_parser.cpp"
+#line 4979 "bison_parser.cpp"
     break;
 
   case 215: /* binary_expr: operand ILIKE operand  */
-#line 1152 "bison_parser.y"
+#line 1167 "bison_parser.y"
                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpILike, (yyvsp[0].expr)); }
-#line 4977 "bison_parser.cpp"
+#line 4985 "bison_parser.cpp"
     break;
 
   case 216: /* binary_expr: operand CONCAT operand  */
-#line 1153 "bison_parser.y"
+#line 1168 "bison_parser.y"
                          { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpConcat, (yyvsp[0].expr)); }
-#line 4983 "bison_parser.cpp"
+#line 4991 "bison_parser.cpp"
     break;
 
   case 217: /* logic_expr: expr AND expr  */
-#line 1155 "bison_parser.y"
+#line 1170 "bison_parser.y"
                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAnd, (yyvsp[0].expr)); }
-#line 4989 "bison_parser.cpp"
+#line 4997 "bison_parser.cpp"
     break;
 
   case 218: /* logic_expr: expr OR expr  */
-#line 1156 "bison_parser.y"
+#line 1171 "bison_parser.y"
                { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpOr, (yyvsp[0].expr)); }
-#line 4995 "bison_parser.cpp"
+#line 5003 "bison_parser.cpp"
     break;
 
   case 219: /* in_expr: operand IN '(' expr_list ')'  */
-#line 1158 "bison_parser.y"
+#line 1173 "bison_parser.y"
                                        { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].expr_vec)); }
-#line 5001 "bison_parser.cpp"
+#line 5009 "bison_parser.cpp"
     break;
 
   case 220: /* in_expr: operand NOT IN '(' expr_list ')'  */
-#line 1159 "bison_parser.y"
+#line 1174 "bison_parser.y"
                                    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].expr_vec))); }
-#line 5007 "bison_parser.cpp"
+#line 5015 "bison_parser.cpp"
     break;
 
   case 221: /* in_expr: operand IN '(' select_no_paren ')'  */
-#line 1160 "bison_parser.y"
+#line 1175 "bison_parser.y"
                                      { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].select_stmt)); }
-#line 5013 "bison_parser.cpp"
+#line 5021 "bison_parser.cpp"
     break;
 
   case 222: /* in_expr: operand NOT IN '(' select_no_paren ')'  */
-#line 1161 "bison_parser.y"
+#line 1176 "bison_parser.y"
                                          { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].select_stmt))); }
-#line 5019 "bison_parser.cpp"
+#line 5027 "bison_parser.cpp"
     break;
 
   case 223: /* case_expr: CASE expr case_list END  */
-#line 1165 "bison_parser.y"
+#line 1180 "bison_parser.y"
                                     { (yyval.expr) = Expr::makeCase((yyvsp[-2].expr), (yyvsp[-1].expr), nullptr); }
-#line 5025 "bison_parser.cpp"
+#line 5033 "bison_parser.cpp"
     break;
 
   case 224: /* case_expr: CASE expr case_list ELSE expr END  */
-#line 1166 "bison_parser.y"
+#line 1181 "bison_parser.y"
                                     { (yyval.expr) = Expr::makeCase((yyvsp[-4].expr), (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 5031 "bison_parser.cpp"
+#line 5039 "bison_parser.cpp"
     break;
 
   case 225: /* case_expr: CASE case_list END  */
-#line 1167 "bison_parser.y"
+#line 1182 "bison_parser.y"
                      { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-1].expr), nullptr); }
-#line 5037 "bison_parser.cpp"
+#line 5045 "bison_parser.cpp"
     break;
 
   case 226: /* case_expr: CASE case_list ELSE expr END  */
-#line 1168 "bison_parser.y"
+#line 1183 "bison_parser.y"
                                { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 5043 "bison_parser.cpp"
+#line 5051 "bison_parser.cpp"
     break;
 
   case 227: /* case_list: WHEN expr THEN expr  */
-#line 1170 "bison_parser.y"
+#line 1185 "bison_parser.y"
                                 { (yyval.expr) = Expr::makeCaseList(Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
-#line 5049 "bison_parser.cpp"
+#line 5057 "bison_parser.cpp"
     break;
 
   case 228: /* case_list: case_list WHEN expr THEN expr  */
-#line 1171 "bison_parser.y"
+#line 1186 "bison_parser.y"
                                 { (yyval.expr) = Expr::caseListAppend((yyvsp[-4].expr), Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
-#line 5055 "bison_parser.cpp"
+#line 5063 "bison_parser.cpp"
     break;
 
   case 229: /* exists_expr: EXISTS '(' select_no_paren ')'  */
-#line 1173 "bison_parser.y"
+#line 1188 "bison_parser.y"
                                              { (yyval.expr) = Expr::makeExists((yyvsp[-1].select_stmt)); }
-#line 5061 "bison_parser.cpp"
+#line 5069 "bison_parser.cpp"
     break;
 
   case 230: /* exists_expr: NOT EXISTS '(' select_no_paren ')'  */
-#line 1174 "bison_parser.y"
+#line 1189 "bison_parser.y"
                                      { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeExists((yyvsp[-1].select_stmt))); }
-#line 5067 "bison_parser.cpp"
+#line 5075 "bison_parser.cpp"
     break;
 
   case 231: /* comp_expr: operand '=' operand  */
-#line 1176 "bison_parser.y"
+#line 1191 "bison_parser.y"
                                 { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
-#line 5073 "bison_parser.cpp"
+#line 5081 "bison_parser.cpp"
     break;
 
   case 232: /* comp_expr: operand EQUALS operand  */
-#line 1177 "bison_parser.y"
+#line 1192 "bison_parser.y"
                          { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
-#line 5079 "bison_parser.cpp"
+#line 5087 "bison_parser.cpp"
     break;
 
   case 233: /* comp_expr: operand NOTEQUALS operand  */
-#line 1178 "bison_parser.y"
+#line 1193 "bison_parser.y"
                             { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpNotEquals, (yyvsp[0].expr)); }
-#line 5085 "bison_parser.cpp"
+#line 5093 "bison_parser.cpp"
     break;
 
   case 234: /* comp_expr: operand '<' operand  */
-#line 1179 "bison_parser.y"
+#line 1194 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLess, (yyvsp[0].expr)); }
-#line 5091 "bison_parser.cpp"
+#line 5099 "bison_parser.cpp"
     break;
 
   case 235: /* comp_expr: operand '>' operand  */
-#line 1180 "bison_parser.y"
+#line 1195 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreater, (yyvsp[0].expr)); }
-#line 5097 "bison_parser.cpp"
+#line 5105 "bison_parser.cpp"
     break;
 
   case 236: /* comp_expr: operand LESSEQ operand  */
-#line 1181 "bison_parser.y"
+#line 1196 "bison_parser.y"
                          { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLessEq, (yyvsp[0].expr)); }
-#line 5103 "bison_parser.cpp"
+#line 5111 "bison_parser.cpp"
     break;
 
   case 237: /* comp_expr: operand GREATEREQ operand  */
-#line 1182 "bison_parser.y"
+#line 1197 "bison_parser.y"
                             { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreaterEq, (yyvsp[0].expr)); }
-#line 5109 "bison_parser.cpp"
+#line 5117 "bison_parser.cpp"
     break;
 
   case 238: /* function_expr: IDENTIFIER '(' ')' opt_window  */
-#line 1186 "bison_parser.y"
+#line 1201 "bison_parser.y"
                                               { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
-#line 5115 "bison_parser.cpp"
+#line 5123 "bison_parser.cpp"
     break;
 
   case 239: /* function_expr: IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
-#line 1187 "bison_parser.y"
+#line 1202 "bison_parser.y"
                                                        { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
-#line 5121 "bison_parser.cpp"
-    break;
-
-  case 240: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' ')' opt_window  */
-#line 1188 "bison_parser.y"
-                                               {
-  (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), (yyvsp[-5].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description));
-}
 #line 5129 "bison_parser.cpp"
     break;
 
-  case 241: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
-#line 1191 "bison_parser.y"
-                                                                      {
-  (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-7].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description));
+  case 240: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' ')' opt_window  */
+#line 1203 "bison_parser.y"
+                                               {
+  (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), (yyvsp[-5].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description));
 }
 #line 5137 "bison_parser.cpp"
     break;
 
+  case 241: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
+#line 1206 "bison_parser.y"
+                                                                      {
+  (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-7].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description));
+}
+#line 5145 "bison_parser.cpp"
+    break;
+
   case 242: /* opt_window: OVER '(' opt_partition opt_order opt_frame_clause ')'  */
-#line 1197 "bison_parser.y"
+#line 1212 "bison_parser.y"
                                                                    { (yyval.window_description) = new WindowDescription((yyvsp[-3].expr_vec), (yyvsp[-2].order_vec), (yyvsp[-1].frame_description)); }
-#line 5143 "bison_parser.cpp"
+#line 5151 "bison_parser.cpp"
     break;
 
   case 243: /* opt_window: %empty  */
-#line 1198 "bison_parser.y"
+#line 1213 "bison_parser.y"
               { (yyval.window_description) = nullptr; }
-#line 5149 "bison_parser.cpp"
+#line 5157 "bison_parser.cpp"
     break;
 
   case 244: /* opt_partition: PARTITION BY expr_list  */
-#line 1200 "bison_parser.y"
+#line 1215 "bison_parser.y"
                                        { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
-#line 5155 "bison_parser.cpp"
+#line 5163 "bison_parser.cpp"
     break;
 
   case 245: /* opt_partition: %empty  */
-#line 1201 "bison_parser.y"
+#line 1216 "bison_parser.y"
               { (yyval.expr_vec) = nullptr; }
-#line 5161 "bison_parser.cpp"
+#line 5169 "bison_parser.cpp"
     break;
 
   case 246: /* opt_frame_clause: frame_type frame_bound  */
-#line 1206 "bison_parser.y"
+#line 1221 "bison_parser.y"
                                           { (yyval.frame_description) = new FrameDescription{(yyvsp[-1].frame_type), (yyvsp[0].frame_bound), new FrameBound{0, kCurrentRow, false}}; }
-#line 5167 "bison_parser.cpp"
+#line 5175 "bison_parser.cpp"
     break;
 
   case 247: /* opt_frame_clause: frame_type BETWEEN frame_bound AND frame_bound  */
-#line 1207 "bison_parser.y"
+#line 1222 "bison_parser.y"
                                                  { (yyval.frame_description) = new FrameDescription{(yyvsp[-4].frame_type), (yyvsp[-2].frame_bound), (yyvsp[0].frame_bound)}; }
-#line 5173 "bison_parser.cpp"
-    break;
-
-  case 248: /* opt_frame_clause: %empty  */
-#line 1208 "bison_parser.y"
-              {
-  (yyval.frame_description) = new FrameDescription{kRange, new FrameBound{0, kPreceding, true}, new FrameBound{0, kCurrentRow, false}};
-}
 #line 5181 "bison_parser.cpp"
     break;
 
+  case 248: /* opt_frame_clause: %empty  */
+#line 1223 "bison_parser.y"
+              {
+  (yyval.frame_description) = new FrameDescription{kRange, new FrameBound{0, kPreceding, true}, new FrameBound{0, kCurrentRow, false}};
+}
+#line 5189 "bison_parser.cpp"
+    break;
+
   case 249: /* frame_type: RANGE  */
-#line 1212 "bison_parser.y"
+#line 1227 "bison_parser.y"
                    { (yyval.frame_type) = kRange; }
-#line 5187 "bison_parser.cpp"
+#line 5195 "bison_parser.cpp"
     break;
 
   case 250: /* frame_type: ROWS  */
-#line 1213 "bison_parser.y"
+#line 1228 "bison_parser.y"
        { (yyval.frame_type) = kRows; }
-#line 5193 "bison_parser.cpp"
+#line 5201 "bison_parser.cpp"
     break;
 
   case 251: /* frame_type: GROUPS  */
-#line 1214 "bison_parser.y"
+#line 1229 "bison_parser.y"
          { (yyval.frame_type) = kGroups; }
-#line 5199 "bison_parser.cpp"
+#line 5207 "bison_parser.cpp"
     break;
 
   case 252: /* frame_bound: UNBOUNDED PRECEDING  */
-#line 1216 "bison_parser.y"
+#line 1231 "bison_parser.y"
                                   { (yyval.frame_bound) = new FrameBound{0, kPreceding, true}; }
-#line 5205 "bison_parser.cpp"
+#line 5213 "bison_parser.cpp"
     break;
 
   case 253: /* frame_bound: INTVAL PRECEDING  */
-#line 1217 "bison_parser.y"
+#line 1232 "bison_parser.y"
                    { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kPreceding, false}; }
-#line 5211 "bison_parser.cpp"
+#line 5219 "bison_parser.cpp"
     break;
 
   case 254: /* frame_bound: UNBOUNDED FOLLOWING  */
-#line 1218 "bison_parser.y"
+#line 1233 "bison_parser.y"
                       { (yyval.frame_bound) = new FrameBound{0, kFollowing, true}; }
-#line 5217 "bison_parser.cpp"
+#line 5225 "bison_parser.cpp"
     break;
 
   case 255: /* frame_bound: INTVAL FOLLOWING  */
-#line 1219 "bison_parser.y"
+#line 1234 "bison_parser.y"
                    { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kFollowing, false}; }
-#line 5223 "bison_parser.cpp"
+#line 5231 "bison_parser.cpp"
     break;
 
   case 256: /* frame_bound: CURRENT_ROW  */
-#line 1220 "bison_parser.y"
+#line 1235 "bison_parser.y"
               { (yyval.frame_bound) = new FrameBound{0, kCurrentRow, false}; }
-#line 5229 "bison_parser.cpp"
+#line 5237 "bison_parser.cpp"
     break;
 
   case 257: /* extract_expr: EXTRACT '(' datetime_field FROM expr ')'  */
-#line 1222 "bison_parser.y"
+#line 1237 "bison_parser.y"
                                                         { (yyval.expr) = Expr::makeExtract((yyvsp[-3].datetime_field), (yyvsp[-1].expr)); }
-#line 5235 "bison_parser.cpp"
+#line 5243 "bison_parser.cpp"
     break;
 
   case 258: /* cast_expr: CAST '(' expr AS column_type ')'  */
-#line 1224 "bison_parser.y"
+#line 1239 "bison_parser.y"
                                              { (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t)); }
-#line 5241 "bison_parser.cpp"
+#line 5249 "bison_parser.cpp"
     break;
 
   case 259: /* datetime_field: SECOND  */
-#line 1226 "bison_parser.y"
+#line 1241 "bison_parser.y"
                         { (yyval.datetime_field) = kDatetimeSecond; }
-#line 5247 "bison_parser.cpp"
+#line 5255 "bison_parser.cpp"
     break;
 
   case 260: /* datetime_field: MINUTE  */
-#line 1227 "bison_parser.y"
+#line 1242 "bison_parser.y"
          { (yyval.datetime_field) = kDatetimeMinute; }
-#line 5253 "bison_parser.cpp"
+#line 5261 "bison_parser.cpp"
     break;
 
   case 261: /* datetime_field: HOUR  */
-#line 1228 "bison_parser.y"
+#line 1243 "bison_parser.y"
        { (yyval.datetime_field) = kDatetimeHour; }
-#line 5259 "bison_parser.cpp"
+#line 5267 "bison_parser.cpp"
     break;
 
   case 262: /* datetime_field: DAY  */
-#line 1229 "bison_parser.y"
+#line 1244 "bison_parser.y"
       { (yyval.datetime_field) = kDatetimeDay; }
-#line 5265 "bison_parser.cpp"
+#line 5273 "bison_parser.cpp"
     break;
 
   case 263: /* datetime_field: MONTH  */
-#line 1230 "bison_parser.y"
+#line 1245 "bison_parser.y"
         { (yyval.datetime_field) = kDatetimeMonth; }
-#line 5271 "bison_parser.cpp"
+#line 5279 "bison_parser.cpp"
     break;
 
   case 264: /* datetime_field: YEAR  */
-#line 1231 "bison_parser.y"
+#line 1246 "bison_parser.y"
        { (yyval.datetime_field) = kDatetimeYear; }
-#line 5277 "bison_parser.cpp"
+#line 5285 "bison_parser.cpp"
     break;
 
   case 265: /* datetime_field_plural: SECONDS  */
-#line 1233 "bison_parser.y"
+#line 1248 "bison_parser.y"
                                 { (yyval.datetime_field) = kDatetimeSecond; }
-#line 5283 "bison_parser.cpp"
+#line 5291 "bison_parser.cpp"
     break;
 
   case 266: /* datetime_field_plural: MINUTES  */
-#line 1234 "bison_parser.y"
+#line 1249 "bison_parser.y"
           { (yyval.datetime_field) = kDatetimeMinute; }
-#line 5289 "bison_parser.cpp"
+#line 5297 "bison_parser.cpp"
     break;
 
   case 267: /* datetime_field_plural: HOURS  */
-#line 1235 "bison_parser.y"
+#line 1250 "bison_parser.y"
         { (yyval.datetime_field) = kDatetimeHour; }
-#line 5295 "bison_parser.cpp"
+#line 5303 "bison_parser.cpp"
     break;
 
   case 268: /* datetime_field_plural: DAYS  */
-#line 1236 "bison_parser.y"
+#line 1251 "bison_parser.y"
        { (yyval.datetime_field) = kDatetimeDay; }
-#line 5301 "bison_parser.cpp"
+#line 5309 "bison_parser.cpp"
     break;
 
   case 269: /* datetime_field_plural: MONTHS  */
-#line 1237 "bison_parser.y"
+#line 1252 "bison_parser.y"
          { (yyval.datetime_field) = kDatetimeMonth; }
-#line 5307 "bison_parser.cpp"
+#line 5315 "bison_parser.cpp"
     break;
 
   case 270: /* datetime_field_plural: YEARS  */
-#line 1238 "bison_parser.y"
+#line 1253 "bison_parser.y"
         { (yyval.datetime_field) = kDatetimeYear; }
-#line 5313 "bison_parser.cpp"
+#line 5321 "bison_parser.cpp"
     break;
 
   case 273: /* array_expr: ARRAY '[' expr_list ']'  */
-#line 1242 "bison_parser.y"
+#line 1257 "bison_parser.y"
                                      { (yyval.expr) = Expr::makeArray((yyvsp[-1].expr_vec)); }
-#line 5319 "bison_parser.cpp"
+#line 5327 "bison_parser.cpp"
     break;
 
   case 274: /* array_index: operand '[' int_literal ']'  */
-#line 1244 "bison_parser.y"
+#line 1259 "bison_parser.y"
                                           { (yyval.expr) = Expr::makeArrayIndex((yyvsp[-3].expr), (yyvsp[-1].expr)->ival); }
-#line 5325 "bison_parser.cpp"
+#line 5333 "bison_parser.cpp"
     break;
 
   case 275: /* between_expr: operand BETWEEN operand AND operand  */
-#line 1246 "bison_parser.y"
+#line 1261 "bison_parser.y"
                                                    { (yyval.expr) = Expr::makeBetween((yyvsp[-4].expr), (yyvsp[-2].expr), (yyvsp[0].expr)); }
-#line 5331 "bison_parser.cpp"
+#line 5339 "bison_parser.cpp"
     break;
 
   case 276: /* column_name: IDENTIFIER  */
-#line 1248 "bison_parser.y"
+#line 1263 "bison_parser.y"
                          { (yyval.expr) = Expr::makeColumnRef((yyvsp[0].sval)); }
-#line 5337 "bison_parser.cpp"
+#line 5345 "bison_parser.cpp"
     break;
 
   case 277: /* column_name: IDENTIFIER '.' IDENTIFIER  */
-#line 1249 "bison_parser.y"
+#line 1264 "bison_parser.y"
                             { (yyval.expr) = Expr::makeColumnRef((yyvsp[-2].sval), (yyvsp[0].sval)); }
-#line 5343 "bison_parser.cpp"
+#line 5351 "bison_parser.cpp"
     break;
 
   case 278: /* column_name: '*'  */
-#line 1250 "bison_parser.y"
+#line 1265 "bison_parser.y"
       { (yyval.expr) = Expr::makeStar(); }
-#line 5349 "bison_parser.cpp"
+#line 5357 "bison_parser.cpp"
     break;
 
   case 279: /* column_name: IDENTIFIER '.' '*'  */
-#line 1251 "bison_parser.y"
+#line 1266 "bison_parser.y"
                      { (yyval.expr) = Expr::makeStar((yyvsp[-2].sval)); }
-#line 5355 "bison_parser.cpp"
+#line 5363 "bison_parser.cpp"
     break;
 
   case 287: /* string_literal: STRING  */
-#line 1255 "bison_parser.y"
+#line 1270 "bison_parser.y"
                         { (yyval.expr) = Expr::makeLiteral((yyvsp[0].sval)); }
-#line 5361 "bison_parser.cpp"
+#line 5369 "bison_parser.cpp"
     break;
 
   case 288: /* bool_literal: TRUE  */
-#line 1257 "bison_parser.y"
+#line 1272 "bison_parser.y"
                     { (yyval.expr) = Expr::makeLiteral(true); }
-#line 5367 "bison_parser.cpp"
+#line 5375 "bison_parser.cpp"
     break;
 
   case 289: /* bool_literal: FALSE  */
-#line 1258 "bison_parser.y"
+#line 1273 "bison_parser.y"
         { (yyval.expr) = Expr::makeLiteral(false); }
-#line 5373 "bison_parser.cpp"
+#line 5381 "bison_parser.cpp"
     break;
 
   case 290: /* num_literal: FLOATVAL  */
-#line 1260 "bison_parser.y"
+#line 1275 "bison_parser.y"
                        { (yyval.expr) = Expr::makeLiteral((yyvsp[0].fval)); }
-#line 5379 "bison_parser.cpp"
+#line 5387 "bison_parser.cpp"
     break;
 
   case 292: /* int_literal: INTVAL  */
-#line 1263 "bison_parser.y"
+#line 1278 "bison_parser.y"
                      { (yyval.expr) = Expr::makeLiteral((yyvsp[0].ival)); }
-#line 5385 "bison_parser.cpp"
+#line 5393 "bison_parser.cpp"
     break;
 
   case 293: /* null_literal: NULL  */
-#line 1265 "bison_parser.y"
+#line 1280 "bison_parser.y"
                     { (yyval.expr) = Expr::makeNullLiteral(); }
-#line 5391 "bison_parser.cpp"
+#line 5399 "bison_parser.cpp"
     break;
 
   case 294: /* date_literal: DATE STRING  */
-#line 1267 "bison_parser.y"
+#line 1282 "bison_parser.y"
                            {
   int day{0}, month{0}, year{0}, chars_parsed{0};
   // If the whole string is parsed, chars_parsed points to the terminating null byte after the last character
@@ -5402,17 +5410,17 @@ yyreduce:
   }
   (yyval.expr) = Expr::makeDateLiteral((yyvsp[0].sval));
 }
-#line 5406 "bison_parser.cpp"
+#line 5414 "bison_parser.cpp"
     break;
 
   case 295: /* interval_literal: INTVAL duration_field  */
-#line 1278 "bison_parser.y"
+#line 1293 "bison_parser.y"
                                          { (yyval.expr) = Expr::makeIntervalLiteral((yyvsp[-1].ival), (yyvsp[0].datetime_field)); }
-#line 5412 "bison_parser.cpp"
+#line 5420 "bison_parser.cpp"
     break;
 
   case 296: /* interval_literal: INTERVAL STRING datetime_field  */
-#line 1279 "bison_parser.y"
+#line 1294 "bison_parser.y"
                                  {
   int duration{0}, chars_parsed{0};
   // If the whole string is parsed, chars_parsed points to the terminating null byte after the last character
@@ -5424,11 +5432,11 @@ yyreduce:
   free((yyvsp[-1].sval));
   (yyval.expr) = Expr::makeIntervalLiteral(duration, (yyvsp[0].datetime_field));
 }
-#line 5428 "bison_parser.cpp"
+#line 5436 "bison_parser.cpp"
     break;
 
   case 297: /* interval_literal: INTERVAL STRING  */
-#line 1290 "bison_parser.y"
+#line 1305 "bison_parser.y"
                   {
   int duration{0}, chars_parsed{0};
   // 'seconds' and 'minutes' are the longest accepted interval qualifiers (7 chars) + null byte
@@ -5460,21 +5468,21 @@ yyreduce:
   }
   (yyval.expr) = Expr::makeIntervalLiteral(duration, unit);
 }
-#line 5464 "bison_parser.cpp"
+#line 5472 "bison_parser.cpp"
     break;
 
   case 298: /* param_expr: '?'  */
-#line 1322 "bison_parser.y"
+#line 1337 "bison_parser.y"
                  {
   (yyval.expr) = Expr::makeParameter(yylloc.total_column);
   (yyval.expr)->ival2 = yylloc.total_column - 1;  // source column (0-based) of the '?' token
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5474 "bison_parser.cpp"
+#line 5482 "bison_parser.cpp"
     break;
 
   case 299: /* param_expr: DOLLAR_PARAM  */
-#line 1327 "bison_parser.y"
+#line 1342 "bison_parser.y"
                {
   if ((yyvsp[0].ival) < 1) {
     yyerror(&yyloc, result, scanner, "$0 is not a valid positional parameter.");
@@ -5487,61 +5495,61 @@ yyreduce:
   (yyval.expr)->ival2 = yylloc.total_column - dollarLen;
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5491 "bison_parser.cpp"
+#line 5499 "bison_parser.cpp"
     break;
 
   case 300: /* param_expr: NAMED_PARAM  */
-#line 1339 "bison_parser.y"
+#line 1354 "bison_parser.y"
               {
   (yyval.expr) = Expr::makeNamedParameter((yyvsp[0].sval));
   (yyval.expr)->ival2 = yylloc.total_column - 1 - (int64_t)strlen((yyvsp[0].sval));
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5501 "bison_parser.cpp"
+#line 5509 "bison_parser.cpp"
     break;
 
   case 302: /* table_ref: table_ref_commalist ',' table_ref_atomic  */
-#line 1348 "bison_parser.y"
+#line 1363 "bison_parser.y"
                                                                         {
   (yyvsp[-2].table_vec)->push_back((yyvsp[0].table));
   auto tbl = new TableRef(kTableCrossProduct);
   tbl->list = (yyvsp[-2].table_vec);
   (yyval.table) = tbl;
 }
-#line 5512 "bison_parser.cpp"
+#line 5520 "bison_parser.cpp"
     break;
 
   case 306: /* nonjoin_table_ref_atomic: '(' select_statement ')' opt_table_alias  */
-#line 1357 "bison_parser.y"
+#line 1372 "bison_parser.y"
                                                                                      {
   auto tbl = new TableRef(kTableSelect);
   tbl->select = (yyvsp[-2].select_stmt);
   tbl->alias = (yyvsp[0].alias_t);
   (yyval.table) = tbl;
 }
-#line 5523 "bison_parser.cpp"
+#line 5531 "bison_parser.cpp"
     break;
 
   case 307: /* table_ref_commalist: table_ref_atomic  */
-#line 1364 "bison_parser.y"
+#line 1379 "bison_parser.y"
                                        {
   (yyval.table_vec) = new std::vector<TableRef*>();
   (yyval.table_vec)->push_back((yyvsp[0].table));
 }
-#line 5532 "bison_parser.cpp"
+#line 5540 "bison_parser.cpp"
     break;
 
   case 308: /* table_ref_commalist: table_ref_commalist ',' table_ref_atomic  */
-#line 1368 "bison_parser.y"
+#line 1383 "bison_parser.y"
                                            {
   (yyvsp[-2].table_vec)->push_back((yyvsp[0].table));
   (yyval.table_vec) = (yyvsp[-2].table_vec);
 }
-#line 5541 "bison_parser.cpp"
+#line 5549 "bison_parser.cpp"
     break;
 
   case 309: /* table_ref_name: table_name opt_table_alias  */
-#line 1373 "bison_parser.y"
+#line 1388 "bison_parser.y"
                                             {
   auto tbl = new TableRef(kTableName);
   tbl->schema = (yyvsp[-1].table_name).schema;
@@ -5549,215 +5557,215 @@ yyreduce:
   tbl->alias = (yyvsp[0].alias_t);
   (yyval.table) = tbl;
 }
-#line 5553 "bison_parser.cpp"
+#line 5561 "bison_parser.cpp"
     break;
 
   case 310: /* table_ref_name_no_alias: table_name  */
-#line 1381 "bison_parser.y"
+#line 1396 "bison_parser.y"
                                      {
   (yyval.table) = new TableRef(kTableName);
   (yyval.table)->schema = (yyvsp[0].table_name).schema;
   (yyval.table)->name = (yyvsp[0].table_name).name;
 }
-#line 5563 "bison_parser.cpp"
+#line 5571 "bison_parser.cpp"
     break;
 
   case 311: /* table_name: IDENTIFIER  */
-#line 1387 "bison_parser.y"
+#line 1402 "bison_parser.y"
                         {
   (yyval.table_name).schema = nullptr;
   (yyval.table_name).name = (yyvsp[0].sval);
 }
-#line 5572 "bison_parser.cpp"
+#line 5580 "bison_parser.cpp"
     break;
 
   case 312: /* table_name: IDENTIFIER '.' IDENTIFIER  */
-#line 1391 "bison_parser.y"
+#line 1406 "bison_parser.y"
                             {
   (yyval.table_name).schema = (yyvsp[-2].sval);
   (yyval.table_name).name = (yyvsp[0].sval);
 }
-#line 5581 "bison_parser.cpp"
+#line 5589 "bison_parser.cpp"
     break;
 
   case 313: /* opt_index_name: IDENTIFIER  */
-#line 1396 "bison_parser.y"
+#line 1411 "bison_parser.y"
                             { (yyval.sval) = (yyvsp[0].sval); }
-#line 5587 "bison_parser.cpp"
+#line 5595 "bison_parser.cpp"
     break;
 
   case 314: /* opt_index_name: %empty  */
-#line 1397 "bison_parser.y"
+#line 1412 "bison_parser.y"
               { (yyval.sval) = nullptr; }
-#line 5593 "bison_parser.cpp"
+#line 5601 "bison_parser.cpp"
     break;
 
   case 316: /* table_alias: AS IDENTIFIER '(' ident_commalist ')'  */
-#line 1399 "bison_parser.y"
+#line 1414 "bison_parser.y"
                                                             { (yyval.alias_t) = new Alias((yyvsp[-3].sval), (yyvsp[-1].str_vec)); }
-#line 5599 "bison_parser.cpp"
+#line 5607 "bison_parser.cpp"
     break;
 
   case 318: /* opt_table_alias: %empty  */
-#line 1401 "bison_parser.y"
+#line 1416 "bison_parser.y"
                                             { (yyval.alias_t) = nullptr; }
-#line 5605 "bison_parser.cpp"
+#line 5613 "bison_parser.cpp"
     break;
 
   case 319: /* alias: AS IDENTIFIER  */
-#line 1403 "bison_parser.y"
+#line 1418 "bison_parser.y"
                       { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
-#line 5611 "bison_parser.cpp"
+#line 5619 "bison_parser.cpp"
     break;
 
   case 320: /* alias: IDENTIFIER  */
-#line 1404 "bison_parser.y"
+#line 1419 "bison_parser.y"
              { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
-#line 5617 "bison_parser.cpp"
+#line 5625 "bison_parser.cpp"
     break;
 
   case 322: /* opt_alias: %empty  */
-#line 1406 "bison_parser.y"
+#line 1421 "bison_parser.y"
                                 { (yyval.alias_t) = nullptr; }
-#line 5623 "bison_parser.cpp"
+#line 5631 "bison_parser.cpp"
     break;
 
   case 323: /* opt_locking_clause: opt_locking_clause_list  */
-#line 1412 "bison_parser.y"
+#line 1427 "bison_parser.y"
                                              { (yyval.locking_clause_vec) = (yyvsp[0].locking_clause_vec); }
-#line 5629 "bison_parser.cpp"
+#line 5637 "bison_parser.cpp"
     break;
 
   case 324: /* opt_locking_clause: %empty  */
-#line 1413 "bison_parser.y"
+#line 1428 "bison_parser.y"
               { (yyval.locking_clause_vec) = nullptr; }
-#line 5635 "bison_parser.cpp"
+#line 5643 "bison_parser.cpp"
     break;
 
   case 325: /* opt_locking_clause_list: locking_clause  */
-#line 1415 "bison_parser.y"
+#line 1430 "bison_parser.y"
                                          {
   (yyval.locking_clause_vec) = new std::vector<LockingClause*>();
   (yyval.locking_clause_vec)->push_back((yyvsp[0].locking_t));
 }
-#line 5644 "bison_parser.cpp"
+#line 5652 "bison_parser.cpp"
     break;
 
   case 326: /* opt_locking_clause_list: opt_locking_clause_list locking_clause  */
-#line 1419 "bison_parser.y"
+#line 1434 "bison_parser.y"
                                          {
   (yyvsp[-1].locking_clause_vec)->push_back((yyvsp[0].locking_t));
   (yyval.locking_clause_vec) = (yyvsp[-1].locking_clause_vec);
 }
-#line 5653 "bison_parser.cpp"
+#line 5661 "bison_parser.cpp"
     break;
 
   case 327: /* locking_clause: FOR row_lock_mode opt_row_lock_policy  */
-#line 1424 "bison_parser.y"
+#line 1439 "bison_parser.y"
                                                        {
   (yyval.locking_t) = new LockingClause();
   (yyval.locking_t)->rowLockMode = (yyvsp[-1].lock_mode_t);
   (yyval.locking_t)->rowLockWaitPolicy = (yyvsp[0].lock_wait_policy_t);
   (yyval.locking_t)->tables = nullptr;
 }
-#line 5664 "bison_parser.cpp"
+#line 5672 "bison_parser.cpp"
     break;
 
   case 328: /* locking_clause: FOR row_lock_mode OF ident_commalist opt_row_lock_policy  */
-#line 1430 "bison_parser.y"
+#line 1445 "bison_parser.y"
                                                            {
   (yyval.locking_t) = new LockingClause();
   (yyval.locking_t)->rowLockMode = (yyvsp[-3].lock_mode_t);
   (yyval.locking_t)->tables = (yyvsp[-1].str_vec);
   (yyval.locking_t)->rowLockWaitPolicy = (yyvsp[0].lock_wait_policy_t);
 }
-#line 5675 "bison_parser.cpp"
+#line 5683 "bison_parser.cpp"
     break;
 
   case 329: /* row_lock_mode: UPDATE  */
-#line 1437 "bison_parser.y"
+#line 1452 "bison_parser.y"
                        { (yyval.lock_mode_t) = RowLockMode::ForUpdate; }
-#line 5681 "bison_parser.cpp"
+#line 5689 "bison_parser.cpp"
     break;
 
   case 330: /* row_lock_mode: NO KEY UPDATE  */
-#line 1438 "bison_parser.y"
+#line 1453 "bison_parser.y"
                 { (yyval.lock_mode_t) = RowLockMode::ForNoKeyUpdate; }
-#line 5687 "bison_parser.cpp"
+#line 5695 "bison_parser.cpp"
     break;
 
   case 331: /* row_lock_mode: SHARE  */
-#line 1439 "bison_parser.y"
+#line 1454 "bison_parser.y"
         { (yyval.lock_mode_t) = RowLockMode::ForShare; }
-#line 5693 "bison_parser.cpp"
+#line 5701 "bison_parser.cpp"
     break;
 
   case 332: /* row_lock_mode: KEY SHARE  */
-#line 1440 "bison_parser.y"
+#line 1455 "bison_parser.y"
             { (yyval.lock_mode_t) = RowLockMode::ForKeyShare; }
-#line 5699 "bison_parser.cpp"
+#line 5707 "bison_parser.cpp"
     break;
 
   case 333: /* opt_row_lock_policy: SKIP LOCKED  */
-#line 1442 "bison_parser.y"
+#line 1457 "bison_parser.y"
                                   { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::SkipLocked; }
-#line 5705 "bison_parser.cpp"
+#line 5713 "bison_parser.cpp"
     break;
 
   case 334: /* opt_row_lock_policy: NOWAIT  */
-#line 1443 "bison_parser.y"
+#line 1458 "bison_parser.y"
          { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::NoWait; }
-#line 5711 "bison_parser.cpp"
+#line 5719 "bison_parser.cpp"
     break;
 
   case 335: /* opt_row_lock_policy: %empty  */
-#line 1444 "bison_parser.y"
+#line 1459 "bison_parser.y"
               { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::None; }
-#line 5717 "bison_parser.cpp"
+#line 5725 "bison_parser.cpp"
     break;
 
   case 337: /* opt_with_clause: %empty  */
-#line 1450 "bison_parser.y"
+#line 1465 "bison_parser.y"
                                             { (yyval.with_description_vec) = nullptr; }
-#line 5723 "bison_parser.cpp"
+#line 5731 "bison_parser.cpp"
     break;
 
   case 338: /* with_clause: WITH with_description_list  */
-#line 1452 "bison_parser.y"
+#line 1467 "bison_parser.y"
                                          { (yyval.with_description_vec) = (yyvsp[0].with_description_vec); }
-#line 5729 "bison_parser.cpp"
+#line 5737 "bison_parser.cpp"
     break;
 
   case 339: /* with_description_list: with_description  */
-#line 1454 "bison_parser.y"
+#line 1469 "bison_parser.y"
                                          {
   (yyval.with_description_vec) = new std::vector<WithDescription*>();
   (yyval.with_description_vec)->push_back((yyvsp[0].with_description_t));
 }
-#line 5738 "bison_parser.cpp"
+#line 5746 "bison_parser.cpp"
     break;
 
   case 340: /* with_description_list: with_description_list ',' with_description  */
-#line 1458 "bison_parser.y"
+#line 1473 "bison_parser.y"
                                              {
   (yyvsp[-2].with_description_vec)->push_back((yyvsp[0].with_description_t));
   (yyval.with_description_vec) = (yyvsp[-2].with_description_vec);
 }
-#line 5747 "bison_parser.cpp"
+#line 5755 "bison_parser.cpp"
     break;
 
   case 341: /* with_description: IDENTIFIER AS select_with_paren  */
-#line 1463 "bison_parser.y"
+#line 1478 "bison_parser.y"
                                                    {
   (yyval.with_description_t) = new WithDescription();
   (yyval.with_description_t)->alias = (yyvsp[-2].sval);
   (yyval.with_description_t)->select = (yyvsp[0].select_stmt);
 }
-#line 5757 "bison_parser.cpp"
+#line 5765 "bison_parser.cpp"
     break;
 
   case 342: /* join_clause: table_ref_atomic NATURAL JOIN nonjoin_table_ref_atomic  */
-#line 1473 "bison_parser.y"
+#line 1488 "bison_parser.y"
                                                                      {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
@@ -5765,11 +5773,11 @@ yyreduce:
   (yyval.table)->join->left = (yyvsp[-3].table);
   (yyval.table)->join->right = (yyvsp[0].table);
 }
-#line 5769 "bison_parser.cpp"
+#line 5777 "bison_parser.cpp"
     break;
 
   case 343: /* join_clause: table_ref_atomic opt_join_type JOIN table_ref_atomic ON join_condition  */
-#line 1480 "bison_parser.y"
+#line 1495 "bison_parser.y"
                                                                          {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
@@ -5778,11 +5786,11 @@ yyreduce:
   (yyval.table)->join->right = (yyvsp[-2].table);
   (yyval.table)->join->condition = (yyvsp[0].expr);
 }
-#line 5782 "bison_parser.cpp"
+#line 5790 "bison_parser.cpp"
     break;
 
   case 344: /* join_clause: table_ref_atomic opt_join_type JOIN table_ref_atomic USING '(' ident_commalist ')'  */
-#line 1488 "bison_parser.y"
+#line 1503 "bison_parser.y"
                                                                                      {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
@@ -5791,89 +5799,89 @@ yyreduce:
   (yyval.table)->join->right = (yyvsp[-4].table);
   (yyval.table)->join->namedColumns = (yyvsp[-1].str_vec);
 }
-#line 5795 "bison_parser.cpp"
+#line 5803 "bison_parser.cpp"
     break;
 
   case 345: /* opt_join_type: INNER  */
-#line 1497 "bison_parser.y"
+#line 1512 "bison_parser.y"
                       { (yyval.join_type) = kJoinInner; }
-#line 5801 "bison_parser.cpp"
+#line 5809 "bison_parser.cpp"
     break;
 
   case 346: /* opt_join_type: LEFT OUTER  */
-#line 1498 "bison_parser.y"
+#line 1513 "bison_parser.y"
              { (yyval.join_type) = kJoinLeft; }
-#line 5807 "bison_parser.cpp"
+#line 5815 "bison_parser.cpp"
     break;
 
   case 347: /* opt_join_type: LEFT  */
-#line 1499 "bison_parser.y"
+#line 1514 "bison_parser.y"
        { (yyval.join_type) = kJoinLeft; }
-#line 5813 "bison_parser.cpp"
+#line 5821 "bison_parser.cpp"
     break;
 
   case 348: /* opt_join_type: RIGHT OUTER  */
-#line 1500 "bison_parser.y"
+#line 1515 "bison_parser.y"
               { (yyval.join_type) = kJoinRight; }
-#line 5819 "bison_parser.cpp"
+#line 5827 "bison_parser.cpp"
     break;
 
   case 349: /* opt_join_type: RIGHT  */
-#line 1501 "bison_parser.y"
+#line 1516 "bison_parser.y"
         { (yyval.join_type) = kJoinRight; }
-#line 5825 "bison_parser.cpp"
+#line 5833 "bison_parser.cpp"
     break;
 
   case 350: /* opt_join_type: FULL OUTER  */
-#line 1502 "bison_parser.y"
+#line 1517 "bison_parser.y"
              { (yyval.join_type) = kJoinFull; }
-#line 5831 "bison_parser.cpp"
+#line 5839 "bison_parser.cpp"
     break;
 
   case 351: /* opt_join_type: OUTER  */
-#line 1503 "bison_parser.y"
+#line 1518 "bison_parser.y"
         { (yyval.join_type) = kJoinFull; }
-#line 5837 "bison_parser.cpp"
+#line 5845 "bison_parser.cpp"
     break;
 
   case 352: /* opt_join_type: FULL  */
-#line 1504 "bison_parser.y"
+#line 1519 "bison_parser.y"
        { (yyval.join_type) = kJoinFull; }
-#line 5843 "bison_parser.cpp"
+#line 5851 "bison_parser.cpp"
     break;
 
   case 353: /* opt_join_type: CROSS  */
-#line 1505 "bison_parser.y"
+#line 1520 "bison_parser.y"
         { (yyval.join_type) = kJoinCross; }
-#line 5849 "bison_parser.cpp"
+#line 5857 "bison_parser.cpp"
     break;
 
   case 354: /* opt_join_type: %empty  */
-#line 1506 "bison_parser.y"
+#line 1521 "bison_parser.y"
                        { (yyval.join_type) = kJoinInner; }
-#line 5855 "bison_parser.cpp"
+#line 5863 "bison_parser.cpp"
     break;
 
   case 358: /* ident_commalist: IDENTIFIER  */
-#line 1517 "bison_parser.y"
+#line 1532 "bison_parser.y"
                              {
   (yyval.str_vec) = new std::vector<char*>();
   (yyval.str_vec)->push_back((yyvsp[0].sval));
 }
-#line 5864 "bison_parser.cpp"
+#line 5872 "bison_parser.cpp"
     break;
 
   case 359: /* ident_commalist: ident_commalist ',' IDENTIFIER  */
-#line 1521 "bison_parser.y"
+#line 1536 "bison_parser.y"
                                  {
   (yyvsp[-2].str_vec)->push_back((yyvsp[0].sval));
   (yyval.str_vec) = (yyvsp[-2].str_vec);
 }
-#line 5873 "bison_parser.cpp"
+#line 5881 "bison_parser.cpp"
     break;
 
 
-#line 5877 "bison_parser.cpp"
+#line 5885 "bison_parser.cpp"
 
       default: break;
     }
@@ -6102,7 +6110,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 1527 "bison_parser.y"
+#line 1542 "bison_parser.y"
 
 
 /*********************************

--- a/src/parser/bison_parser.cpp
+++ b/src/parser/bison_parser.cpp
@@ -876,42 +876,42 @@ static const yytype_uint8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   345,   345,   365,   371,   378,   382,   386,   387,   388,
-     390,   391,   392,   393,   394,   395,   396,   397,   398,   399,
-     405,   406,   408,   412,   417,   421,   431,   432,   433,   435,
-     435,   441,   447,   449,   453,   465,   471,   488,   503,   505,
-     506,   507,   509,   523,   527,   537,   541,   565,   573,   586,
-     593,   608,   628,   629,   634,   645,   658,   670,   677,   684,
-     693,   694,   696,   700,   705,   706,   708,   716,   717,   718,
-     719,   720,   721,   722,   726,   727,   728,   729,   730,   731,
-     732,   733,   734,   735,   736,   738,   739,   741,   742,   743,
-     745,   746,   748,   752,   756,   761,   769,   770,   771,   772,
-     774,   775,   776,   778,   786,   792,   798,   804,   810,   811,
-     818,   824,   826,   836,   843,   854,   861,   869,   870,   877,
-     884,   888,   893,   903,   907,   911,   923,   923,   925,   926,
-     935,   936,   938,   952,   964,   969,   973,   977,   982,   983,
-     985,   995,   996,   998,  1000,  1001,  1003,  1005,  1006,  1008,
-    1013,  1015,  1016,  1018,  1019,  1021,  1025,  1030,  1032,  1033,
-    1034,  1036,  1037,  1059,  1060,  1062,  1063,  1064,  1065,  1066,
-    1067,  1072,  1076,  1082,  1083,  1085,  1089,  1094,  1094,  1098,
-    1099,  1100,  1102,  1111,  1111,  1111,  1111,  1111,  1113,  1114,
-    1114,  1114,  1114,  1114,  1114,  1114,  1114,  1115,  1115,  1119,
-    1119,  1121,  1122,  1123,  1124,  1125,  1127,  1127,  1128,  1129,
-    1130,  1131,  1132,  1133,  1134,  1135,  1136,  1138,  1139,  1141,
-    1142,  1143,  1144,  1148,  1149,  1150,  1151,  1153,  1154,  1156,
-    1157,  1159,  1160,  1161,  1162,  1163,  1164,  1165,  1169,  1170,
-    1171,  1174,  1180,  1181,  1183,  1184,  1189,  1190,  1191,  1195,
-    1196,  1197,  1199,  1200,  1201,  1202,  1203,  1205,  1207,  1209,
-    1210,  1211,  1212,  1213,  1214,  1216,  1217,  1218,  1219,  1220,
-    1221,  1223,  1223,  1225,  1227,  1229,  1231,  1232,  1233,  1234,
-    1236,  1236,  1236,  1236,  1236,  1236,  1236,  1238,  1240,  1241,
-    1243,  1244,  1246,  1248,  1250,  1261,  1262,  1273,  1305,  1310,
-    1322,  1331,  1331,  1338,  1338,  1340,  1340,  1347,  1351,  1356,
-    1364,  1370,  1374,  1379,  1380,  1382,  1382,  1384,  1384,  1386,
-    1387,  1389,  1389,  1395,  1396,  1398,  1402,  1407,  1413,  1420,
-    1421,  1422,  1423,  1425,  1426,  1427,  1433,  1433,  1435,  1437,
-    1441,  1446,  1456,  1463,  1471,  1480,  1481,  1482,  1483,  1484,
-    1485,  1486,  1487,  1488,  1489,  1491,  1497,  1497,  1500,  1504
+       0,   362,   362,   382,   388,   395,   399,   403,   404,   405,
+     407,   408,   409,   410,   411,   412,   413,   414,   415,   416,
+     422,   423,   425,   429,   434,   438,   448,   449,   450,   452,
+     452,   458,   464,   466,   470,   482,   488,   505,   520,   522,
+     523,   524,   526,   540,   544,   554,   558,   582,   590,   603,
+     610,   625,   645,   646,   651,   662,   675,   687,   694,   701,
+     710,   711,   713,   717,   722,   723,   725,   733,   734,   735,
+     736,   737,   738,   739,   743,   744,   745,   746,   747,   748,
+     749,   750,   751,   752,   753,   755,   756,   758,   759,   760,
+     762,   763,   765,   769,   773,   778,   786,   787,   788,   789,
+     791,   792,   793,   795,   803,   809,   815,   821,   827,   828,
+     835,   841,   843,   853,   860,   871,   878,   886,   887,   894,
+     901,   905,   910,   920,   924,   928,   940,   940,   942,   943,
+     952,   953,   955,   969,   981,   986,   990,   994,   999,  1000,
+    1002,  1012,  1013,  1015,  1017,  1018,  1020,  1022,  1023,  1025,
+    1030,  1032,  1033,  1035,  1036,  1038,  1042,  1047,  1049,  1050,
+    1051,  1053,  1054,  1076,  1077,  1079,  1080,  1081,  1082,  1083,
+    1084,  1089,  1093,  1099,  1100,  1102,  1106,  1111,  1111,  1115,
+    1116,  1117,  1119,  1128,  1128,  1128,  1128,  1128,  1130,  1131,
+    1131,  1131,  1131,  1131,  1131,  1131,  1131,  1132,  1132,  1136,
+    1136,  1138,  1139,  1140,  1141,  1142,  1144,  1144,  1145,  1146,
+    1147,  1148,  1149,  1150,  1151,  1152,  1153,  1155,  1156,  1158,
+    1159,  1160,  1161,  1165,  1166,  1167,  1168,  1170,  1171,  1173,
+    1174,  1176,  1177,  1178,  1179,  1180,  1181,  1182,  1186,  1187,
+    1188,  1191,  1197,  1198,  1200,  1201,  1206,  1207,  1208,  1212,
+    1213,  1214,  1216,  1217,  1218,  1219,  1220,  1222,  1224,  1226,
+    1227,  1228,  1229,  1230,  1231,  1233,  1234,  1235,  1236,  1237,
+    1238,  1240,  1240,  1242,  1244,  1246,  1248,  1249,  1250,  1251,
+    1253,  1253,  1253,  1253,  1253,  1253,  1253,  1255,  1257,  1258,
+    1260,  1261,  1263,  1265,  1267,  1278,  1279,  1290,  1322,  1327,
+    1339,  1348,  1348,  1355,  1355,  1357,  1357,  1364,  1368,  1373,
+    1381,  1387,  1391,  1396,  1397,  1399,  1399,  1401,  1401,  1403,
+    1404,  1406,  1406,  1412,  1413,  1415,  1419,  1424,  1430,  1437,
+    1438,  1439,  1440,  1442,  1443,  1444,  1450,  1450,  1452,  1454,
+    1458,  1463,  1473,  1480,  1488,  1497,  1498,  1499,  1500,  1501,
+    1502,  1503,  1504,  1505,  1506,  1508,  1514,  1514,  1517,  1521
 };
 #endif
 
@@ -2155,13 +2155,13 @@ yydestruct (const char *yymsg,
         break;
 
     case YYSYMBOL_statement: /* statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).statement)); }
 #line 2161 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_preparable_statement: /* preparable_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).statement)); }
 #line 2167 "bison_parser.cpp"
         break;
@@ -2193,19 +2193,19 @@ yydestruct (const char *yymsg,
         break;
 
     case YYSYMBOL_hint: /* hint  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
 #line 2199 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_transaction_statement: /* transaction_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).transaction_stmt)); }
 #line 2205 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_prepare_statement: /* prepare_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).prep_stmt)); }
 #line 2211 "bison_parser.cpp"
         break;
@@ -2217,13 +2217,13 @@ yydestruct (const char *yymsg,
         break;
 
     case YYSYMBOL_execute_statement: /* execute_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).exec_stmt)); }
 #line 2223 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_import_statement: /* import_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).import_stmt)); }
 #line 2229 "bison_parser.cpp"
         break;
@@ -2241,13 +2241,13 @@ yydestruct (const char *yymsg,
         break;
 
     case YYSYMBOL_opt_import_export_options: /* opt_import_export_options  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).import_export_option_t)); }
 #line 2247 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_import_export_options: /* import_export_options  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).import_export_option_t)); }
 #line 2253 "bison_parser.cpp"
         break;
@@ -2262,19 +2262,19 @@ yydestruct (const char *yymsg,
         break;
 
     case YYSYMBOL_export_statement: /* export_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).export_stmt)); }
 #line 2268 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_show_statement: /* show_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).show_stmt)); }
 #line 2274 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_create_statement: /* create_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).create_stmt)); }
 #line 2280 "bison_parser.cpp"
         break;
@@ -2299,13 +2299,13 @@ yydestruct (const char *yymsg,
         break;
 
     case YYSYMBOL_table_elem: /* table_elem  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).table_element_t)); }
 #line 2305 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_column_def: /* column_def  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).column_t)); }
 #line 2311 "bison_parser.cpp"
         break;
@@ -2323,87 +2323,119 @@ yydestruct (const char *yymsg,
         break;
 
     case YYSYMBOL_opt_decimal_specification: /* opt_decimal_specification  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).ival_pair)); }
 #line 2329 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_column_constraints: /* opt_column_constraints  */
 #line 207 "bison_parser.y"
-            { delete (((*yyvaluep).column_constraints_t)); }
-#line 2335 "bison_parser.cpp"
+            {
+  // ColumnConstraints owns heap-allocated members (constraints, references).
+  // The happy path transfers those pointers into a ColumnDefinition and then
+  // deletes the wrapper; bison only reaches this destructor on parse error,
+  // when the inner pointers are still owned by the wrapper and must be
+  // released here to avoid leaks.
+  if (((*yyvaluep).column_constraints_t)) {
+    delete ((*yyvaluep).column_constraints_t)->constraints;
+    if (((*yyvaluep).column_constraints_t)->references) {
+      for (auto ptr : *(((*yyvaluep).column_constraints_t)->references)) {
+        delete ptr;
+      }
+    }
+    delete ((*yyvaluep).column_constraints_t)->references;
+  }
+  delete (((*yyvaluep).column_constraints_t));
+}
+#line 2351 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_column_constraints: /* column_constraints  */
 #line 207 "bison_parser.y"
-            { delete (((*yyvaluep).column_constraints_t)); }
-#line 2341 "bison_parser.cpp"
+            {
+  // ColumnConstraints owns heap-allocated members (constraints, references).
+  // The happy path transfers those pointers into a ColumnDefinition and then
+  // deletes the wrapper; bison only reaches this destructor on parse error,
+  // when the inner pointers are still owned by the wrapper and must be
+  // released here to avoid leaks.
+  if (((*yyvaluep).column_constraints_t)) {
+    delete ((*yyvaluep).column_constraints_t)->constraints;
+    if (((*yyvaluep).column_constraints_t)->references) {
+      for (auto ptr : *(((*yyvaluep).column_constraints_t)->references)) {
+        delete ptr;
+      }
+    }
+    delete ((*yyvaluep).column_constraints_t)->references;
+  }
+  delete (((*yyvaluep).column_constraints_t));
+}
+#line 2373 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_column_constraint: /* column_constraint  */
 #line 181 "bison_parser.y"
             { }
-#line 2347 "bison_parser.cpp"
+#line 2379 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_constraint: /* table_constraint  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).table_constraint_t)); }
-#line 2353 "bison_parser.cpp"
+#line 2385 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_references_spec: /* references_spec  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).references_spec_t)); }
-#line 2359 "bison_parser.cpp"
+#line 2391 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_drop_statement: /* drop_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).drop_stmt)); }
-#line 2365 "bison_parser.cpp"
+#line 2397 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_exists: /* opt_exists  */
 #line 181 "bison_parser.y"
             { }
-#line 2371 "bison_parser.cpp"
+#line 2403 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_alter_statement: /* alter_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).alter_stmt)); }
-#line 2377 "bison_parser.cpp"
+#line 2409 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_alter_action: /* alter_action  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).alter_action_t)); }
-#line 2383 "bison_parser.cpp"
+#line 2415 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_drop_action: /* drop_action  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).drop_action_t)); }
-#line 2389 "bison_parser.cpp"
+#line 2421 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_delete_statement: /* delete_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).delete_stmt)); }
-#line 2395 "bison_parser.cpp"
+#line 2427 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_truncate_statement: /* truncate_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).delete_stmt)); }
-#line 2401 "bison_parser.cpp"
+#line 2433 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_insert_statement: /* insert_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).insert_stmt)); }
-#line 2407 "bison_parser.cpp"
+#line 2439 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_column_list: /* opt_column_list  */
@@ -2416,13 +2448,13 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).str_vec));
 }
-#line 2420 "bison_parser.cpp"
+#line 2452 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_update_statement: /* update_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).update_stmt)); }
-#line 2426 "bison_parser.cpp"
+#line 2458 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_update_clause_commalist: /* update_clause_commalist  */
@@ -2435,73 +2467,73 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).update_vec));
 }
-#line 2439 "bison_parser.cpp"
+#line 2471 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_update_clause: /* update_clause  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).update_t)); }
-#line 2445 "bison_parser.cpp"
+#line 2477 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_statement: /* select_statement  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2451 "bison_parser.cpp"
+#line 2483 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_within_set_operation: /* select_within_set_operation  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2457 "bison_parser.cpp"
+#line 2489 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_within_set_operation_no_parentheses: /* select_within_set_operation_no_parentheses  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2463 "bison_parser.cpp"
+#line 2495 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_with_paren: /* select_with_paren  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2469 "bison_parser.cpp"
+#line 2501 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_no_paren: /* select_no_paren  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2475 "bison_parser.cpp"
+#line 2507 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_set_operator: /* set_operator  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).set_operator_t)); }
-#line 2481 "bison_parser.cpp"
+#line 2513 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_set_type: /* set_type  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).set_operator_t)); }
-#line 2487 "bison_parser.cpp"
+#line 2519 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_all: /* opt_all  */
 #line 181 "bison_parser.y"
             { }
-#line 2493 "bison_parser.cpp"
+#line 2525 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_clause: /* select_clause  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).select_stmt)); }
-#line 2499 "bison_parser.cpp"
+#line 2531 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_distinct: /* opt_distinct  */
 #line 181 "bison_parser.y"
             { }
-#line 2505 "bison_parser.cpp"
+#line 2537 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_select_list: /* select_list  */
@@ -2514,37 +2546,37 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2518 "bison_parser.cpp"
+#line 2550 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_from_clause: /* opt_from_clause  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2524 "bison_parser.cpp"
+#line 2556 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_from_clause: /* from_clause  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2530 "bison_parser.cpp"
+#line 2562 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_where: /* opt_where  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2536 "bison_parser.cpp"
+#line 2568 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_group: /* opt_group  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).group_t)); }
-#line 2542 "bison_parser.cpp"
+#line 2574 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_having: /* opt_having  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2548 "bison_parser.cpp"
+#line 2580 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_order: /* opt_order  */
@@ -2557,7 +2589,7 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).order_vec));
 }
-#line 2561 "bison_parser.cpp"
+#line 2593 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_order_list: /* order_list  */
@@ -2570,37 +2602,37 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).order_vec));
 }
-#line 2574 "bison_parser.cpp"
+#line 2606 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_order_desc: /* order_desc  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).order)); }
-#line 2580 "bison_parser.cpp"
+#line 2612 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_order_type: /* opt_order_type  */
 #line 181 "bison_parser.y"
             { }
-#line 2586 "bison_parser.cpp"
+#line 2618 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_null_ordering: /* opt_null_ordering  */
 #line 181 "bison_parser.y"
             { }
-#line 2592 "bison_parser.cpp"
+#line 2624 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_top: /* opt_top  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).limit)); }
-#line 2598 "bison_parser.cpp"
+#line 2630 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_limit: /* opt_limit  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).limit)); }
-#line 2604 "bison_parser.cpp"
+#line 2636 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_expr_list: /* expr_list  */
@@ -2613,7 +2645,7 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2617 "bison_parser.cpp"
+#line 2649 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_extended_literal_list: /* opt_extended_literal_list  */
@@ -2626,7 +2658,7 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2630 "bison_parser.cpp"
+#line 2662 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_extended_literal_list: /* extended_literal_list  */
@@ -2639,103 +2671,103 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2643 "bison_parser.cpp"
+#line 2675 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_casted_extended_literal: /* casted_extended_literal  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2649 "bison_parser.cpp"
+#line 2681 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_extended_literal: /* extended_literal  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2655 "bison_parser.cpp"
+#line 2687 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_expr_alias: /* expr_alias  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2661 "bison_parser.cpp"
+#line 2693 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_expr: /* expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2667 "bison_parser.cpp"
+#line 2699 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_operand: /* operand  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2673 "bison_parser.cpp"
+#line 2705 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_scalar_expr: /* scalar_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2679 "bison_parser.cpp"
+#line 2711 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_unary_expr: /* unary_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2685 "bison_parser.cpp"
+#line 2717 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_binary_expr: /* binary_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2691 "bison_parser.cpp"
+#line 2723 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_logic_expr: /* logic_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2697 "bison_parser.cpp"
+#line 2729 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_in_expr: /* in_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2703 "bison_parser.cpp"
+#line 2735 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_case_expr: /* case_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2709 "bison_parser.cpp"
+#line 2741 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_case_list: /* case_list  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2715 "bison_parser.cpp"
+#line 2747 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_exists_expr: /* exists_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2721 "bison_parser.cpp"
+#line 2753 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_comp_expr: /* comp_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2727 "bison_parser.cpp"
+#line 2759 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_function_expr: /* function_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2733 "bison_parser.cpp"
+#line 2765 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_window: /* opt_window  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).window_description)); }
-#line 2739 "bison_parser.cpp"
+#line 2771 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_partition: /* opt_partition  */
@@ -2748,151 +2780,151 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2752 "bison_parser.cpp"
+#line 2784 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_frame_clause: /* opt_frame_clause  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).frame_description)); }
-#line 2758 "bison_parser.cpp"
+#line 2790 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_frame_type: /* frame_type  */
 #line 181 "bison_parser.y"
             { }
-#line 2764 "bison_parser.cpp"
+#line 2796 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_frame_bound: /* frame_bound  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).frame_bound)); }
-#line 2770 "bison_parser.cpp"
+#line 2802 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_extract_expr: /* extract_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2776 "bison_parser.cpp"
+#line 2808 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_cast_expr: /* cast_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2782 "bison_parser.cpp"
+#line 2814 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_datetime_field: /* datetime_field  */
 #line 181 "bison_parser.y"
             { }
-#line 2788 "bison_parser.cpp"
+#line 2820 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_datetime_field_plural: /* datetime_field_plural  */
 #line 181 "bison_parser.y"
             { }
-#line 2794 "bison_parser.cpp"
+#line 2826 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_duration_field: /* duration_field  */
 #line 181 "bison_parser.y"
             { }
-#line 2800 "bison_parser.cpp"
+#line 2832 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_array_expr: /* array_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2806 "bison_parser.cpp"
+#line 2838 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_array_index: /* array_index  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2812 "bison_parser.cpp"
+#line 2844 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_between_expr: /* between_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2818 "bison_parser.cpp"
+#line 2850 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_column_name: /* column_name  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2824 "bison_parser.cpp"
+#line 2856 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_literal: /* literal  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2830 "bison_parser.cpp"
+#line 2862 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_string_literal: /* string_literal  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2836 "bison_parser.cpp"
+#line 2868 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_bool_literal: /* bool_literal  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2842 "bison_parser.cpp"
+#line 2874 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_num_literal: /* num_literal  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2848 "bison_parser.cpp"
+#line 2880 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_int_literal: /* int_literal  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2854 "bison_parser.cpp"
+#line 2886 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_null_literal: /* null_literal  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2860 "bison_parser.cpp"
+#line 2892 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_date_literal: /* date_literal  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2866 "bison_parser.cpp"
+#line 2898 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_interval_literal: /* interval_literal  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2872 "bison_parser.cpp"
+#line 2904 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_param_expr: /* param_expr  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 2878 "bison_parser.cpp"
+#line 2910 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_ref: /* table_ref  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2884 "bison_parser.cpp"
+#line 2916 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_ref_atomic: /* table_ref_atomic  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2890 "bison_parser.cpp"
+#line 2922 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_nonjoin_table_ref_atomic: /* nonjoin_table_ref_atomic  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2896 "bison_parser.cpp"
+#line 2928 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_ref_commalist: /* table_ref_commalist  */
@@ -2905,19 +2937,19 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).table_vec));
 }
-#line 2909 "bison_parser.cpp"
+#line 2941 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_ref_name: /* table_ref_name  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2915 "bison_parser.cpp"
+#line 2947 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_ref_name_no_alias: /* table_ref_name_no_alias  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 2921 "bison_parser.cpp"
+#line 2953 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_name: /* table_name  */
@@ -2926,109 +2958,109 @@ yydestruct (const char *yymsg,
   free(((*yyvaluep).table_name).name);
   free(((*yyvaluep).table_name).schema);
 }
-#line 2930 "bison_parser.cpp"
+#line 2962 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_index_name: /* opt_index_name  */
 #line 194 "bison_parser.y"
             { free(((*yyvaluep).sval)); }
-#line 2936 "bison_parser.cpp"
+#line 2968 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_table_alias: /* table_alias  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).alias_t)); }
-#line 2942 "bison_parser.cpp"
+#line 2974 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_table_alias: /* opt_table_alias  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).alias_t)); }
-#line 2948 "bison_parser.cpp"
+#line 2980 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_alias: /* alias  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).alias_t)); }
-#line 2954 "bison_parser.cpp"
+#line 2986 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_alias: /* opt_alias  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).alias_t)); }
-#line 2960 "bison_parser.cpp"
+#line 2992 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_locking_clause: /* opt_locking_clause  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).locking_clause_vec)); }
-#line 2966 "bison_parser.cpp"
+#line 2998 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_locking_clause_list: /* opt_locking_clause_list  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).locking_clause_vec)); }
-#line 2972 "bison_parser.cpp"
+#line 3004 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_locking_clause: /* locking_clause  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).locking_t)); }
-#line 2978 "bison_parser.cpp"
+#line 3010 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_row_lock_mode: /* row_lock_mode  */
 #line 181 "bison_parser.y"
             { }
-#line 2984 "bison_parser.cpp"
+#line 3016 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_row_lock_policy: /* opt_row_lock_policy  */
 #line 181 "bison_parser.y"
             { }
-#line 2990 "bison_parser.cpp"
+#line 3022 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_with_clause: /* opt_with_clause  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).with_description_vec)); }
-#line 2996 "bison_parser.cpp"
+#line 3028 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_with_clause: /* with_clause  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).with_description_vec)); }
-#line 3002 "bison_parser.cpp"
+#line 3034 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_with_description_list: /* with_description_list  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).with_description_vec)); }
-#line 3008 "bison_parser.cpp"
+#line 3040 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_with_description: /* with_description  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).with_description_t)); }
-#line 3014 "bison_parser.cpp"
+#line 3046 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_join_clause: /* join_clause  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).table)); }
-#line 3020 "bison_parser.cpp"
+#line 3052 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_opt_join_type: /* opt_join_type  */
 #line 181 "bison_parser.y"
             { }
-#line 3026 "bison_parser.cpp"
+#line 3058 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_join_condition: /* join_condition  */
-#line 207 "bison_parser.y"
+#line 224 "bison_parser.y"
             { delete (((*yyvaluep).expr)); }
-#line 3032 "bison_parser.cpp"
+#line 3064 "bison_parser.cpp"
         break;
 
     case YYSYMBOL_ident_commalist: /* ident_commalist  */
@@ -3041,7 +3073,7 @@ yydestruct (const char *yymsg,
   }
   delete (((*yyvaluep).str_vec));
 }
-#line 3045 "bison_parser.cpp"
+#line 3077 "bison_parser.cpp"
         break;
 
       default:
@@ -3149,7 +3181,7 @@ YYLTYPE yylloc = yyloc_default;
   yylloc.string_length = 0;
 }
 
-#line 3153 "bison_parser.cpp"
+#line 3185 "bison_parser.cpp"
 
   yylsp[0] = yylloc;
   goto yysetstate;
@@ -3360,7 +3392,7 @@ yyreduce:
   switch (yyn)
     {
   case 2: /* input: statement_list opt_semicolon  */
-#line 345 "bison_parser.y"
+#line 362 "bison_parser.y"
                                      {
   for (SQLStatement* stmt : *(yyvsp[-1].stmt_vec)) {
     // Transfers ownership of the statement.
@@ -3379,236 +3411,236 @@ yyreduce:
   }
     delete (yyvsp[-1].stmt_vec);
   }
-#line 3383 "bison_parser.cpp"
+#line 3415 "bison_parser.cpp"
     break;
 
   case 3: /* statement_list: statement  */
-#line 365 "bison_parser.y"
+#line 382 "bison_parser.y"
                            {
   (yyvsp[0].statement)->stringLength = yylloc.string_length;
   yylloc.string_length = 0;
   (yyval.stmt_vec) = new std::vector<SQLStatement*>();
   (yyval.stmt_vec)->push_back((yyvsp[0].statement));
 }
-#line 3394 "bison_parser.cpp"
+#line 3426 "bison_parser.cpp"
     break;
 
   case 4: /* statement_list: statement_list ';' statement  */
-#line 371 "bison_parser.y"
+#line 388 "bison_parser.y"
                                {
   (yyvsp[0].statement)->stringLength = yylloc.string_length;
   yylloc.string_length = 0;
   (yyvsp[-2].stmt_vec)->push_back((yyvsp[0].statement));
   (yyval.stmt_vec) = (yyvsp[-2].stmt_vec);
 }
-#line 3405 "bison_parser.cpp"
+#line 3437 "bison_parser.cpp"
     break;
 
   case 5: /* statement: prepare_statement opt_hints  */
-#line 378 "bison_parser.y"
+#line 395 "bison_parser.y"
                                         {
   (yyval.statement) = (yyvsp[-1].prep_stmt);
   (yyval.statement)->hints = (yyvsp[0].expr_vec);
 }
-#line 3414 "bison_parser.cpp"
+#line 3446 "bison_parser.cpp"
     break;
 
   case 6: /* statement: preparable_statement opt_hints  */
-#line 382 "bison_parser.y"
+#line 399 "bison_parser.y"
                                  {
   (yyval.statement) = (yyvsp[-1].statement);
   (yyval.statement)->hints = (yyvsp[0].expr_vec);
 }
-#line 3423 "bison_parser.cpp"
+#line 3455 "bison_parser.cpp"
     break;
 
   case 7: /* statement: show_statement  */
-#line 386 "bison_parser.y"
+#line 403 "bison_parser.y"
                  { (yyval.statement) = (yyvsp[0].show_stmt); }
-#line 3429 "bison_parser.cpp"
+#line 3461 "bison_parser.cpp"
     break;
 
   case 8: /* statement: import_statement  */
-#line 387 "bison_parser.y"
+#line 404 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].import_stmt); }
-#line 3435 "bison_parser.cpp"
+#line 3467 "bison_parser.cpp"
     break;
 
   case 9: /* statement: export_statement  */
-#line 388 "bison_parser.y"
+#line 405 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].export_stmt); }
-#line 3441 "bison_parser.cpp"
+#line 3473 "bison_parser.cpp"
     break;
 
   case 10: /* preparable_statement: select_statement  */
-#line 390 "bison_parser.y"
+#line 407 "bison_parser.y"
                                         { (yyval.statement) = (yyvsp[0].select_stmt); }
-#line 3447 "bison_parser.cpp"
+#line 3479 "bison_parser.cpp"
     break;
 
   case 11: /* preparable_statement: create_statement  */
-#line 391 "bison_parser.y"
+#line 408 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].create_stmt); }
-#line 3453 "bison_parser.cpp"
+#line 3485 "bison_parser.cpp"
     break;
 
   case 12: /* preparable_statement: insert_statement  */
-#line 392 "bison_parser.y"
+#line 409 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].insert_stmt); }
-#line 3459 "bison_parser.cpp"
+#line 3491 "bison_parser.cpp"
     break;
 
   case 13: /* preparable_statement: delete_statement  */
-#line 393 "bison_parser.y"
+#line 410 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 3465 "bison_parser.cpp"
+#line 3497 "bison_parser.cpp"
     break;
 
   case 14: /* preparable_statement: truncate_statement  */
-#line 394 "bison_parser.y"
+#line 411 "bison_parser.y"
                      { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 3471 "bison_parser.cpp"
+#line 3503 "bison_parser.cpp"
     break;
 
   case 15: /* preparable_statement: update_statement  */
-#line 395 "bison_parser.y"
+#line 412 "bison_parser.y"
                    { (yyval.statement) = (yyvsp[0].update_stmt); }
-#line 3477 "bison_parser.cpp"
+#line 3509 "bison_parser.cpp"
     break;
 
   case 16: /* preparable_statement: drop_statement  */
-#line 396 "bison_parser.y"
+#line 413 "bison_parser.y"
                  { (yyval.statement) = (yyvsp[0].drop_stmt); }
-#line 3483 "bison_parser.cpp"
+#line 3515 "bison_parser.cpp"
     break;
 
   case 17: /* preparable_statement: alter_statement  */
-#line 397 "bison_parser.y"
+#line 414 "bison_parser.y"
                   { (yyval.statement) = (yyvsp[0].alter_stmt); }
-#line 3489 "bison_parser.cpp"
+#line 3521 "bison_parser.cpp"
     break;
 
   case 18: /* preparable_statement: execute_statement  */
-#line 398 "bison_parser.y"
+#line 415 "bison_parser.y"
                     { (yyval.statement) = (yyvsp[0].exec_stmt); }
-#line 3495 "bison_parser.cpp"
+#line 3527 "bison_parser.cpp"
     break;
 
   case 19: /* preparable_statement: transaction_statement  */
-#line 399 "bison_parser.y"
+#line 416 "bison_parser.y"
                         { (yyval.statement) = (yyvsp[0].transaction_stmt); }
-#line 3501 "bison_parser.cpp"
+#line 3533 "bison_parser.cpp"
     break;
 
   case 20: /* opt_hints: WITH HINT '(' hint_list ')'  */
-#line 405 "bison_parser.y"
+#line 422 "bison_parser.y"
                                         { (yyval.expr_vec) = (yyvsp[-1].expr_vec); }
-#line 3507 "bison_parser.cpp"
+#line 3539 "bison_parser.cpp"
     break;
 
   case 21: /* opt_hints: %empty  */
-#line 406 "bison_parser.y"
+#line 423 "bison_parser.y"
               { (yyval.expr_vec) = nullptr; }
-#line 3513 "bison_parser.cpp"
+#line 3545 "bison_parser.cpp"
     break;
 
   case 22: /* hint_list: hint  */
-#line 408 "bison_parser.y"
+#line 425 "bison_parser.y"
                  {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 3522 "bison_parser.cpp"
+#line 3554 "bison_parser.cpp"
     break;
 
   case 23: /* hint_list: hint_list ',' hint  */
-#line 412 "bison_parser.y"
+#line 429 "bison_parser.y"
                      {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 3531 "bison_parser.cpp"
+#line 3563 "bison_parser.cpp"
     break;
 
   case 24: /* hint: IDENTIFIER  */
-#line 417 "bison_parser.y"
+#line 434 "bison_parser.y"
                   {
   (yyval.expr) = Expr::make(kExprHint);
   (yyval.expr)->name = (yyvsp[0].sval);
 }
-#line 3540 "bison_parser.cpp"
+#line 3572 "bison_parser.cpp"
     break;
 
   case 25: /* hint: IDENTIFIER '(' extended_literal_list ')'  */
-#line 421 "bison_parser.y"
+#line 438 "bison_parser.y"
                                            {
   (yyval.expr) = Expr::make(kExprHint);
   (yyval.expr)->name = (yyvsp[-3].sval);
   (yyval.expr)->exprList = (yyvsp[-1].expr_vec);
 }
-#line 3550 "bison_parser.cpp"
+#line 3582 "bison_parser.cpp"
     break;
 
   case 26: /* transaction_statement: BEGIN opt_transaction_keyword  */
-#line 431 "bison_parser.y"
+#line 448 "bison_parser.y"
                                                       { (yyval.transaction_stmt) = new TransactionStatement(kBeginTransaction); }
-#line 3556 "bison_parser.cpp"
+#line 3588 "bison_parser.cpp"
     break;
 
   case 27: /* transaction_statement: ROLLBACK opt_transaction_keyword  */
-#line 432 "bison_parser.y"
+#line 449 "bison_parser.y"
                                    { (yyval.transaction_stmt) = new TransactionStatement(kRollbackTransaction); }
-#line 3562 "bison_parser.cpp"
+#line 3594 "bison_parser.cpp"
     break;
 
   case 28: /* transaction_statement: COMMIT opt_transaction_keyword  */
-#line 433 "bison_parser.y"
+#line 450 "bison_parser.y"
                                  { (yyval.transaction_stmt) = new TransactionStatement(kCommitTransaction); }
-#line 3568 "bison_parser.cpp"
+#line 3600 "bison_parser.cpp"
     break;
 
   case 31: /* prepare_statement: PREPARE IDENTIFIER FROM prepare_target_query  */
-#line 441 "bison_parser.y"
+#line 458 "bison_parser.y"
                                                                  {
   (yyval.prep_stmt) = new PrepareStatement();
   (yyval.prep_stmt)->name = (yyvsp[-2].sval);
   (yyval.prep_stmt)->query = (yyvsp[0].sval);
 }
-#line 3578 "bison_parser.cpp"
+#line 3610 "bison_parser.cpp"
     break;
 
   case 33: /* execute_statement: EXECUTE IDENTIFIER  */
-#line 449 "bison_parser.y"
+#line 466 "bison_parser.y"
                                        {
   (yyval.exec_stmt) = new ExecuteStatement();
   (yyval.exec_stmt)->name = (yyvsp[0].sval);
 }
-#line 3587 "bison_parser.cpp"
+#line 3619 "bison_parser.cpp"
     break;
 
   case 34: /* execute_statement: EXECUTE IDENTIFIER '(' opt_extended_literal_list ')'  */
-#line 453 "bison_parser.y"
+#line 470 "bison_parser.y"
                                                        {
   (yyval.exec_stmt) = new ExecuteStatement();
   (yyval.exec_stmt)->name = (yyvsp[-3].sval);
   (yyval.exec_stmt)->parameters = (yyvsp[-1].expr_vec);
 }
-#line 3597 "bison_parser.cpp"
+#line 3629 "bison_parser.cpp"
     break;
 
   case 35: /* import_statement: IMPORT FROM file_type FILE file_path INTO table_name  */
-#line 465 "bison_parser.y"
+#line 482 "bison_parser.y"
                                                                         {
   (yyval.import_stmt) = new ImportStatement((yyvsp[-4].import_type_t));
   (yyval.import_stmt)->filePath = (yyvsp[-2].sval);
   (yyval.import_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.import_stmt)->tableName = (yyvsp[0].table_name).name;
 }
-#line 3608 "bison_parser.cpp"
+#line 3640 "bison_parser.cpp"
     break;
 
   case 36: /* import_statement: COPY table_name FROM file_path opt_import_export_options opt_where  */
-#line 471 "bison_parser.y"
+#line 488 "bison_parser.y"
                                                                      {
   (yyval.import_stmt) = new ImportStatement((yyvsp[-1].import_export_option_t)->format);
   (yyval.import_stmt)->filePath = (yyvsp[-2].sval);
@@ -3625,11 +3657,11 @@ yyreduce:
   }
   delete (yyvsp[-1].import_export_option_t);
 }
-#line 3629 "bison_parser.cpp"
+#line 3661 "bison_parser.cpp"
     break;
 
   case 37: /* file_type: IDENTIFIER  */
-#line 488 "bison_parser.y"
+#line 505 "bison_parser.y"
                        {
   if (strcasecmp((yyvsp[0].sval), "csv") == 0) {
     (yyval.import_type_t) = kImportCSV;
@@ -3644,35 +3676,35 @@ yyreduce:
   }
   free((yyvsp[0].sval));
 }
-#line 3648 "bison_parser.cpp"
+#line 3680 "bison_parser.cpp"
     break;
 
   case 38: /* file_path: STRING  */
-#line 503 "bison_parser.y"
+#line 520 "bison_parser.y"
                    { (yyval.sval) = (yyvsp[0].sval); }
-#line 3654 "bison_parser.cpp"
+#line 3686 "bison_parser.cpp"
     break;
 
   case 39: /* opt_import_export_options: WITH '(' import_export_options ')'  */
-#line 505 "bison_parser.y"
+#line 522 "bison_parser.y"
                                                                { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
-#line 3660 "bison_parser.cpp"
+#line 3692 "bison_parser.cpp"
     break;
 
   case 40: /* opt_import_export_options: '(' import_export_options ')'  */
-#line 506 "bison_parser.y"
+#line 523 "bison_parser.y"
                                 { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
-#line 3666 "bison_parser.cpp"
+#line 3698 "bison_parser.cpp"
     break;
 
   case 41: /* opt_import_export_options: %empty  */
-#line 507 "bison_parser.y"
+#line 524 "bison_parser.y"
               { (yyval.import_export_option_t) = new ImportExportOptions{}; }
-#line 3672 "bison_parser.cpp"
+#line 3704 "bison_parser.cpp"
     break;
 
   case 42: /* import_export_options: import_export_options ',' FORMAT file_type  */
-#line 509 "bison_parser.y"
+#line 526 "bison_parser.y"
                                                                    {
   if ((yyvsp[-3].import_export_option_t)->format != kImportAuto) {
     delete (yyvsp[-3].import_export_option_t);
@@ -3687,20 +3719,20 @@ yyreduce:
   (yyvsp[-3].import_export_option_t)->format = (yyvsp[0].import_type_t);
   (yyval.import_export_option_t) = (yyvsp[-3].import_export_option_t);
 }
-#line 3691 "bison_parser.cpp"
+#line 3723 "bison_parser.cpp"
     break;
 
   case 43: /* import_export_options: FORMAT file_type  */
-#line 523 "bison_parser.y"
+#line 540 "bison_parser.y"
                    {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->format = (yyvsp[0].import_type_t);
 }
-#line 3700 "bison_parser.cpp"
+#line 3732 "bison_parser.cpp"
     break;
 
   case 44: /* import_export_options: import_export_options ',' ENCODING STRING  */
-#line 527 "bison_parser.y"
+#line 544 "bison_parser.y"
                                             {
   if ((yyvsp[-3].import_export_option_t)->encoding) {
     delete (yyvsp[-3].import_export_option_t);
@@ -3711,20 +3743,20 @@ yyreduce:
   (yyvsp[-3].import_export_option_t)->encoding = (yyvsp[0].sval);
   (yyval.import_export_option_t) = (yyvsp[-3].import_export_option_t);
 }
-#line 3715 "bison_parser.cpp"
+#line 3747 "bison_parser.cpp"
     break;
 
   case 45: /* import_export_options: ENCODING STRING  */
-#line 537 "bison_parser.y"
+#line 554 "bison_parser.y"
                   {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->encoding = (yyvsp[0].sval);
 }
-#line 3724 "bison_parser.cpp"
+#line 3756 "bison_parser.cpp"
     break;
 
   case 46: /* import_export_options: import_export_options ',' csv_option  */
-#line 541 "bison_parser.y"
+#line 558 "bison_parser.y"
                                        {
   if ((yyvsp[-2].import_export_option_t)->format != kImportAuto && (yyvsp[-2].import_export_option_t)->format != kImportCSV) {
     delete (yyvsp[-2].import_export_option_t);
@@ -3749,11 +3781,11 @@ yyreduce:
   delete (yyvsp[0].csv_option_t);
   (yyval.import_export_option_t) = (yyvsp[-2].import_export_option_t);
 }
-#line 3753 "bison_parser.cpp"
+#line 3785 "bison_parser.cpp"
     break;
 
   case 47: /* import_export_options: csv_option  */
-#line 565 "bison_parser.y"
+#line 582 "bison_parser.y"
              {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->csv_options = new CsvOptions{};
@@ -3761,11 +3793,11 @@ yyreduce:
 
   delete (yyvsp[0].csv_option_t);
 }
-#line 3765 "bison_parser.cpp"
+#line 3797 "bison_parser.cpp"
     break;
 
   case 48: /* csv_option: IDENTIFIER STRING  */
-#line 573 "bison_parser.y"
+#line 590 "bison_parser.y"
                                {
   if (strcasecmp((yyvsp[-1].sval), "DELIMITER") == 0) {
     (yyval.csv_option_t) = new std::pair<CsvOptionType, char*>(CsvOptionType::Delimiter, (yyvsp[0].sval));
@@ -3779,17 +3811,17 @@ yyreduce:
   }
   free((yyvsp[-1].sval));
 }
-#line 3783 "bison_parser.cpp"
+#line 3815 "bison_parser.cpp"
     break;
 
   case 49: /* csv_option: NULL STRING  */
-#line 586 "bison_parser.y"
+#line 603 "bison_parser.y"
               { (yyval.csv_option_t) = new std::pair<CsvOptionType, char*>(CsvOptionType::Null, (yyvsp[0].sval)); }
-#line 3789 "bison_parser.cpp"
+#line 3821 "bison_parser.cpp"
     break;
 
   case 50: /* export_statement: COPY table_name TO file_path opt_import_export_options  */
-#line 593 "bison_parser.y"
+#line 610 "bison_parser.y"
                                                                           {
   (yyval.export_stmt) = new ExportStatement((yyvsp[0].import_export_option_t)->format);
   (yyval.export_stmt)->filePath = (yyvsp[-1].sval);
@@ -3805,11 +3837,11 @@ yyreduce:
   }
   delete (yyvsp[0].import_export_option_t);
 }
-#line 3809 "bison_parser.cpp"
+#line 3841 "bison_parser.cpp"
     break;
 
   case 51: /* export_statement: COPY select_with_paren TO file_path opt_import_export_options  */
-#line 608 "bison_parser.y"
+#line 625 "bison_parser.y"
                                                                 {
   (yyval.export_stmt) = new ExportStatement((yyvsp[0].import_export_option_t)->format);
   (yyval.export_stmt)->filePath = (yyvsp[-1].sval);
@@ -3824,37 +3856,37 @@ yyreduce:
   }
   delete (yyvsp[0].import_export_option_t);
 }
-#line 3828 "bison_parser.cpp"
+#line 3860 "bison_parser.cpp"
     break;
 
   case 52: /* show_statement: SHOW TABLES  */
-#line 628 "bison_parser.y"
+#line 645 "bison_parser.y"
                              { (yyval.show_stmt) = new ShowStatement(kShowTables); }
-#line 3834 "bison_parser.cpp"
+#line 3866 "bison_parser.cpp"
     break;
 
   case 53: /* show_statement: SHOW COLUMNS table_name  */
-#line 629 "bison_parser.y"
+#line 646 "bison_parser.y"
                           {
   (yyval.show_stmt) = new ShowStatement(kShowColumns);
   (yyval.show_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.show_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 3844 "bison_parser.cpp"
+#line 3876 "bison_parser.cpp"
     break;
 
   case 54: /* show_statement: DESCRIBE table_name  */
-#line 634 "bison_parser.y"
+#line 651 "bison_parser.y"
                       {
   (yyval.show_stmt) = new ShowStatement(kShowColumns);
   (yyval.show_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.show_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 3854 "bison_parser.cpp"
+#line 3886 "bison_parser.cpp"
     break;
 
   case 55: /* create_statement: CREATE TABLE opt_not_exists table_name FROM IDENTIFIER FILE file_path  */
-#line 645 "bison_parser.y"
+#line 662 "bison_parser.y"
                                                                                          {
   (yyval.create_stmt) = new CreateStatement(kCreateTableFromTbl);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-5].bval);
@@ -3868,11 +3900,11 @@ yyreduce:
   free((yyvsp[-2].sval));
   (yyval.create_stmt)->filePath = (yyvsp[0].sval);
 }
-#line 3872 "bison_parser.cpp"
+#line 3904 "bison_parser.cpp"
     break;
 
   case 56: /* create_statement: CREATE TABLE opt_not_exists table_name '(' table_elem_commalist ')'  */
-#line 658 "bison_parser.y"
+#line 675 "bison_parser.y"
                                                                       {
   (yyval.create_stmt) = new CreateStatement(kCreateTable);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
@@ -3885,11 +3917,11 @@ yyreduce:
     YYERROR;
   }
 }
-#line 3889 "bison_parser.cpp"
+#line 3921 "bison_parser.cpp"
     break;
 
   case 57: /* create_statement: CREATE TABLE opt_not_exists table_name AS select_statement  */
-#line 670 "bison_parser.y"
+#line 687 "bison_parser.y"
                                                              {
   (yyval.create_stmt) = new CreateStatement(kCreateTable);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-3].bval);
@@ -3897,11 +3929,11 @@ yyreduce:
   (yyval.create_stmt)->tableName = (yyvsp[-2].table_name).name;
   (yyval.create_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 3901 "bison_parser.cpp"
+#line 3933 "bison_parser.cpp"
     break;
 
   case 58: /* create_statement: CREATE INDEX opt_not_exists opt_index_name ON table_name '(' ident_commalist ')'  */
-#line 677 "bison_parser.y"
+#line 694 "bison_parser.y"
                                                                                    {
   (yyval.create_stmt) = new CreateStatement(kCreateIndex);
   (yyval.create_stmt)->indexName = (yyvsp[-5].sval);
@@ -3909,11 +3941,11 @@ yyreduce:
   (yyval.create_stmt)->tableName = (yyvsp[-3].table_name).name;
   (yyval.create_stmt)->indexColumns = (yyvsp[-1].str_vec);
 }
-#line 3913 "bison_parser.cpp"
+#line 3945 "bison_parser.cpp"
     break;
 
   case 59: /* create_statement: CREATE VIEW opt_not_exists table_name opt_column_list AS select_statement  */
-#line 684 "bison_parser.y"
+#line 701 "bison_parser.y"
                                                                             {
   (yyval.create_stmt) = new CreateStatement(kCreateView);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
@@ -3922,53 +3954,53 @@ yyreduce:
   (yyval.create_stmt)->viewColumns = (yyvsp[-2].str_vec);
   (yyval.create_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 3926 "bison_parser.cpp"
+#line 3958 "bison_parser.cpp"
     break;
 
   case 60: /* opt_not_exists: IF NOT EXISTS  */
-#line 693 "bison_parser.y"
+#line 710 "bison_parser.y"
                                { (yyval.bval) = true; }
-#line 3932 "bison_parser.cpp"
+#line 3964 "bison_parser.cpp"
     break;
 
   case 61: /* opt_not_exists: %empty  */
-#line 694 "bison_parser.y"
+#line 711 "bison_parser.y"
               { (yyval.bval) = false; }
-#line 3938 "bison_parser.cpp"
+#line 3970 "bison_parser.cpp"
     break;
 
   case 62: /* table_elem_commalist: table_elem  */
-#line 696 "bison_parser.y"
+#line 713 "bison_parser.y"
                                   {
   (yyval.table_element_vec) = new std::vector<TableElement*>();
   (yyval.table_element_vec)->push_back((yyvsp[0].table_element_t));
 }
-#line 3947 "bison_parser.cpp"
+#line 3979 "bison_parser.cpp"
     break;
 
   case 63: /* table_elem_commalist: table_elem_commalist ',' table_elem  */
-#line 700 "bison_parser.y"
+#line 717 "bison_parser.y"
                                       {
   (yyvsp[-2].table_element_vec)->push_back((yyvsp[0].table_element_t));
   (yyval.table_element_vec) = (yyvsp[-2].table_element_vec);
 }
-#line 3956 "bison_parser.cpp"
+#line 3988 "bison_parser.cpp"
     break;
 
   case 64: /* table_elem: column_def  */
-#line 705 "bison_parser.y"
+#line 722 "bison_parser.y"
                         { (yyval.table_element_t) = (yyvsp[0].column_t); }
-#line 3962 "bison_parser.cpp"
+#line 3994 "bison_parser.cpp"
     break;
 
   case 65: /* table_elem: table_constraint  */
-#line 706 "bison_parser.y"
+#line 723 "bison_parser.y"
                    { (yyval.table_element_t) = (yyvsp[0].table_constraint_t); }
-#line 3968 "bison_parser.cpp"
+#line 4000 "bison_parser.cpp"
     break;
 
   case 66: /* column_def: IDENTIFIER column_type opt_column_constraints  */
-#line 708 "bison_parser.y"
+#line 725 "bison_parser.y"
                                                            {
   (yyval.column_t) = new ColumnDefinition((yyvsp[-2].sval), (yyvsp[-1].column_type_t), (yyvsp[0].column_constraints_t)->constraints, (yyvsp[0].column_constraints_t)->references);
   if (!(yyval.column_t)->trySetNullableExplicit()) {
@@ -3976,192 +4008,192 @@ yyreduce:
   }
   delete (yyvsp[0].column_constraints_t);
 }
-#line 3980 "bison_parser.cpp"
+#line 4012 "bison_parser.cpp"
     break;
 
   case 67: /* column_type: BIGINT  */
-#line 716 "bison_parser.y"
+#line 733 "bison_parser.y"
                      { (yyval.column_type_t) = ColumnType{DataType::BIGINT}; }
-#line 3986 "bison_parser.cpp"
+#line 4018 "bison_parser.cpp"
     break;
 
   case 68: /* column_type: BOOLEAN  */
-#line 717 "bison_parser.y"
+#line 734 "bison_parser.y"
           { (yyval.column_type_t) = ColumnType{DataType::BOOLEAN}; }
-#line 3992 "bison_parser.cpp"
+#line 4024 "bison_parser.cpp"
     break;
 
   case 69: /* column_type: CHAR '(' INTVAL ')'  */
-#line 718 "bison_parser.y"
+#line 735 "bison_parser.y"
                       { (yyval.column_type_t) = ColumnType{DataType::CHAR, (yyvsp[-1].ival)}; }
-#line 3998 "bison_parser.cpp"
+#line 4030 "bison_parser.cpp"
     break;
 
   case 70: /* column_type: CHARACTER_VARYING '(' INTVAL ')'  */
-#line 719 "bison_parser.y"
+#line 736 "bison_parser.y"
                                    { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
-#line 4004 "bison_parser.cpp"
+#line 4036 "bison_parser.cpp"
     break;
 
   case 71: /* column_type: DATE  */
-#line 720 "bison_parser.y"
+#line 737 "bison_parser.y"
        { (yyval.column_type_t) = ColumnType{DataType::DATE}; }
-#line 4010 "bison_parser.cpp"
+#line 4042 "bison_parser.cpp"
     break;
 
   case 72: /* column_type: DATETIME  */
-#line 721 "bison_parser.y"
+#line 738 "bison_parser.y"
            { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
-#line 4016 "bison_parser.cpp"
+#line 4048 "bison_parser.cpp"
     break;
 
   case 73: /* column_type: DECIMAL opt_decimal_specification  */
-#line 722 "bison_parser.y"
+#line 739 "bison_parser.y"
                                     {
   (yyval.column_type_t) = ColumnType{DataType::DECIMAL, 0, (yyvsp[0].ival_pair)->first, (yyvsp[0].ival_pair)->second};
   delete (yyvsp[0].ival_pair);
 }
-#line 4025 "bison_parser.cpp"
+#line 4057 "bison_parser.cpp"
     break;
 
   case 74: /* column_type: DOUBLE  */
-#line 726 "bison_parser.y"
+#line 743 "bison_parser.y"
          { (yyval.column_type_t) = ColumnType{DataType::DOUBLE}; }
-#line 4031 "bison_parser.cpp"
+#line 4063 "bison_parser.cpp"
     break;
 
   case 75: /* column_type: FLOAT  */
-#line 727 "bison_parser.y"
+#line 744 "bison_parser.y"
         { (yyval.column_type_t) = ColumnType{DataType::FLOAT}; }
-#line 4037 "bison_parser.cpp"
+#line 4069 "bison_parser.cpp"
     break;
 
   case 76: /* column_type: INT  */
-#line 728 "bison_parser.y"
+#line 745 "bison_parser.y"
       { (yyval.column_type_t) = ColumnType{DataType::INT}; }
-#line 4043 "bison_parser.cpp"
+#line 4075 "bison_parser.cpp"
     break;
 
   case 77: /* column_type: INTEGER  */
-#line 729 "bison_parser.y"
+#line 746 "bison_parser.y"
           { (yyval.column_type_t) = ColumnType{DataType::INT}; }
-#line 4049 "bison_parser.cpp"
+#line 4081 "bison_parser.cpp"
     break;
 
   case 78: /* column_type: LONG  */
-#line 730 "bison_parser.y"
+#line 747 "bison_parser.y"
        { (yyval.column_type_t) = ColumnType{DataType::LONG}; }
-#line 4055 "bison_parser.cpp"
+#line 4087 "bison_parser.cpp"
     break;
 
   case 79: /* column_type: REAL  */
-#line 731 "bison_parser.y"
+#line 748 "bison_parser.y"
        { (yyval.column_type_t) = ColumnType{DataType::REAL}; }
-#line 4061 "bison_parser.cpp"
+#line 4093 "bison_parser.cpp"
     break;
 
   case 80: /* column_type: SMALLINT  */
-#line 732 "bison_parser.y"
+#line 749 "bison_parser.y"
            { (yyval.column_type_t) = ColumnType{DataType::SMALLINT}; }
-#line 4067 "bison_parser.cpp"
+#line 4099 "bison_parser.cpp"
     break;
 
   case 81: /* column_type: TEXT  */
-#line 733 "bison_parser.y"
+#line 750 "bison_parser.y"
        { (yyval.column_type_t) = ColumnType{DataType::TEXT}; }
-#line 4073 "bison_parser.cpp"
+#line 4105 "bison_parser.cpp"
     break;
 
   case 82: /* column_type: TIME opt_time_precision  */
-#line 734 "bison_parser.y"
+#line 751 "bison_parser.y"
                           { (yyval.column_type_t) = ColumnType{DataType::TIME, 0, (yyvsp[0].ival)}; }
-#line 4079 "bison_parser.cpp"
+#line 4111 "bison_parser.cpp"
     break;
 
   case 83: /* column_type: TIMESTAMP  */
-#line 735 "bison_parser.y"
+#line 752 "bison_parser.y"
             { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
-#line 4085 "bison_parser.cpp"
+#line 4117 "bison_parser.cpp"
     break;
 
   case 84: /* column_type: VARCHAR '(' INTVAL ')'  */
-#line 736 "bison_parser.y"
+#line 753 "bison_parser.y"
                          { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
-#line 4091 "bison_parser.cpp"
+#line 4123 "bison_parser.cpp"
     break;
 
   case 85: /* opt_time_precision: '(' INTVAL ')'  */
-#line 738 "bison_parser.y"
+#line 755 "bison_parser.y"
                                     { (yyval.ival) = (yyvsp[-1].ival); }
-#line 4097 "bison_parser.cpp"
+#line 4129 "bison_parser.cpp"
     break;
 
   case 86: /* opt_time_precision: %empty  */
-#line 739 "bison_parser.y"
+#line 756 "bison_parser.y"
               { (yyval.ival) = 0; }
-#line 4103 "bison_parser.cpp"
+#line 4135 "bison_parser.cpp"
     break;
 
   case 87: /* opt_decimal_specification: '(' INTVAL ',' INTVAL ')'  */
-#line 741 "bison_parser.y"
+#line 758 "bison_parser.y"
                                                       { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-3].ival), (yyvsp[-1].ival)}; }
-#line 4109 "bison_parser.cpp"
+#line 4141 "bison_parser.cpp"
     break;
 
   case 88: /* opt_decimal_specification: '(' INTVAL ')'  */
-#line 742 "bison_parser.y"
+#line 759 "bison_parser.y"
                  { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-1].ival), 0}; }
-#line 4115 "bison_parser.cpp"
+#line 4147 "bison_parser.cpp"
     break;
 
   case 89: /* opt_decimal_specification: %empty  */
-#line 743 "bison_parser.y"
+#line 760 "bison_parser.y"
               { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{0, 0}; }
-#line 4121 "bison_parser.cpp"
+#line 4153 "bison_parser.cpp"
     break;
 
   case 90: /* opt_column_constraints: column_constraints  */
-#line 745 "bison_parser.y"
+#line 762 "bison_parser.y"
                                             { (yyval.column_constraints_t) = (yyvsp[0].column_constraints_t); }
-#line 4127 "bison_parser.cpp"
+#line 4159 "bison_parser.cpp"
     break;
 
   case 91: /* opt_column_constraints: %empty  */
-#line 746 "bison_parser.y"
+#line 763 "bison_parser.y"
               { (yyval.column_constraints_t) = new ColumnConstraints(); }
-#line 4133 "bison_parser.cpp"
+#line 4165 "bison_parser.cpp"
     break;
 
   case 92: /* column_constraints: column_constraint  */
-#line 748 "bison_parser.y"
+#line 765 "bison_parser.y"
                                        {
   (yyval.column_constraints_t) = new ColumnConstraints();
   (yyval.column_constraints_t)->constraints->insert((yyvsp[0].column_constraint_t));
 }
-#line 4142 "bison_parser.cpp"
+#line 4174 "bison_parser.cpp"
     break;
 
   case 93: /* column_constraints: column_constraints column_constraint  */
-#line 752 "bison_parser.y"
+#line 769 "bison_parser.y"
                                        {
   (yyvsp[-1].column_constraints_t)->constraints->insert((yyvsp[0].column_constraint_t));
   (yyval.column_constraints_t) = (yyvsp[-1].column_constraints_t);
 }
-#line 4151 "bison_parser.cpp"
+#line 4183 "bison_parser.cpp"
     break;
 
   case 94: /* column_constraints: references_spec  */
-#line 756 "bison_parser.y"
+#line 773 "bison_parser.y"
                   {
   (yyval.column_constraints_t) = new ColumnConstraints();
   (yyval.column_constraints_t)->constraints->insert(ConstraintType::ForeignKey);
   (yyval.column_constraints_t)->references->emplace_back((yyvsp[0].references_spec_t));
 }
-#line 4161 "bison_parser.cpp"
+#line 4193 "bison_parser.cpp"
     break;
 
   case 95: /* column_constraints: column_constraints references_spec  */
-#line 761 "bison_parser.y"
+#line 778 "bison_parser.y"
                                      {
   // Multiple foreign keys for the same column could be possible, so we do not raise an error in that case.
   // Think of foreign keys referenced on multiple levels (returned item references sold item references items).
@@ -4169,159 +4201,159 @@ yyreduce:
   (yyvsp[-1].column_constraints_t)->references->emplace_back((yyvsp[0].references_spec_t));
   (yyval.column_constraints_t) = (yyvsp[-1].column_constraints_t);
 }
-#line 4173 "bison_parser.cpp"
+#line 4205 "bison_parser.cpp"
     break;
 
   case 96: /* column_constraint: PRIMARY KEY  */
-#line 769 "bison_parser.y"
+#line 786 "bison_parser.y"
                                 { (yyval.column_constraint_t) = ConstraintType::PrimaryKey; }
-#line 4179 "bison_parser.cpp"
+#line 4211 "bison_parser.cpp"
     break;
 
   case 97: /* column_constraint: UNIQUE  */
-#line 770 "bison_parser.y"
+#line 787 "bison_parser.y"
          { (yyval.column_constraint_t) = ConstraintType::Unique; }
-#line 4185 "bison_parser.cpp"
+#line 4217 "bison_parser.cpp"
     break;
 
   case 98: /* column_constraint: NULL  */
-#line 771 "bison_parser.y"
+#line 788 "bison_parser.y"
        { (yyval.column_constraint_t) = ConstraintType::Null; }
-#line 4191 "bison_parser.cpp"
+#line 4223 "bison_parser.cpp"
     break;
 
   case 99: /* column_constraint: NOT NULL  */
-#line 772 "bison_parser.y"
+#line 789 "bison_parser.y"
            { (yyval.column_constraint_t) = ConstraintType::NotNull; }
-#line 4197 "bison_parser.cpp"
+#line 4229 "bison_parser.cpp"
     break;
 
   case 100: /* table_constraint: PRIMARY KEY '(' ident_commalist ')'  */
-#line 774 "bison_parser.y"
+#line 791 "bison_parser.y"
                                                        { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::PrimaryKey, (yyvsp[-1].str_vec)); }
-#line 4203 "bison_parser.cpp"
+#line 4235 "bison_parser.cpp"
     break;
 
   case 101: /* table_constraint: UNIQUE '(' ident_commalist ')'  */
-#line 775 "bison_parser.y"
+#line 792 "bison_parser.y"
                                  { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::Unique, (yyvsp[-1].str_vec)); }
-#line 4209 "bison_parser.cpp"
+#line 4241 "bison_parser.cpp"
     break;
 
   case 102: /* table_constraint: FOREIGN KEY '(' ident_commalist ')' references_spec  */
-#line 776 "bison_parser.y"
+#line 793 "bison_parser.y"
                                                       { (yyval.table_constraint_t) = new ForeignKeyConstraint((yyvsp[-2].str_vec), (yyvsp[0].references_spec_t)); }
-#line 4215 "bison_parser.cpp"
+#line 4247 "bison_parser.cpp"
     break;
 
   case 103: /* references_spec: REFERENCES table_name opt_column_list  */
-#line 778 "bison_parser.y"
+#line 795 "bison_parser.y"
                                                         { (yyval.references_spec_t) = new ReferencesSpecification((yyvsp[-1].table_name).schema, (yyvsp[-1].table_name).name, (yyvsp[0].str_vec)); }
-#line 4221 "bison_parser.cpp"
+#line 4253 "bison_parser.cpp"
     break;
 
   case 104: /* drop_statement: DROP TABLE opt_exists table_name  */
-#line 786 "bison_parser.y"
+#line 803 "bison_parser.y"
                                                   {
   (yyval.drop_stmt) = new DropStatement(kDropTable);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.drop_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 4232 "bison_parser.cpp"
+#line 4264 "bison_parser.cpp"
     break;
 
   case 105: /* drop_statement: DROP VIEW opt_exists table_name  */
-#line 792 "bison_parser.y"
+#line 809 "bison_parser.y"
                                   {
   (yyval.drop_stmt) = new DropStatement(kDropView);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.drop_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 4243 "bison_parser.cpp"
+#line 4275 "bison_parser.cpp"
     break;
 
   case 106: /* drop_statement: DEALLOCATE PREPARE IDENTIFIER  */
-#line 798 "bison_parser.y"
+#line 815 "bison_parser.y"
                                 {
   (yyval.drop_stmt) = new DropStatement(kDropPreparedStatement);
   (yyval.drop_stmt)->ifExists = false;
   (yyval.drop_stmt)->name = (yyvsp[0].sval);
 }
-#line 4253 "bison_parser.cpp"
+#line 4285 "bison_parser.cpp"
     break;
 
   case 107: /* drop_statement: DROP INDEX opt_exists IDENTIFIER  */
-#line 804 "bison_parser.y"
+#line 821 "bison_parser.y"
                                    {
   (yyval.drop_stmt) = new DropStatement(kDropIndex);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->indexName = (yyvsp[0].sval);
 }
-#line 4263 "bison_parser.cpp"
+#line 4295 "bison_parser.cpp"
     break;
 
   case 108: /* opt_exists: IF EXISTS  */
-#line 810 "bison_parser.y"
+#line 827 "bison_parser.y"
                        { (yyval.bval) = true; }
-#line 4269 "bison_parser.cpp"
+#line 4301 "bison_parser.cpp"
     break;
 
   case 109: /* opt_exists: %empty  */
-#line 811 "bison_parser.y"
+#line 828 "bison_parser.y"
               { (yyval.bval) = false; }
-#line 4275 "bison_parser.cpp"
+#line 4307 "bison_parser.cpp"
     break;
 
   case 110: /* alter_statement: ALTER TABLE opt_exists table_name alter_action  */
-#line 818 "bison_parser.y"
+#line 835 "bison_parser.y"
                                                                  {
   (yyval.alter_stmt) = new AlterStatement((yyvsp[-1].table_name).name, (yyvsp[0].alter_action_t));
   (yyval.alter_stmt)->ifTableExists = (yyvsp[-2].bval);
   (yyval.alter_stmt)->schema = (yyvsp[-1].table_name).schema;
 }
-#line 4285 "bison_parser.cpp"
+#line 4317 "bison_parser.cpp"
     break;
 
   case 111: /* alter_action: drop_action  */
-#line 824 "bison_parser.y"
+#line 841 "bison_parser.y"
                            { (yyval.alter_action_t) = (yyvsp[0].drop_action_t); }
-#line 4291 "bison_parser.cpp"
+#line 4323 "bison_parser.cpp"
     break;
 
   case 112: /* drop_action: DROP COLUMN opt_exists IDENTIFIER  */
-#line 826 "bison_parser.y"
+#line 843 "bison_parser.y"
                                                 {
   (yyval.drop_action_t) = new DropColumnAction((yyvsp[0].sval));
   (yyval.drop_action_t)->ifExists = (yyvsp[-1].bval);
 }
-#line 4300 "bison_parser.cpp"
+#line 4332 "bison_parser.cpp"
     break;
 
   case 113: /* delete_statement: DELETE FROM table_name opt_where  */
-#line 836 "bison_parser.y"
+#line 853 "bison_parser.y"
                                                     {
   (yyval.delete_stmt) = new DeleteStatement();
   (yyval.delete_stmt)->schema = (yyvsp[-1].table_name).schema;
   (yyval.delete_stmt)->tableName = (yyvsp[-1].table_name).name;
   (yyval.delete_stmt)->expr = (yyvsp[0].expr);
 }
-#line 4311 "bison_parser.cpp"
+#line 4343 "bison_parser.cpp"
     break;
 
   case 114: /* truncate_statement: TRUNCATE table_name  */
-#line 843 "bison_parser.y"
+#line 860 "bison_parser.y"
                                          {
   (yyval.delete_stmt) = new DeleteStatement();
   (yyval.delete_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.delete_stmt)->tableName = (yyvsp[0].table_name).name;
 }
-#line 4321 "bison_parser.cpp"
+#line 4353 "bison_parser.cpp"
     break;
 
   case 115: /* insert_statement: INSERT INTO table_name opt_column_list VALUES '(' extended_literal_list ')'  */
-#line 854 "bison_parser.y"
+#line 871 "bison_parser.y"
                                                                                                {
   (yyval.insert_stmt) = new InsertStatement(kInsertValues);
   (yyval.insert_stmt)->schema = (yyvsp[-5].table_name).schema;
@@ -4329,11 +4361,11 @@ yyreduce:
   (yyval.insert_stmt)->columns = (yyvsp[-4].str_vec);
   (yyval.insert_stmt)->values = (yyvsp[-1].expr_vec);
 }
-#line 4333 "bison_parser.cpp"
+#line 4365 "bison_parser.cpp"
     break;
 
   case 116: /* insert_statement: INSERT INTO table_name opt_column_list select_no_paren  */
-#line 861 "bison_parser.y"
+#line 878 "bison_parser.y"
                                                          {
   (yyval.insert_stmt) = new InsertStatement(kInsertSelect);
   (yyval.insert_stmt)->schema = (yyvsp[-2].table_name).schema;
@@ -4341,80 +4373,80 @@ yyreduce:
   (yyval.insert_stmt)->columns = (yyvsp[-1].str_vec);
   (yyval.insert_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 4345 "bison_parser.cpp"
+#line 4377 "bison_parser.cpp"
     break;
 
   case 117: /* opt_column_list: '(' ident_commalist ')'  */
-#line 869 "bison_parser.y"
+#line 886 "bison_parser.y"
                                           { (yyval.str_vec) = (yyvsp[-1].str_vec); }
-#line 4351 "bison_parser.cpp"
+#line 4383 "bison_parser.cpp"
     break;
 
   case 118: /* opt_column_list: %empty  */
-#line 870 "bison_parser.y"
+#line 887 "bison_parser.y"
               { (yyval.str_vec) = nullptr; }
-#line 4357 "bison_parser.cpp"
+#line 4389 "bison_parser.cpp"
     break;
 
   case 119: /* update_statement: UPDATE table_ref_name_no_alias SET update_clause_commalist opt_where  */
-#line 877 "bison_parser.y"
+#line 894 "bison_parser.y"
                                                                                         {
   (yyval.update_stmt) = new UpdateStatement();
   (yyval.update_stmt)->table = (yyvsp[-3].table);
   (yyval.update_stmt)->updates = (yyvsp[-1].update_vec);
   (yyval.update_stmt)->where = (yyvsp[0].expr);
 }
-#line 4368 "bison_parser.cpp"
+#line 4400 "bison_parser.cpp"
     break;
 
   case 120: /* update_clause_commalist: update_clause  */
-#line 884 "bison_parser.y"
+#line 901 "bison_parser.y"
                                         {
   (yyval.update_vec) = new std::vector<UpdateClause*>();
   (yyval.update_vec)->push_back((yyvsp[0].update_t));
 }
-#line 4377 "bison_parser.cpp"
+#line 4409 "bison_parser.cpp"
     break;
 
   case 121: /* update_clause_commalist: update_clause_commalist ',' update_clause  */
-#line 888 "bison_parser.y"
+#line 905 "bison_parser.y"
                                             {
   (yyvsp[-2].update_vec)->push_back((yyvsp[0].update_t));
   (yyval.update_vec) = (yyvsp[-2].update_vec);
 }
-#line 4386 "bison_parser.cpp"
+#line 4418 "bison_parser.cpp"
     break;
 
   case 122: /* update_clause: IDENTIFIER '=' expr  */
-#line 893 "bison_parser.y"
+#line 910 "bison_parser.y"
                                     {
   (yyval.update_t) = new UpdateClause();
   (yyval.update_t)->column = (yyvsp[-2].sval);
   (yyval.update_t)->value = (yyvsp[0].expr);
 }
-#line 4396 "bison_parser.cpp"
+#line 4428 "bison_parser.cpp"
     break;
 
   case 123: /* select_statement: opt_with_clause select_with_paren  */
-#line 903 "bison_parser.y"
+#line 920 "bison_parser.y"
                                                      {
   (yyval.select_stmt) = (yyvsp[0].select_stmt);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-1].with_description_vec);
 }
-#line 4405 "bison_parser.cpp"
+#line 4437 "bison_parser.cpp"
     break;
 
   case 124: /* select_statement: opt_with_clause select_no_paren  */
-#line 907 "bison_parser.y"
+#line 924 "bison_parser.y"
                                   {
   (yyval.select_stmt) = (yyvsp[0].select_stmt);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-1].with_description_vec);
 }
-#line 4414 "bison_parser.cpp"
+#line 4446 "bison_parser.cpp"
     break;
 
   case 125: /* select_statement: opt_with_clause select_with_paren set_operator select_within_set_operation opt_order opt_limit  */
-#line 911 "bison_parser.y"
+#line 928 "bison_parser.y"
                                                                                                  {
   (yyval.select_stmt) = (yyvsp[-4].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
@@ -4426,17 +4458,17 @@ yyreduce:
   (yyval.select_stmt)->setOperations->back()->resultLimit = (yyvsp[0].limit);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-5].with_description_vec);
 }
-#line 4430 "bison_parser.cpp"
+#line 4462 "bison_parser.cpp"
     break;
 
   case 128: /* select_within_set_operation_no_parentheses: select_clause  */
-#line 925 "bison_parser.y"
+#line 942 "bison_parser.y"
                                                            { (yyval.select_stmt) = (yyvsp[0].select_stmt); }
-#line 4436 "bison_parser.cpp"
+#line 4468 "bison_parser.cpp"
     break;
 
   case 129: /* select_within_set_operation_no_parentheses: select_clause set_operator select_within_set_operation  */
-#line 926 "bison_parser.y"
+#line 943 "bison_parser.y"
                                                          {
   (yyval.select_stmt) = (yyvsp[-2].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
@@ -4445,23 +4477,23 @@ yyreduce:
   (yyval.select_stmt)->setOperations->push_back((yyvsp[-1].set_operator_t));
   (yyval.select_stmt)->setOperations->back()->nestedSelectStatement = (yyvsp[0].select_stmt);
 }
-#line 4449 "bison_parser.cpp"
+#line 4481 "bison_parser.cpp"
     break;
 
   case 130: /* select_with_paren: '(' select_no_paren ')'  */
-#line 935 "bison_parser.y"
+#line 952 "bison_parser.y"
                                             { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 4455 "bison_parser.cpp"
+#line 4487 "bison_parser.cpp"
     break;
 
   case 131: /* select_with_paren: '(' select_with_paren ')'  */
-#line 936 "bison_parser.y"
+#line 953 "bison_parser.y"
                             { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 4461 "bison_parser.cpp"
+#line 4493 "bison_parser.cpp"
     break;
 
   case 132: /* select_no_paren: select_clause opt_order opt_limit opt_locking_clause  */
-#line 938 "bison_parser.y"
+#line 955 "bison_parser.y"
                                                                        {
   (yyval.select_stmt) = (yyvsp[-3].select_stmt);
   (yyval.select_stmt)->order = (yyvsp[-2].order_vec);
@@ -4476,11 +4508,11 @@ yyreduce:
     (yyval.select_stmt)->lockings = (yyvsp[0].locking_clause_vec);
   }
 }
-#line 4480 "bison_parser.cpp"
+#line 4512 "bison_parser.cpp"
     break;
 
   case 133: /* select_no_paren: select_clause set_operator select_within_set_operation opt_order opt_limit opt_locking_clause  */
-#line 952 "bison_parser.y"
+#line 969 "bison_parser.y"
                                                                                                 {
   (yyval.select_stmt) = (yyvsp[-5].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
@@ -4492,59 +4524,59 @@ yyreduce:
   (yyval.select_stmt)->setOperations->back()->resultLimit = (yyvsp[-1].limit);
   (yyval.select_stmt)->lockings = (yyvsp[0].locking_clause_vec);
 }
-#line 4496 "bison_parser.cpp"
+#line 4528 "bison_parser.cpp"
     break;
 
   case 134: /* set_operator: set_type opt_all  */
-#line 964 "bison_parser.y"
+#line 981 "bison_parser.y"
                                 {
   (yyval.set_operator_t) = (yyvsp[-1].set_operator_t);
   (yyval.set_operator_t)->isAll = (yyvsp[0].bval);
 }
-#line 4505 "bison_parser.cpp"
+#line 4537 "bison_parser.cpp"
     break;
 
   case 135: /* set_type: UNION  */
-#line 969 "bison_parser.y"
+#line 986 "bison_parser.y"
                  {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetUnion;
 }
-#line 4514 "bison_parser.cpp"
+#line 4546 "bison_parser.cpp"
     break;
 
   case 136: /* set_type: INTERSECT  */
-#line 973 "bison_parser.y"
+#line 990 "bison_parser.y"
             {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetIntersect;
 }
-#line 4523 "bison_parser.cpp"
+#line 4555 "bison_parser.cpp"
     break;
 
   case 137: /* set_type: EXCEPT  */
-#line 977 "bison_parser.y"
+#line 994 "bison_parser.y"
          {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetExcept;
 }
-#line 4532 "bison_parser.cpp"
+#line 4564 "bison_parser.cpp"
     break;
 
   case 138: /* opt_all: ALL  */
-#line 982 "bison_parser.y"
+#line 999 "bison_parser.y"
               { (yyval.bval) = true; }
-#line 4538 "bison_parser.cpp"
+#line 4570 "bison_parser.cpp"
     break;
 
   case 139: /* opt_all: %empty  */
-#line 983 "bison_parser.y"
+#line 1000 "bison_parser.y"
               { (yyval.bval) = false; }
-#line 4544 "bison_parser.cpp"
+#line 4576 "bison_parser.cpp"
     break;
 
   case 140: /* select_clause: SELECT opt_top opt_distinct select_list opt_from_clause opt_where opt_group  */
-#line 985 "bison_parser.y"
+#line 1002 "bison_parser.y"
                                                                                             {
   (yyval.select_stmt) = new SelectStatement();
   (yyval.select_stmt)->limit = (yyvsp[-5].limit);
@@ -4554,141 +4586,141 @@ yyreduce:
   (yyval.select_stmt)->whereClause = (yyvsp[-1].expr);
   (yyval.select_stmt)->groupBy = (yyvsp[0].group_t);
 }
-#line 4558 "bison_parser.cpp"
+#line 4590 "bison_parser.cpp"
     break;
 
   case 141: /* opt_distinct: DISTINCT  */
-#line 995 "bison_parser.y"
+#line 1012 "bison_parser.y"
                         { (yyval.bval) = true; }
-#line 4564 "bison_parser.cpp"
+#line 4596 "bison_parser.cpp"
     break;
 
   case 142: /* opt_distinct: %empty  */
-#line 996 "bison_parser.y"
+#line 1013 "bison_parser.y"
               { (yyval.bval) = false; }
-#line 4570 "bison_parser.cpp"
+#line 4602 "bison_parser.cpp"
     break;
 
   case 144: /* opt_from_clause: from_clause  */
-#line 1000 "bison_parser.y"
+#line 1017 "bison_parser.y"
                               { (yyval.table) = (yyvsp[0].table); }
-#line 4576 "bison_parser.cpp"
+#line 4608 "bison_parser.cpp"
     break;
 
   case 145: /* opt_from_clause: %empty  */
-#line 1001 "bison_parser.y"
+#line 1018 "bison_parser.y"
               { (yyval.table) = nullptr; }
-#line 4582 "bison_parser.cpp"
+#line 4614 "bison_parser.cpp"
     break;
 
   case 146: /* from_clause: FROM table_ref  */
-#line 1003 "bison_parser.y"
+#line 1020 "bison_parser.y"
                              { (yyval.table) = (yyvsp[0].table); }
-#line 4588 "bison_parser.cpp"
+#line 4620 "bison_parser.cpp"
     break;
 
   case 147: /* opt_where: WHERE expr  */
-#line 1005 "bison_parser.y"
+#line 1022 "bison_parser.y"
                        { (yyval.expr) = (yyvsp[0].expr); }
-#line 4594 "bison_parser.cpp"
+#line 4626 "bison_parser.cpp"
     break;
 
   case 148: /* opt_where: %empty  */
-#line 1006 "bison_parser.y"
+#line 1023 "bison_parser.y"
               { (yyval.expr) = nullptr; }
-#line 4600 "bison_parser.cpp"
+#line 4632 "bison_parser.cpp"
     break;
 
   case 149: /* opt_group: GROUP BY expr_list opt_having  */
-#line 1008 "bison_parser.y"
+#line 1025 "bison_parser.y"
                                           {
   (yyval.group_t) = new GroupByDescription();
   (yyval.group_t)->columns = (yyvsp[-1].expr_vec);
   (yyval.group_t)->having = (yyvsp[0].expr);
 }
-#line 4610 "bison_parser.cpp"
+#line 4642 "bison_parser.cpp"
     break;
 
   case 150: /* opt_group: %empty  */
-#line 1013 "bison_parser.y"
+#line 1030 "bison_parser.y"
               { (yyval.group_t) = nullptr; }
-#line 4616 "bison_parser.cpp"
+#line 4648 "bison_parser.cpp"
     break;
 
   case 151: /* opt_having: HAVING expr  */
-#line 1015 "bison_parser.y"
+#line 1032 "bison_parser.y"
                          { (yyval.expr) = (yyvsp[0].expr); }
-#line 4622 "bison_parser.cpp"
+#line 4654 "bison_parser.cpp"
     break;
 
   case 152: /* opt_having: %empty  */
-#line 1016 "bison_parser.y"
+#line 1033 "bison_parser.y"
               { (yyval.expr) = nullptr; }
-#line 4628 "bison_parser.cpp"
+#line 4660 "bison_parser.cpp"
     break;
 
   case 153: /* opt_order: ORDER BY order_list  */
-#line 1018 "bison_parser.y"
+#line 1035 "bison_parser.y"
                                 { (yyval.order_vec) = (yyvsp[0].order_vec); }
-#line 4634 "bison_parser.cpp"
+#line 4666 "bison_parser.cpp"
     break;
 
   case 154: /* opt_order: %empty  */
-#line 1019 "bison_parser.y"
+#line 1036 "bison_parser.y"
               { (yyval.order_vec) = nullptr; }
-#line 4640 "bison_parser.cpp"
+#line 4672 "bison_parser.cpp"
     break;
 
   case 155: /* order_list: order_desc  */
-#line 1021 "bison_parser.y"
+#line 1038 "bison_parser.y"
                         {
   (yyval.order_vec) = new std::vector<OrderDescription*>();
   (yyval.order_vec)->push_back((yyvsp[0].order));
 }
-#line 4649 "bison_parser.cpp"
+#line 4681 "bison_parser.cpp"
     break;
 
   case 156: /* order_list: order_list ',' order_desc  */
-#line 1025 "bison_parser.y"
+#line 1042 "bison_parser.y"
                             {
   (yyvsp[-2].order_vec)->push_back((yyvsp[0].order));
   (yyval.order_vec) = (yyvsp[-2].order_vec);
 }
-#line 4658 "bison_parser.cpp"
+#line 4690 "bison_parser.cpp"
     break;
 
   case 157: /* order_desc: expr opt_order_type opt_null_ordering  */
-#line 1030 "bison_parser.y"
+#line 1047 "bison_parser.y"
                                                    { (yyval.order) = new OrderDescription((yyvsp[-1].order_type), (yyvsp[-2].expr), (yyvsp[0].null_ordering_t)); }
-#line 4664 "bison_parser.cpp"
+#line 4696 "bison_parser.cpp"
     break;
 
   case 158: /* opt_order_type: ASC  */
-#line 1032 "bison_parser.y"
+#line 1049 "bison_parser.y"
                      { (yyval.order_type) = kOrderAsc; }
-#line 4670 "bison_parser.cpp"
+#line 4702 "bison_parser.cpp"
     break;
 
   case 159: /* opt_order_type: DESC  */
-#line 1033 "bison_parser.y"
+#line 1050 "bison_parser.y"
        { (yyval.order_type) = kOrderDesc; }
-#line 4676 "bison_parser.cpp"
+#line 4708 "bison_parser.cpp"
     break;
 
   case 160: /* opt_order_type: %empty  */
-#line 1034 "bison_parser.y"
+#line 1051 "bison_parser.y"
               { (yyval.order_type) = kOrderAsc; }
-#line 4682 "bison_parser.cpp"
+#line 4714 "bison_parser.cpp"
     break;
 
   case 161: /* opt_null_ordering: %empty  */
-#line 1036 "bison_parser.y"
+#line 1053 "bison_parser.y"
                                 { (yyval.null_ordering_t) = NullOrdering::Undefined; }
-#line 4688 "bison_parser.cpp"
+#line 4720 "bison_parser.cpp"
     break;
 
   case 162: /* opt_null_ordering: IDENTIFIER IDENTIFIER  */
-#line 1037 "bison_parser.y"
+#line 1054 "bison_parser.y"
                         {
   auto null_ordering = NullOrdering::Undefined;
   if (strcasecmp((yyvsp[-1].sval), "nulls") == 0) {
@@ -4708,133 +4740,133 @@ yyreduce:
 
   (yyval.null_ordering_t) = null_ordering;
 }
-#line 4712 "bison_parser.cpp"
+#line 4744 "bison_parser.cpp"
     break;
 
   case 163: /* opt_top: TOP int_literal  */
-#line 1059 "bison_parser.y"
+#line 1076 "bison_parser.y"
                           { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
-#line 4718 "bison_parser.cpp"
+#line 4750 "bison_parser.cpp"
     break;
 
   case 164: /* opt_top: %empty  */
-#line 1060 "bison_parser.y"
+#line 1077 "bison_parser.y"
               { (yyval.limit) = nullptr; }
-#line 4724 "bison_parser.cpp"
+#line 4756 "bison_parser.cpp"
     break;
 
   case 165: /* opt_limit: LIMIT expr  */
-#line 1062 "bison_parser.y"
+#line 1079 "bison_parser.y"
                        { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
-#line 4730 "bison_parser.cpp"
+#line 4762 "bison_parser.cpp"
     break;
 
   case 166: /* opt_limit: OFFSET expr  */
-#line 1063 "bison_parser.y"
+#line 1080 "bison_parser.y"
               { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
-#line 4736 "bison_parser.cpp"
+#line 4768 "bison_parser.cpp"
     break;
 
   case 167: /* opt_limit: LIMIT expr OFFSET expr  */
-#line 1064 "bison_parser.y"
+#line 1081 "bison_parser.y"
                          { (yyval.limit) = new LimitDescription((yyvsp[-2].expr), (yyvsp[0].expr)); }
-#line 4742 "bison_parser.cpp"
+#line 4774 "bison_parser.cpp"
     break;
 
   case 168: /* opt_limit: LIMIT ALL  */
-#line 1065 "bison_parser.y"
+#line 1082 "bison_parser.y"
             { (yyval.limit) = new LimitDescription(nullptr, nullptr); }
-#line 4748 "bison_parser.cpp"
+#line 4780 "bison_parser.cpp"
     break;
 
   case 169: /* opt_limit: LIMIT ALL OFFSET expr  */
-#line 1066 "bison_parser.y"
+#line 1083 "bison_parser.y"
                         { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
-#line 4754 "bison_parser.cpp"
+#line 4786 "bison_parser.cpp"
     break;
 
   case 170: /* opt_limit: %empty  */
-#line 1067 "bison_parser.y"
+#line 1084 "bison_parser.y"
               { (yyval.limit) = nullptr; }
-#line 4760 "bison_parser.cpp"
+#line 4792 "bison_parser.cpp"
     break;
 
   case 171: /* expr_list: expr_alias  */
-#line 1072 "bison_parser.y"
+#line 1089 "bison_parser.y"
                        {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 4769 "bison_parser.cpp"
+#line 4801 "bison_parser.cpp"
     break;
 
   case 172: /* expr_list: expr_list ',' expr_alias  */
-#line 1076 "bison_parser.y"
+#line 1093 "bison_parser.y"
                            {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 4778 "bison_parser.cpp"
+#line 4810 "bison_parser.cpp"
     break;
 
   case 173: /* opt_extended_literal_list: extended_literal_list  */
-#line 1082 "bison_parser.y"
+#line 1099 "bison_parser.y"
                                                   { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
-#line 4784 "bison_parser.cpp"
+#line 4816 "bison_parser.cpp"
     break;
 
   case 174: /* opt_extended_literal_list: %empty  */
-#line 1083 "bison_parser.y"
+#line 1100 "bison_parser.y"
               { (yyval.expr_vec) = nullptr; }
-#line 4790 "bison_parser.cpp"
+#line 4822 "bison_parser.cpp"
     break;
 
   case 175: /* extended_literal_list: casted_extended_literal  */
-#line 1085 "bison_parser.y"
+#line 1102 "bison_parser.y"
                                                 {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 4799 "bison_parser.cpp"
+#line 4831 "bison_parser.cpp"
     break;
 
   case 176: /* extended_literal_list: extended_literal_list ',' casted_extended_literal  */
-#line 1089 "bison_parser.y"
+#line 1106 "bison_parser.y"
                                                     {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 4808 "bison_parser.cpp"
+#line 4840 "bison_parser.cpp"
     break;
 
   case 178: /* casted_extended_literal: CAST '(' extended_literal AS column_type ')'  */
-#line 1094 "bison_parser.y"
+#line 1111 "bison_parser.y"
                                                                                           {
   (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t));
 }
-#line 4816 "bison_parser.cpp"
+#line 4848 "bison_parser.cpp"
     break;
 
   case 179: /* extended_literal: literal  */
-#line 1098 "bison_parser.y"
+#line 1115 "bison_parser.y"
                            { (yyval.expr) = (yyvsp[0].expr); }
-#line 4822 "bison_parser.cpp"
+#line 4854 "bison_parser.cpp"
     break;
 
   case 180: /* extended_literal: '-' num_literal  */
-#line 1099 "bison_parser.y"
+#line 1116 "bison_parser.y"
                   { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4828 "bison_parser.cpp"
+#line 4860 "bison_parser.cpp"
     break;
 
   case 181: /* extended_literal: '-' interval_literal  */
-#line 1100 "bison_parser.y"
+#line 1117 "bison_parser.y"
                        { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4834 "bison_parser.cpp"
+#line 4866 "bison_parser.cpp"
     break;
 
   case 182: /* expr_alias: expr opt_alias  */
-#line 1102 "bison_parser.y"
+#line 1119 "bison_parser.y"
                             {
   (yyval.expr) = (yyvsp[-1].expr);
   if ((yyvsp[0].alias_t)) {
@@ -4843,523 +4875,523 @@ yyreduce:
     delete (yyvsp[0].alias_t);
   }
 }
-#line 4847 "bison_parser.cpp"
-    break;
-
-  case 188: /* operand: '(' expr ')'  */
-#line 1113 "bison_parser.y"
-                       { (yyval.expr) = (yyvsp[-1].expr); }
-#line 4853 "bison_parser.cpp"
-    break;
-
-  case 198: /* operand: '(' select_no_paren ')'  */
-#line 1115 "bison_parser.y"
-                                         {
-  (yyval.expr) = Expr::makeSelect((yyvsp[-1].select_stmt));
-}
-#line 4861 "bison_parser.cpp"
-    break;
-
-  case 201: /* unary_expr: '-' operand  */
-#line 1121 "bison_parser.y"
-                         { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4867 "bison_parser.cpp"
-    break;
-
-  case 202: /* unary_expr: NOT operand  */
-#line 1122 "bison_parser.y"
-              { (yyval.expr) = Expr::makeOpUnary(kOpNot, (yyvsp[0].expr)); }
-#line 4873 "bison_parser.cpp"
-    break;
-
-  case 203: /* unary_expr: operand ISNULL  */
-#line 1123 "bison_parser.y"
-                 { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-1].expr)); }
 #line 4879 "bison_parser.cpp"
     break;
 
-  case 204: /* unary_expr: operand IS NULL  */
-#line 1124 "bison_parser.y"
-                  { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-2].expr)); }
+  case 188: /* operand: '(' expr ')'  */
+#line 1130 "bison_parser.y"
+                       { (yyval.expr) = (yyvsp[-1].expr); }
 #line 4885 "bison_parser.cpp"
     break;
 
+  case 198: /* operand: '(' select_no_paren ')'  */
+#line 1132 "bison_parser.y"
+                                         {
+  (yyval.expr) = Expr::makeSelect((yyvsp[-1].select_stmt));
+}
+#line 4893 "bison_parser.cpp"
+    break;
+
+  case 201: /* unary_expr: '-' operand  */
+#line 1138 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
+#line 4899 "bison_parser.cpp"
+    break;
+
+  case 202: /* unary_expr: NOT operand  */
+#line 1139 "bison_parser.y"
+              { (yyval.expr) = Expr::makeOpUnary(kOpNot, (yyvsp[0].expr)); }
+#line 4905 "bison_parser.cpp"
+    break;
+
+  case 203: /* unary_expr: operand ISNULL  */
+#line 1140 "bison_parser.y"
+                 { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-1].expr)); }
+#line 4911 "bison_parser.cpp"
+    break;
+
+  case 204: /* unary_expr: operand IS NULL  */
+#line 1141 "bison_parser.y"
+                  { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-2].expr)); }
+#line 4917 "bison_parser.cpp"
+    break;
+
   case 205: /* unary_expr: operand IS NOT NULL  */
-#line 1125 "bison_parser.y"
+#line 1142 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeOpUnary(kOpIsNull, (yyvsp[-3].expr))); }
-#line 4891 "bison_parser.cpp"
+#line 4923 "bison_parser.cpp"
     break;
 
   case 207: /* binary_expr: operand '-' operand  */
-#line 1127 "bison_parser.y"
+#line 1144 "bison_parser.y"
                                               { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpMinus, (yyvsp[0].expr)); }
-#line 4897 "bison_parser.cpp"
+#line 4929 "bison_parser.cpp"
     break;
 
   case 208: /* binary_expr: operand '+' operand  */
-#line 1128 "bison_parser.y"
+#line 1145 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPlus, (yyvsp[0].expr)); }
-#line 4903 "bison_parser.cpp"
+#line 4935 "bison_parser.cpp"
     break;
 
   case 209: /* binary_expr: operand '/' operand  */
-#line 1129 "bison_parser.y"
+#line 1146 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpSlash, (yyvsp[0].expr)); }
-#line 4909 "bison_parser.cpp"
+#line 4941 "bison_parser.cpp"
     break;
 
   case 210: /* binary_expr: operand '*' operand  */
-#line 1130 "bison_parser.y"
+#line 1147 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAsterisk, (yyvsp[0].expr)); }
-#line 4915 "bison_parser.cpp"
+#line 4947 "bison_parser.cpp"
     break;
 
   case 211: /* binary_expr: operand '%' operand  */
-#line 1131 "bison_parser.y"
+#line 1148 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPercentage, (yyvsp[0].expr)); }
-#line 4921 "bison_parser.cpp"
+#line 4953 "bison_parser.cpp"
     break;
 
   case 212: /* binary_expr: operand '^' operand  */
-#line 1132 "bison_parser.y"
+#line 1149 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpCaret, (yyvsp[0].expr)); }
-#line 4927 "bison_parser.cpp"
+#line 4959 "bison_parser.cpp"
     break;
 
   case 213: /* binary_expr: operand LIKE operand  */
-#line 1133 "bison_parser.y"
+#line 1150 "bison_parser.y"
                        { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLike, (yyvsp[0].expr)); }
-#line 4933 "bison_parser.cpp"
+#line 4965 "bison_parser.cpp"
     break;
 
   case 214: /* binary_expr: operand NOT LIKE operand  */
-#line 1134 "bison_parser.y"
+#line 1151 "bison_parser.y"
                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-3].expr), kOpNotLike, (yyvsp[0].expr)); }
-#line 4939 "bison_parser.cpp"
+#line 4971 "bison_parser.cpp"
     break;
 
   case 215: /* binary_expr: operand ILIKE operand  */
-#line 1135 "bison_parser.y"
+#line 1152 "bison_parser.y"
                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpILike, (yyvsp[0].expr)); }
-#line 4945 "bison_parser.cpp"
+#line 4977 "bison_parser.cpp"
     break;
 
   case 216: /* binary_expr: operand CONCAT operand  */
-#line 1136 "bison_parser.y"
+#line 1153 "bison_parser.y"
                          { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpConcat, (yyvsp[0].expr)); }
-#line 4951 "bison_parser.cpp"
+#line 4983 "bison_parser.cpp"
     break;
 
   case 217: /* logic_expr: expr AND expr  */
-#line 1138 "bison_parser.y"
+#line 1155 "bison_parser.y"
                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAnd, (yyvsp[0].expr)); }
-#line 4957 "bison_parser.cpp"
+#line 4989 "bison_parser.cpp"
     break;
 
   case 218: /* logic_expr: expr OR expr  */
-#line 1139 "bison_parser.y"
+#line 1156 "bison_parser.y"
                { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpOr, (yyvsp[0].expr)); }
-#line 4963 "bison_parser.cpp"
+#line 4995 "bison_parser.cpp"
     break;
 
   case 219: /* in_expr: operand IN '(' expr_list ')'  */
-#line 1141 "bison_parser.y"
+#line 1158 "bison_parser.y"
                                        { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].expr_vec)); }
-#line 4969 "bison_parser.cpp"
+#line 5001 "bison_parser.cpp"
     break;
 
   case 220: /* in_expr: operand NOT IN '(' expr_list ')'  */
-#line 1142 "bison_parser.y"
+#line 1159 "bison_parser.y"
                                    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].expr_vec))); }
-#line 4975 "bison_parser.cpp"
+#line 5007 "bison_parser.cpp"
     break;
 
   case 221: /* in_expr: operand IN '(' select_no_paren ')'  */
-#line 1143 "bison_parser.y"
+#line 1160 "bison_parser.y"
                                      { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].select_stmt)); }
-#line 4981 "bison_parser.cpp"
+#line 5013 "bison_parser.cpp"
     break;
 
   case 222: /* in_expr: operand NOT IN '(' select_no_paren ')'  */
-#line 1144 "bison_parser.y"
+#line 1161 "bison_parser.y"
                                          { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].select_stmt))); }
-#line 4987 "bison_parser.cpp"
+#line 5019 "bison_parser.cpp"
     break;
 
   case 223: /* case_expr: CASE expr case_list END  */
-#line 1148 "bison_parser.y"
+#line 1165 "bison_parser.y"
                                     { (yyval.expr) = Expr::makeCase((yyvsp[-2].expr), (yyvsp[-1].expr), nullptr); }
-#line 4993 "bison_parser.cpp"
+#line 5025 "bison_parser.cpp"
     break;
 
   case 224: /* case_expr: CASE expr case_list ELSE expr END  */
-#line 1149 "bison_parser.y"
+#line 1166 "bison_parser.y"
                                     { (yyval.expr) = Expr::makeCase((yyvsp[-4].expr), (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 4999 "bison_parser.cpp"
+#line 5031 "bison_parser.cpp"
     break;
 
   case 225: /* case_expr: CASE case_list END  */
-#line 1150 "bison_parser.y"
+#line 1167 "bison_parser.y"
                      { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-1].expr), nullptr); }
-#line 5005 "bison_parser.cpp"
+#line 5037 "bison_parser.cpp"
     break;
 
   case 226: /* case_expr: CASE case_list ELSE expr END  */
-#line 1151 "bison_parser.y"
+#line 1168 "bison_parser.y"
                                { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 5011 "bison_parser.cpp"
+#line 5043 "bison_parser.cpp"
     break;
 
   case 227: /* case_list: WHEN expr THEN expr  */
-#line 1153 "bison_parser.y"
+#line 1170 "bison_parser.y"
                                 { (yyval.expr) = Expr::makeCaseList(Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
-#line 5017 "bison_parser.cpp"
+#line 5049 "bison_parser.cpp"
     break;
 
   case 228: /* case_list: case_list WHEN expr THEN expr  */
-#line 1154 "bison_parser.y"
+#line 1171 "bison_parser.y"
                                 { (yyval.expr) = Expr::caseListAppend((yyvsp[-4].expr), Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
-#line 5023 "bison_parser.cpp"
+#line 5055 "bison_parser.cpp"
     break;
 
   case 229: /* exists_expr: EXISTS '(' select_no_paren ')'  */
-#line 1156 "bison_parser.y"
+#line 1173 "bison_parser.y"
                                              { (yyval.expr) = Expr::makeExists((yyvsp[-1].select_stmt)); }
-#line 5029 "bison_parser.cpp"
+#line 5061 "bison_parser.cpp"
     break;
 
   case 230: /* exists_expr: NOT EXISTS '(' select_no_paren ')'  */
-#line 1157 "bison_parser.y"
+#line 1174 "bison_parser.y"
                                      { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeExists((yyvsp[-1].select_stmt))); }
-#line 5035 "bison_parser.cpp"
+#line 5067 "bison_parser.cpp"
     break;
 
   case 231: /* comp_expr: operand '=' operand  */
-#line 1159 "bison_parser.y"
+#line 1176 "bison_parser.y"
                                 { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
-#line 5041 "bison_parser.cpp"
+#line 5073 "bison_parser.cpp"
     break;
 
   case 232: /* comp_expr: operand EQUALS operand  */
-#line 1160 "bison_parser.y"
+#line 1177 "bison_parser.y"
                          { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
-#line 5047 "bison_parser.cpp"
+#line 5079 "bison_parser.cpp"
     break;
 
   case 233: /* comp_expr: operand NOTEQUALS operand  */
-#line 1161 "bison_parser.y"
+#line 1178 "bison_parser.y"
                             { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpNotEquals, (yyvsp[0].expr)); }
-#line 5053 "bison_parser.cpp"
+#line 5085 "bison_parser.cpp"
     break;
 
   case 234: /* comp_expr: operand '<' operand  */
-#line 1162 "bison_parser.y"
+#line 1179 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLess, (yyvsp[0].expr)); }
-#line 5059 "bison_parser.cpp"
+#line 5091 "bison_parser.cpp"
     break;
 
   case 235: /* comp_expr: operand '>' operand  */
-#line 1163 "bison_parser.y"
+#line 1180 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreater, (yyvsp[0].expr)); }
-#line 5065 "bison_parser.cpp"
-    break;
-
-  case 236: /* comp_expr: operand LESSEQ operand  */
-#line 1164 "bison_parser.y"
-                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLessEq, (yyvsp[0].expr)); }
-#line 5071 "bison_parser.cpp"
-    break;
-
-  case 237: /* comp_expr: operand GREATEREQ operand  */
-#line 1165 "bison_parser.y"
-                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreaterEq, (yyvsp[0].expr)); }
-#line 5077 "bison_parser.cpp"
-    break;
-
-  case 238: /* function_expr: IDENTIFIER '(' ')' opt_window  */
-#line 1169 "bison_parser.y"
-                                              { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
-#line 5083 "bison_parser.cpp"
-    break;
-
-  case 239: /* function_expr: IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
-#line 1170 "bison_parser.y"
-                                                       { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
-#line 5089 "bison_parser.cpp"
-    break;
-
-  case 240: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' ')' opt_window  */
-#line 1171 "bison_parser.y"
-                                               {
-  (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), (yyvsp[-5].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description));
-}
 #line 5097 "bison_parser.cpp"
     break;
 
-  case 241: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
-#line 1174 "bison_parser.y"
-                                                                      {
-  (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-7].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description));
-}
-#line 5105 "bison_parser.cpp"
-    break;
-
-  case 242: /* opt_window: OVER '(' opt_partition opt_order opt_frame_clause ')'  */
-#line 1180 "bison_parser.y"
-                                                                   { (yyval.window_description) = new WindowDescription((yyvsp[-3].expr_vec), (yyvsp[-2].order_vec), (yyvsp[-1].frame_description)); }
-#line 5111 "bison_parser.cpp"
-    break;
-
-  case 243: /* opt_window: %empty  */
+  case 236: /* comp_expr: operand LESSEQ operand  */
 #line 1181 "bison_parser.y"
-              { (yyval.window_description) = nullptr; }
-#line 5117 "bison_parser.cpp"
+                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLessEq, (yyvsp[0].expr)); }
+#line 5103 "bison_parser.cpp"
     break;
 
-  case 244: /* opt_partition: PARTITION BY expr_list  */
-#line 1183 "bison_parser.y"
-                                       { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
-#line 5123 "bison_parser.cpp"
+  case 237: /* comp_expr: operand GREATEREQ operand  */
+#line 1182 "bison_parser.y"
+                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreaterEq, (yyvsp[0].expr)); }
+#line 5109 "bison_parser.cpp"
     break;
 
-  case 245: /* opt_partition: %empty  */
-#line 1184 "bison_parser.y"
-              { (yyval.expr_vec) = nullptr; }
+  case 238: /* function_expr: IDENTIFIER '(' ')' opt_window  */
+#line 1186 "bison_parser.y"
+                                              { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
+#line 5115 "bison_parser.cpp"
+    break;
+
+  case 239: /* function_expr: IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
+#line 1187 "bison_parser.y"
+                                                       { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
+#line 5121 "bison_parser.cpp"
+    break;
+
+  case 240: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' ')' opt_window  */
+#line 1188 "bison_parser.y"
+                                               {
+  (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), (yyvsp[-5].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description));
+}
 #line 5129 "bison_parser.cpp"
     break;
 
-  case 246: /* opt_frame_clause: frame_type frame_bound  */
-#line 1189 "bison_parser.y"
-                                          { (yyval.frame_description) = new FrameDescription{(yyvsp[-1].frame_type), (yyvsp[0].frame_bound), new FrameBound{0, kCurrentRow, false}}; }
-#line 5135 "bison_parser.cpp"
-    break;
-
-  case 247: /* opt_frame_clause: frame_type BETWEEN frame_bound AND frame_bound  */
-#line 1190 "bison_parser.y"
-                                                 { (yyval.frame_description) = new FrameDescription{(yyvsp[-4].frame_type), (yyvsp[-2].frame_bound), (yyvsp[0].frame_bound)}; }
-#line 5141 "bison_parser.cpp"
-    break;
-
-  case 248: /* opt_frame_clause: %empty  */
+  case 241: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
 #line 1191 "bison_parser.y"
-              {
-  (yyval.frame_description) = new FrameDescription{kRange, new FrameBound{0, kPreceding, true}, new FrameBound{0, kCurrentRow, false}};
+                                                                      {
+  (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-7].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description));
 }
+#line 5137 "bison_parser.cpp"
+    break;
+
+  case 242: /* opt_window: OVER '(' opt_partition opt_order opt_frame_clause ')'  */
+#line 1197 "bison_parser.y"
+                                                                   { (yyval.window_description) = new WindowDescription((yyvsp[-3].expr_vec), (yyvsp[-2].order_vec), (yyvsp[-1].frame_description)); }
+#line 5143 "bison_parser.cpp"
+    break;
+
+  case 243: /* opt_window: %empty  */
+#line 1198 "bison_parser.y"
+              { (yyval.window_description) = nullptr; }
 #line 5149 "bison_parser.cpp"
     break;
 
-  case 249: /* frame_type: RANGE  */
-#line 1195 "bison_parser.y"
-                   { (yyval.frame_type) = kRange; }
+  case 244: /* opt_partition: PARTITION BY expr_list  */
+#line 1200 "bison_parser.y"
+                                       { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
 #line 5155 "bison_parser.cpp"
     break;
 
-  case 250: /* frame_type: ROWS  */
-#line 1196 "bison_parser.y"
-       { (yyval.frame_type) = kRows; }
+  case 245: /* opt_partition: %empty  */
+#line 1201 "bison_parser.y"
+              { (yyval.expr_vec) = nullptr; }
 #line 5161 "bison_parser.cpp"
     break;
 
-  case 251: /* frame_type: GROUPS  */
-#line 1197 "bison_parser.y"
-         { (yyval.frame_type) = kGroups; }
+  case 246: /* opt_frame_clause: frame_type frame_bound  */
+#line 1206 "bison_parser.y"
+                                          { (yyval.frame_description) = new FrameDescription{(yyvsp[-1].frame_type), (yyvsp[0].frame_bound), new FrameBound{0, kCurrentRow, false}}; }
 #line 5167 "bison_parser.cpp"
     break;
 
-  case 252: /* frame_bound: UNBOUNDED PRECEDING  */
-#line 1199 "bison_parser.y"
-                                  { (yyval.frame_bound) = new FrameBound{0, kPreceding, true}; }
+  case 247: /* opt_frame_clause: frame_type BETWEEN frame_bound AND frame_bound  */
+#line 1207 "bison_parser.y"
+                                                 { (yyval.frame_description) = new FrameDescription{(yyvsp[-4].frame_type), (yyvsp[-2].frame_bound), (yyvsp[0].frame_bound)}; }
 #line 5173 "bison_parser.cpp"
     break;
 
+  case 248: /* opt_frame_clause: %empty  */
+#line 1208 "bison_parser.y"
+              {
+  (yyval.frame_description) = new FrameDescription{kRange, new FrameBound{0, kPreceding, true}, new FrameBound{0, kCurrentRow, false}};
+}
+#line 5181 "bison_parser.cpp"
+    break;
+
+  case 249: /* frame_type: RANGE  */
+#line 1212 "bison_parser.y"
+                   { (yyval.frame_type) = kRange; }
+#line 5187 "bison_parser.cpp"
+    break;
+
+  case 250: /* frame_type: ROWS  */
+#line 1213 "bison_parser.y"
+       { (yyval.frame_type) = kRows; }
+#line 5193 "bison_parser.cpp"
+    break;
+
+  case 251: /* frame_type: GROUPS  */
+#line 1214 "bison_parser.y"
+         { (yyval.frame_type) = kGroups; }
+#line 5199 "bison_parser.cpp"
+    break;
+
+  case 252: /* frame_bound: UNBOUNDED PRECEDING  */
+#line 1216 "bison_parser.y"
+                                  { (yyval.frame_bound) = new FrameBound{0, kPreceding, true}; }
+#line 5205 "bison_parser.cpp"
+    break;
+
   case 253: /* frame_bound: INTVAL PRECEDING  */
-#line 1200 "bison_parser.y"
+#line 1217 "bison_parser.y"
                    { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kPreceding, false}; }
-#line 5179 "bison_parser.cpp"
+#line 5211 "bison_parser.cpp"
     break;
 
   case 254: /* frame_bound: UNBOUNDED FOLLOWING  */
-#line 1201 "bison_parser.y"
+#line 1218 "bison_parser.y"
                       { (yyval.frame_bound) = new FrameBound{0, kFollowing, true}; }
-#line 5185 "bison_parser.cpp"
+#line 5217 "bison_parser.cpp"
     break;
 
   case 255: /* frame_bound: INTVAL FOLLOWING  */
-#line 1202 "bison_parser.y"
+#line 1219 "bison_parser.y"
                    { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kFollowing, false}; }
-#line 5191 "bison_parser.cpp"
+#line 5223 "bison_parser.cpp"
     break;
 
   case 256: /* frame_bound: CURRENT_ROW  */
-#line 1203 "bison_parser.y"
+#line 1220 "bison_parser.y"
               { (yyval.frame_bound) = new FrameBound{0, kCurrentRow, false}; }
-#line 5197 "bison_parser.cpp"
+#line 5229 "bison_parser.cpp"
     break;
 
   case 257: /* extract_expr: EXTRACT '(' datetime_field FROM expr ')'  */
-#line 1205 "bison_parser.y"
+#line 1222 "bison_parser.y"
                                                         { (yyval.expr) = Expr::makeExtract((yyvsp[-3].datetime_field), (yyvsp[-1].expr)); }
-#line 5203 "bison_parser.cpp"
+#line 5235 "bison_parser.cpp"
     break;
 
   case 258: /* cast_expr: CAST '(' expr AS column_type ')'  */
-#line 1207 "bison_parser.y"
+#line 1224 "bison_parser.y"
                                              { (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t)); }
-#line 5209 "bison_parser.cpp"
+#line 5241 "bison_parser.cpp"
     break;
 
   case 259: /* datetime_field: SECOND  */
-#line 1209 "bison_parser.y"
+#line 1226 "bison_parser.y"
                         { (yyval.datetime_field) = kDatetimeSecond; }
-#line 5215 "bison_parser.cpp"
+#line 5247 "bison_parser.cpp"
     break;
 
   case 260: /* datetime_field: MINUTE  */
-#line 1210 "bison_parser.y"
+#line 1227 "bison_parser.y"
          { (yyval.datetime_field) = kDatetimeMinute; }
-#line 5221 "bison_parser.cpp"
+#line 5253 "bison_parser.cpp"
     break;
 
   case 261: /* datetime_field: HOUR  */
-#line 1211 "bison_parser.y"
+#line 1228 "bison_parser.y"
        { (yyval.datetime_field) = kDatetimeHour; }
-#line 5227 "bison_parser.cpp"
+#line 5259 "bison_parser.cpp"
     break;
 
   case 262: /* datetime_field: DAY  */
-#line 1212 "bison_parser.y"
+#line 1229 "bison_parser.y"
       { (yyval.datetime_field) = kDatetimeDay; }
-#line 5233 "bison_parser.cpp"
+#line 5265 "bison_parser.cpp"
     break;
 
   case 263: /* datetime_field: MONTH  */
-#line 1213 "bison_parser.y"
+#line 1230 "bison_parser.y"
         { (yyval.datetime_field) = kDatetimeMonth; }
-#line 5239 "bison_parser.cpp"
+#line 5271 "bison_parser.cpp"
     break;
 
   case 264: /* datetime_field: YEAR  */
-#line 1214 "bison_parser.y"
+#line 1231 "bison_parser.y"
        { (yyval.datetime_field) = kDatetimeYear; }
-#line 5245 "bison_parser.cpp"
+#line 5277 "bison_parser.cpp"
     break;
 
   case 265: /* datetime_field_plural: SECONDS  */
-#line 1216 "bison_parser.y"
+#line 1233 "bison_parser.y"
                                 { (yyval.datetime_field) = kDatetimeSecond; }
-#line 5251 "bison_parser.cpp"
+#line 5283 "bison_parser.cpp"
     break;
 
   case 266: /* datetime_field_plural: MINUTES  */
-#line 1217 "bison_parser.y"
+#line 1234 "bison_parser.y"
           { (yyval.datetime_field) = kDatetimeMinute; }
-#line 5257 "bison_parser.cpp"
+#line 5289 "bison_parser.cpp"
     break;
 
   case 267: /* datetime_field_plural: HOURS  */
-#line 1218 "bison_parser.y"
+#line 1235 "bison_parser.y"
         { (yyval.datetime_field) = kDatetimeHour; }
-#line 5263 "bison_parser.cpp"
+#line 5295 "bison_parser.cpp"
     break;
 
   case 268: /* datetime_field_plural: DAYS  */
-#line 1219 "bison_parser.y"
+#line 1236 "bison_parser.y"
        { (yyval.datetime_field) = kDatetimeDay; }
-#line 5269 "bison_parser.cpp"
+#line 5301 "bison_parser.cpp"
     break;
 
   case 269: /* datetime_field_plural: MONTHS  */
-#line 1220 "bison_parser.y"
+#line 1237 "bison_parser.y"
          { (yyval.datetime_field) = kDatetimeMonth; }
-#line 5275 "bison_parser.cpp"
+#line 5307 "bison_parser.cpp"
     break;
 
   case 270: /* datetime_field_plural: YEARS  */
-#line 1221 "bison_parser.y"
+#line 1238 "bison_parser.y"
         { (yyval.datetime_field) = kDatetimeYear; }
-#line 5281 "bison_parser.cpp"
+#line 5313 "bison_parser.cpp"
     break;
 
   case 273: /* array_expr: ARRAY '[' expr_list ']'  */
-#line 1225 "bison_parser.y"
+#line 1242 "bison_parser.y"
                                      { (yyval.expr) = Expr::makeArray((yyvsp[-1].expr_vec)); }
-#line 5287 "bison_parser.cpp"
+#line 5319 "bison_parser.cpp"
     break;
 
   case 274: /* array_index: operand '[' int_literal ']'  */
-#line 1227 "bison_parser.y"
+#line 1244 "bison_parser.y"
                                           { (yyval.expr) = Expr::makeArrayIndex((yyvsp[-3].expr), (yyvsp[-1].expr)->ival); }
-#line 5293 "bison_parser.cpp"
+#line 5325 "bison_parser.cpp"
     break;
 
   case 275: /* between_expr: operand BETWEEN operand AND operand  */
-#line 1229 "bison_parser.y"
+#line 1246 "bison_parser.y"
                                                    { (yyval.expr) = Expr::makeBetween((yyvsp[-4].expr), (yyvsp[-2].expr), (yyvsp[0].expr)); }
-#line 5299 "bison_parser.cpp"
+#line 5331 "bison_parser.cpp"
     break;
 
   case 276: /* column_name: IDENTIFIER  */
-#line 1231 "bison_parser.y"
+#line 1248 "bison_parser.y"
                          { (yyval.expr) = Expr::makeColumnRef((yyvsp[0].sval)); }
-#line 5305 "bison_parser.cpp"
+#line 5337 "bison_parser.cpp"
     break;
 
   case 277: /* column_name: IDENTIFIER '.' IDENTIFIER  */
-#line 1232 "bison_parser.y"
+#line 1249 "bison_parser.y"
                             { (yyval.expr) = Expr::makeColumnRef((yyvsp[-2].sval), (yyvsp[0].sval)); }
-#line 5311 "bison_parser.cpp"
+#line 5343 "bison_parser.cpp"
     break;
 
   case 278: /* column_name: '*'  */
-#line 1233 "bison_parser.y"
+#line 1250 "bison_parser.y"
       { (yyval.expr) = Expr::makeStar(); }
-#line 5317 "bison_parser.cpp"
+#line 5349 "bison_parser.cpp"
     break;
 
   case 279: /* column_name: IDENTIFIER '.' '*'  */
-#line 1234 "bison_parser.y"
+#line 1251 "bison_parser.y"
                      { (yyval.expr) = Expr::makeStar((yyvsp[-2].sval)); }
-#line 5323 "bison_parser.cpp"
+#line 5355 "bison_parser.cpp"
     break;
 
   case 287: /* string_literal: STRING  */
-#line 1238 "bison_parser.y"
+#line 1255 "bison_parser.y"
                         { (yyval.expr) = Expr::makeLiteral((yyvsp[0].sval)); }
-#line 5329 "bison_parser.cpp"
+#line 5361 "bison_parser.cpp"
     break;
 
   case 288: /* bool_literal: TRUE  */
-#line 1240 "bison_parser.y"
+#line 1257 "bison_parser.y"
                     { (yyval.expr) = Expr::makeLiteral(true); }
-#line 5335 "bison_parser.cpp"
+#line 5367 "bison_parser.cpp"
     break;
 
   case 289: /* bool_literal: FALSE  */
-#line 1241 "bison_parser.y"
+#line 1258 "bison_parser.y"
         { (yyval.expr) = Expr::makeLiteral(false); }
-#line 5341 "bison_parser.cpp"
+#line 5373 "bison_parser.cpp"
     break;
 
   case 290: /* num_literal: FLOATVAL  */
-#line 1243 "bison_parser.y"
+#line 1260 "bison_parser.y"
                        { (yyval.expr) = Expr::makeLiteral((yyvsp[0].fval)); }
-#line 5347 "bison_parser.cpp"
+#line 5379 "bison_parser.cpp"
     break;
 
   case 292: /* int_literal: INTVAL  */
-#line 1246 "bison_parser.y"
+#line 1263 "bison_parser.y"
                      { (yyval.expr) = Expr::makeLiteral((yyvsp[0].ival)); }
-#line 5353 "bison_parser.cpp"
+#line 5385 "bison_parser.cpp"
     break;
 
   case 293: /* null_literal: NULL  */
-#line 1248 "bison_parser.y"
+#line 1265 "bison_parser.y"
                     { (yyval.expr) = Expr::makeNullLiteral(); }
-#line 5359 "bison_parser.cpp"
+#line 5391 "bison_parser.cpp"
     break;
 
   case 294: /* date_literal: DATE STRING  */
-#line 1250 "bison_parser.y"
+#line 1267 "bison_parser.y"
                            {
   int day{0}, month{0}, year{0}, chars_parsed{0};
   // If the whole string is parsed, chars_parsed points to the terminating null byte after the last character
@@ -5370,17 +5402,17 @@ yyreduce:
   }
   (yyval.expr) = Expr::makeDateLiteral((yyvsp[0].sval));
 }
-#line 5374 "bison_parser.cpp"
+#line 5406 "bison_parser.cpp"
     break;
 
   case 295: /* interval_literal: INTVAL duration_field  */
-#line 1261 "bison_parser.y"
+#line 1278 "bison_parser.y"
                                          { (yyval.expr) = Expr::makeIntervalLiteral((yyvsp[-1].ival), (yyvsp[0].datetime_field)); }
-#line 5380 "bison_parser.cpp"
+#line 5412 "bison_parser.cpp"
     break;
 
   case 296: /* interval_literal: INTERVAL STRING datetime_field  */
-#line 1262 "bison_parser.y"
+#line 1279 "bison_parser.y"
                                  {
   int duration{0}, chars_parsed{0};
   // If the whole string is parsed, chars_parsed points to the terminating null byte after the last character
@@ -5392,11 +5424,11 @@ yyreduce:
   free((yyvsp[-1].sval));
   (yyval.expr) = Expr::makeIntervalLiteral(duration, (yyvsp[0].datetime_field));
 }
-#line 5396 "bison_parser.cpp"
+#line 5428 "bison_parser.cpp"
     break;
 
   case 297: /* interval_literal: INTERVAL STRING  */
-#line 1273 "bison_parser.y"
+#line 1290 "bison_parser.y"
                   {
   int duration{0}, chars_parsed{0};
   // 'seconds' and 'minutes' are the longest accepted interval qualifiers (7 chars) + null byte
@@ -5428,21 +5460,21 @@ yyreduce:
   }
   (yyval.expr) = Expr::makeIntervalLiteral(duration, unit);
 }
-#line 5432 "bison_parser.cpp"
+#line 5464 "bison_parser.cpp"
     break;
 
   case 298: /* param_expr: '?'  */
-#line 1305 "bison_parser.y"
+#line 1322 "bison_parser.y"
                  {
   (yyval.expr) = Expr::makeParameter(yylloc.total_column);
   (yyval.expr)->ival2 = yylloc.total_column - 1;  // source column (0-based) of the '?' token
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5442 "bison_parser.cpp"
+#line 5474 "bison_parser.cpp"
     break;
 
   case 299: /* param_expr: DOLLAR_PARAM  */
-#line 1310 "bison_parser.y"
+#line 1327 "bison_parser.y"
                {
   if ((yyvsp[0].ival) < 1) {
     yyerror(&yyloc, result, scanner, "$0 is not a valid positional parameter.");
@@ -5455,61 +5487,61 @@ yyreduce:
   (yyval.expr)->ival2 = yylloc.total_column - dollarLen;
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5459 "bison_parser.cpp"
+#line 5491 "bison_parser.cpp"
     break;
 
   case 300: /* param_expr: NAMED_PARAM  */
-#line 1322 "bison_parser.y"
+#line 1339 "bison_parser.y"
               {
   (yyval.expr) = Expr::makeNamedParameter((yyvsp[0].sval));
   (yyval.expr)->ival2 = yylloc.total_column - 1 - (int64_t)strlen((yyvsp[0].sval));
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5469 "bison_parser.cpp"
+#line 5501 "bison_parser.cpp"
     break;
 
   case 302: /* table_ref: table_ref_commalist ',' table_ref_atomic  */
-#line 1331 "bison_parser.y"
+#line 1348 "bison_parser.y"
                                                                         {
   (yyvsp[-2].table_vec)->push_back((yyvsp[0].table));
   auto tbl = new TableRef(kTableCrossProduct);
   tbl->list = (yyvsp[-2].table_vec);
   (yyval.table) = tbl;
 }
-#line 5480 "bison_parser.cpp"
+#line 5512 "bison_parser.cpp"
     break;
 
   case 306: /* nonjoin_table_ref_atomic: '(' select_statement ')' opt_table_alias  */
-#line 1340 "bison_parser.y"
+#line 1357 "bison_parser.y"
                                                                                      {
   auto tbl = new TableRef(kTableSelect);
   tbl->select = (yyvsp[-2].select_stmt);
   tbl->alias = (yyvsp[0].alias_t);
   (yyval.table) = tbl;
 }
-#line 5491 "bison_parser.cpp"
+#line 5523 "bison_parser.cpp"
     break;
 
   case 307: /* table_ref_commalist: table_ref_atomic  */
-#line 1347 "bison_parser.y"
+#line 1364 "bison_parser.y"
                                        {
   (yyval.table_vec) = new std::vector<TableRef*>();
   (yyval.table_vec)->push_back((yyvsp[0].table));
 }
-#line 5500 "bison_parser.cpp"
+#line 5532 "bison_parser.cpp"
     break;
 
   case 308: /* table_ref_commalist: table_ref_commalist ',' table_ref_atomic  */
-#line 1351 "bison_parser.y"
+#line 1368 "bison_parser.y"
                                            {
   (yyvsp[-2].table_vec)->push_back((yyvsp[0].table));
   (yyval.table_vec) = (yyvsp[-2].table_vec);
 }
-#line 5509 "bison_parser.cpp"
+#line 5541 "bison_parser.cpp"
     break;
 
   case 309: /* table_ref_name: table_name opt_table_alias  */
-#line 1356 "bison_parser.y"
+#line 1373 "bison_parser.y"
                                             {
   auto tbl = new TableRef(kTableName);
   tbl->schema = (yyvsp[-1].table_name).schema;
@@ -5517,215 +5549,215 @@ yyreduce:
   tbl->alias = (yyvsp[0].alias_t);
   (yyval.table) = tbl;
 }
-#line 5521 "bison_parser.cpp"
+#line 5553 "bison_parser.cpp"
     break;
 
   case 310: /* table_ref_name_no_alias: table_name  */
-#line 1364 "bison_parser.y"
+#line 1381 "bison_parser.y"
                                      {
   (yyval.table) = new TableRef(kTableName);
   (yyval.table)->schema = (yyvsp[0].table_name).schema;
   (yyval.table)->name = (yyvsp[0].table_name).name;
 }
-#line 5531 "bison_parser.cpp"
+#line 5563 "bison_parser.cpp"
     break;
 
   case 311: /* table_name: IDENTIFIER  */
-#line 1370 "bison_parser.y"
+#line 1387 "bison_parser.y"
                         {
   (yyval.table_name).schema = nullptr;
   (yyval.table_name).name = (yyvsp[0].sval);
 }
-#line 5540 "bison_parser.cpp"
+#line 5572 "bison_parser.cpp"
     break;
 
   case 312: /* table_name: IDENTIFIER '.' IDENTIFIER  */
-#line 1374 "bison_parser.y"
+#line 1391 "bison_parser.y"
                             {
   (yyval.table_name).schema = (yyvsp[-2].sval);
   (yyval.table_name).name = (yyvsp[0].sval);
 }
-#line 5549 "bison_parser.cpp"
+#line 5581 "bison_parser.cpp"
     break;
 
   case 313: /* opt_index_name: IDENTIFIER  */
-#line 1379 "bison_parser.y"
+#line 1396 "bison_parser.y"
                             { (yyval.sval) = (yyvsp[0].sval); }
-#line 5555 "bison_parser.cpp"
+#line 5587 "bison_parser.cpp"
     break;
 
   case 314: /* opt_index_name: %empty  */
-#line 1380 "bison_parser.y"
+#line 1397 "bison_parser.y"
               { (yyval.sval) = nullptr; }
-#line 5561 "bison_parser.cpp"
+#line 5593 "bison_parser.cpp"
     break;
 
   case 316: /* table_alias: AS IDENTIFIER '(' ident_commalist ')'  */
-#line 1382 "bison_parser.y"
+#line 1399 "bison_parser.y"
                                                             { (yyval.alias_t) = new Alias((yyvsp[-3].sval), (yyvsp[-1].str_vec)); }
-#line 5567 "bison_parser.cpp"
+#line 5599 "bison_parser.cpp"
     break;
 
   case 318: /* opt_table_alias: %empty  */
-#line 1384 "bison_parser.y"
+#line 1401 "bison_parser.y"
                                             { (yyval.alias_t) = nullptr; }
-#line 5573 "bison_parser.cpp"
+#line 5605 "bison_parser.cpp"
     break;
 
   case 319: /* alias: AS IDENTIFIER  */
-#line 1386 "bison_parser.y"
+#line 1403 "bison_parser.y"
                       { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
-#line 5579 "bison_parser.cpp"
+#line 5611 "bison_parser.cpp"
     break;
 
   case 320: /* alias: IDENTIFIER  */
-#line 1387 "bison_parser.y"
+#line 1404 "bison_parser.y"
              { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
-#line 5585 "bison_parser.cpp"
+#line 5617 "bison_parser.cpp"
     break;
 
   case 322: /* opt_alias: %empty  */
-#line 1389 "bison_parser.y"
+#line 1406 "bison_parser.y"
                                 { (yyval.alias_t) = nullptr; }
-#line 5591 "bison_parser.cpp"
+#line 5623 "bison_parser.cpp"
     break;
 
   case 323: /* opt_locking_clause: opt_locking_clause_list  */
-#line 1395 "bison_parser.y"
+#line 1412 "bison_parser.y"
                                              { (yyval.locking_clause_vec) = (yyvsp[0].locking_clause_vec); }
-#line 5597 "bison_parser.cpp"
+#line 5629 "bison_parser.cpp"
     break;
 
   case 324: /* opt_locking_clause: %empty  */
-#line 1396 "bison_parser.y"
+#line 1413 "bison_parser.y"
               { (yyval.locking_clause_vec) = nullptr; }
-#line 5603 "bison_parser.cpp"
+#line 5635 "bison_parser.cpp"
     break;
 
   case 325: /* opt_locking_clause_list: locking_clause  */
-#line 1398 "bison_parser.y"
+#line 1415 "bison_parser.y"
                                          {
   (yyval.locking_clause_vec) = new std::vector<LockingClause*>();
   (yyval.locking_clause_vec)->push_back((yyvsp[0].locking_t));
 }
-#line 5612 "bison_parser.cpp"
+#line 5644 "bison_parser.cpp"
     break;
 
   case 326: /* opt_locking_clause_list: opt_locking_clause_list locking_clause  */
-#line 1402 "bison_parser.y"
+#line 1419 "bison_parser.y"
                                          {
   (yyvsp[-1].locking_clause_vec)->push_back((yyvsp[0].locking_t));
   (yyval.locking_clause_vec) = (yyvsp[-1].locking_clause_vec);
 }
-#line 5621 "bison_parser.cpp"
+#line 5653 "bison_parser.cpp"
     break;
 
   case 327: /* locking_clause: FOR row_lock_mode opt_row_lock_policy  */
-#line 1407 "bison_parser.y"
+#line 1424 "bison_parser.y"
                                                        {
   (yyval.locking_t) = new LockingClause();
   (yyval.locking_t)->rowLockMode = (yyvsp[-1].lock_mode_t);
   (yyval.locking_t)->rowLockWaitPolicy = (yyvsp[0].lock_wait_policy_t);
   (yyval.locking_t)->tables = nullptr;
 }
-#line 5632 "bison_parser.cpp"
+#line 5664 "bison_parser.cpp"
     break;
 
   case 328: /* locking_clause: FOR row_lock_mode OF ident_commalist opt_row_lock_policy  */
-#line 1413 "bison_parser.y"
+#line 1430 "bison_parser.y"
                                                            {
   (yyval.locking_t) = new LockingClause();
   (yyval.locking_t)->rowLockMode = (yyvsp[-3].lock_mode_t);
   (yyval.locking_t)->tables = (yyvsp[-1].str_vec);
   (yyval.locking_t)->rowLockWaitPolicy = (yyvsp[0].lock_wait_policy_t);
 }
-#line 5643 "bison_parser.cpp"
+#line 5675 "bison_parser.cpp"
     break;
 
   case 329: /* row_lock_mode: UPDATE  */
-#line 1420 "bison_parser.y"
+#line 1437 "bison_parser.y"
                        { (yyval.lock_mode_t) = RowLockMode::ForUpdate; }
-#line 5649 "bison_parser.cpp"
+#line 5681 "bison_parser.cpp"
     break;
 
   case 330: /* row_lock_mode: NO KEY UPDATE  */
-#line 1421 "bison_parser.y"
+#line 1438 "bison_parser.y"
                 { (yyval.lock_mode_t) = RowLockMode::ForNoKeyUpdate; }
-#line 5655 "bison_parser.cpp"
+#line 5687 "bison_parser.cpp"
     break;
 
   case 331: /* row_lock_mode: SHARE  */
-#line 1422 "bison_parser.y"
+#line 1439 "bison_parser.y"
         { (yyval.lock_mode_t) = RowLockMode::ForShare; }
-#line 5661 "bison_parser.cpp"
+#line 5693 "bison_parser.cpp"
     break;
 
   case 332: /* row_lock_mode: KEY SHARE  */
-#line 1423 "bison_parser.y"
+#line 1440 "bison_parser.y"
             { (yyval.lock_mode_t) = RowLockMode::ForKeyShare; }
-#line 5667 "bison_parser.cpp"
+#line 5699 "bison_parser.cpp"
     break;
 
   case 333: /* opt_row_lock_policy: SKIP LOCKED  */
-#line 1425 "bison_parser.y"
+#line 1442 "bison_parser.y"
                                   { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::SkipLocked; }
-#line 5673 "bison_parser.cpp"
+#line 5705 "bison_parser.cpp"
     break;
 
   case 334: /* opt_row_lock_policy: NOWAIT  */
-#line 1426 "bison_parser.y"
+#line 1443 "bison_parser.y"
          { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::NoWait; }
-#line 5679 "bison_parser.cpp"
+#line 5711 "bison_parser.cpp"
     break;
 
   case 335: /* opt_row_lock_policy: %empty  */
-#line 1427 "bison_parser.y"
+#line 1444 "bison_parser.y"
               { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::None; }
-#line 5685 "bison_parser.cpp"
+#line 5717 "bison_parser.cpp"
     break;
 
   case 337: /* opt_with_clause: %empty  */
-#line 1433 "bison_parser.y"
+#line 1450 "bison_parser.y"
                                             { (yyval.with_description_vec) = nullptr; }
-#line 5691 "bison_parser.cpp"
+#line 5723 "bison_parser.cpp"
     break;
 
   case 338: /* with_clause: WITH with_description_list  */
-#line 1435 "bison_parser.y"
+#line 1452 "bison_parser.y"
                                          { (yyval.with_description_vec) = (yyvsp[0].with_description_vec); }
-#line 5697 "bison_parser.cpp"
+#line 5729 "bison_parser.cpp"
     break;
 
   case 339: /* with_description_list: with_description  */
-#line 1437 "bison_parser.y"
+#line 1454 "bison_parser.y"
                                          {
   (yyval.with_description_vec) = new std::vector<WithDescription*>();
   (yyval.with_description_vec)->push_back((yyvsp[0].with_description_t));
 }
-#line 5706 "bison_parser.cpp"
+#line 5738 "bison_parser.cpp"
     break;
 
   case 340: /* with_description_list: with_description_list ',' with_description  */
-#line 1441 "bison_parser.y"
+#line 1458 "bison_parser.y"
                                              {
   (yyvsp[-2].with_description_vec)->push_back((yyvsp[0].with_description_t));
   (yyval.with_description_vec) = (yyvsp[-2].with_description_vec);
 }
-#line 5715 "bison_parser.cpp"
+#line 5747 "bison_parser.cpp"
     break;
 
   case 341: /* with_description: IDENTIFIER AS select_with_paren  */
-#line 1446 "bison_parser.y"
+#line 1463 "bison_parser.y"
                                                    {
   (yyval.with_description_t) = new WithDescription();
   (yyval.with_description_t)->alias = (yyvsp[-2].sval);
   (yyval.with_description_t)->select = (yyvsp[0].select_stmt);
 }
-#line 5725 "bison_parser.cpp"
+#line 5757 "bison_parser.cpp"
     break;
 
   case 342: /* join_clause: table_ref_atomic NATURAL JOIN nonjoin_table_ref_atomic  */
-#line 1456 "bison_parser.y"
+#line 1473 "bison_parser.y"
                                                                      {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
@@ -5733,11 +5765,11 @@ yyreduce:
   (yyval.table)->join->left = (yyvsp[-3].table);
   (yyval.table)->join->right = (yyvsp[0].table);
 }
-#line 5737 "bison_parser.cpp"
+#line 5769 "bison_parser.cpp"
     break;
 
   case 343: /* join_clause: table_ref_atomic opt_join_type JOIN table_ref_atomic ON join_condition  */
-#line 1463 "bison_parser.y"
+#line 1480 "bison_parser.y"
                                                                          {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
@@ -5746,11 +5778,11 @@ yyreduce:
   (yyval.table)->join->right = (yyvsp[-2].table);
   (yyval.table)->join->condition = (yyvsp[0].expr);
 }
-#line 5750 "bison_parser.cpp"
+#line 5782 "bison_parser.cpp"
     break;
 
   case 344: /* join_clause: table_ref_atomic opt_join_type JOIN table_ref_atomic USING '(' ident_commalist ')'  */
-#line 1471 "bison_parser.y"
+#line 1488 "bison_parser.y"
                                                                                      {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
@@ -5759,89 +5791,89 @@ yyreduce:
   (yyval.table)->join->right = (yyvsp[-4].table);
   (yyval.table)->join->namedColumns = (yyvsp[-1].str_vec);
 }
-#line 5763 "bison_parser.cpp"
+#line 5795 "bison_parser.cpp"
     break;
 
   case 345: /* opt_join_type: INNER  */
-#line 1480 "bison_parser.y"
+#line 1497 "bison_parser.y"
                       { (yyval.join_type) = kJoinInner; }
-#line 5769 "bison_parser.cpp"
+#line 5801 "bison_parser.cpp"
     break;
 
   case 346: /* opt_join_type: LEFT OUTER  */
-#line 1481 "bison_parser.y"
+#line 1498 "bison_parser.y"
              { (yyval.join_type) = kJoinLeft; }
-#line 5775 "bison_parser.cpp"
+#line 5807 "bison_parser.cpp"
     break;
 
   case 347: /* opt_join_type: LEFT  */
-#line 1482 "bison_parser.y"
+#line 1499 "bison_parser.y"
        { (yyval.join_type) = kJoinLeft; }
-#line 5781 "bison_parser.cpp"
+#line 5813 "bison_parser.cpp"
     break;
 
   case 348: /* opt_join_type: RIGHT OUTER  */
-#line 1483 "bison_parser.y"
+#line 1500 "bison_parser.y"
               { (yyval.join_type) = kJoinRight; }
-#line 5787 "bison_parser.cpp"
+#line 5819 "bison_parser.cpp"
     break;
 
   case 349: /* opt_join_type: RIGHT  */
-#line 1484 "bison_parser.y"
+#line 1501 "bison_parser.y"
         { (yyval.join_type) = kJoinRight; }
-#line 5793 "bison_parser.cpp"
+#line 5825 "bison_parser.cpp"
     break;
 
   case 350: /* opt_join_type: FULL OUTER  */
-#line 1485 "bison_parser.y"
+#line 1502 "bison_parser.y"
              { (yyval.join_type) = kJoinFull; }
-#line 5799 "bison_parser.cpp"
+#line 5831 "bison_parser.cpp"
     break;
 
   case 351: /* opt_join_type: OUTER  */
-#line 1486 "bison_parser.y"
+#line 1503 "bison_parser.y"
         { (yyval.join_type) = kJoinFull; }
-#line 5805 "bison_parser.cpp"
+#line 5837 "bison_parser.cpp"
     break;
 
   case 352: /* opt_join_type: FULL  */
-#line 1487 "bison_parser.y"
+#line 1504 "bison_parser.y"
        { (yyval.join_type) = kJoinFull; }
-#line 5811 "bison_parser.cpp"
+#line 5843 "bison_parser.cpp"
     break;
 
   case 353: /* opt_join_type: CROSS  */
-#line 1488 "bison_parser.y"
+#line 1505 "bison_parser.y"
         { (yyval.join_type) = kJoinCross; }
-#line 5817 "bison_parser.cpp"
+#line 5849 "bison_parser.cpp"
     break;
 
   case 354: /* opt_join_type: %empty  */
-#line 1489 "bison_parser.y"
+#line 1506 "bison_parser.y"
                        { (yyval.join_type) = kJoinInner; }
-#line 5823 "bison_parser.cpp"
+#line 5855 "bison_parser.cpp"
     break;
 
   case 358: /* ident_commalist: IDENTIFIER  */
-#line 1500 "bison_parser.y"
+#line 1517 "bison_parser.y"
                              {
   (yyval.str_vec) = new std::vector<char*>();
   (yyval.str_vec)->push_back((yyvsp[0].sval));
 }
-#line 5832 "bison_parser.cpp"
+#line 5864 "bison_parser.cpp"
     break;
 
   case 359: /* ident_commalist: ident_commalist ',' IDENTIFIER  */
-#line 1504 "bison_parser.y"
+#line 1521 "bison_parser.y"
                                  {
   (yyvsp[-2].str_vec)->push_back((yyvsp[0].sval));
   (yyval.str_vec) = (yyvsp[-2].str_vec);
 }
-#line 5841 "bison_parser.cpp"
+#line 5873 "bison_parser.cpp"
     break;
 
 
-#line 5845 "bison_parser.cpp"
+#line 5877 "bison_parser.cpp"
 
       default: break;
     }
@@ -6070,7 +6102,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 1510 "bison_parser.y"
+#line 1527 "bison_parser.y"
 
 
 /*********************************

--- a/src/parser/bison_parser.cpp
+++ b/src/parser/bison_parser.cpp
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -33,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -40,11 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Identify Bison output.  */
-#define YYBISON 1
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -68,9 +73,8 @@
 #define yydebug         hsql_debug
 #define yynerrs         hsql_nerrs
 
-
-/* Copy the first part of user declarations.  */
-#line 2 "bison_parser.y" /* yacc.c:339  */
+/* First part of user prologue.  */
+#line 2 "bison_parser.y"
 
 
 /**
@@ -101,394 +105,462 @@
   }
   // clang-format off
 
-#line 105 "bison_parser.cpp" /* yacc.c:339  */
+#line 109 "bison_parser.cpp"
 
-# ifndef YY_NULLPTR
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULLPTR nullptr
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
 #  else
-#   define YY_NULLPTR 0
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
 #  endif
 # endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 1
-#endif
-
-/* In a future release of Bison, this section will be replaced
-   by #include "bison_parser.h".  */
-#ifndef YY_HSQL_BISON_PARSER_H_INCLUDED
-# define YY_HSQL_BISON_PARSER_H_INCLUDED
-/* Debug traces.  */
-#ifndef HSQL_DEBUG
-# if defined YYDEBUG
-#if YYDEBUG
-#   define HSQL_DEBUG 1
-#  else
-#   define HSQL_DEBUG 0
-#  endif
-# else /* ! defined YYDEBUG */
-#  define HSQL_DEBUG 0
-# endif /* ! defined YYDEBUG */
-#endif  /* ! defined HSQL_DEBUG */
-#if HSQL_DEBUG
-extern int hsql_debug;
-#endif
-/* "%code requires" blocks.  */
-#line 39 "bison_parser.y" /* yacc.c:355  */
-
-// %code requires block
-
-#include "../SQLParserResult.h"
-#include "../sql/statements.h"
-#include "parser_typedef.h"
-
-// Auto update column and line number
-#define YY_USER_ACTION                        \
-  yylloc->first_line = yylloc->last_line;     \
-  yylloc->first_column = yylloc->last_column; \
-  for (int i = 0; yytext[i] != '\0'; i++) {   \
-    yylloc->total_column++;                   \
-    yylloc->string_length++;                  \
-    if (yytext[i] == '\n') {                  \
-      yylloc->last_line++;                    \
-      yylloc->last_column = 0;                \
-    } else {                                  \
-      yylloc->last_column++;                  \
-    }                                         \
-  }
-
-#line 166 "bison_parser.cpp" /* yacc.c:355  */
-
-/* Token type.  */
-#ifndef HSQL_TOKENTYPE
-# define HSQL_TOKENTYPE
-  enum hsql_tokentype
-  {
-    SQL_IDENTIFIER = 258,
-    SQL_STRING = 259,
-    SQL_FLOATVAL = 260,
-    SQL_INTVAL = 261,
-    SQL_DEALLOCATE = 262,
-    SQL_PARAMETERS = 263,
-    SQL_INTERSECT = 264,
-    SQL_TEMPORARY = 265,
-    SQL_TIMESTAMP = 266,
-    SQL_DISTINCT = 267,
-    SQL_NVARCHAR = 268,
-    SQL_RESTRICT = 269,
-    SQL_TRUNCATE = 270,
-    SQL_ANALYZE = 271,
-    SQL_BETWEEN = 272,
-    SQL_CASCADE = 273,
-    SQL_COLUMNS = 274,
-    SQL_CONTROL = 275,
-    SQL_DEFAULT = 276,
-    SQL_EXECUTE = 277,
-    SQL_EXPLAIN = 278,
-    SQL_ENCODING = 279,
-    SQL_INTEGER = 280,
-    SQL_NATURAL = 281,
-    SQL_PREPARE = 282,
-    SQL_SCHEMAS = 283,
-    SQL_CHARACTER_VARYING = 284,
-    SQL_REAL = 285,
-    SQL_DECIMAL = 286,
-    SQL_SMALLINT = 287,
-    SQL_BIGINT = 288,
-    SQL_SPATIAL = 289,
-    SQL_VARCHAR = 290,
-    SQL_VIRTUAL = 291,
-    SQL_DESCRIBE = 292,
-    SQL_BEFORE = 293,
-    SQL_COLUMN = 294,
-    SQL_CREATE = 295,
-    SQL_DELETE = 296,
-    SQL_DIRECT = 297,
-    SQL_DOUBLE = 298,
-    SQL_ESCAPE = 299,
-    SQL_EXCEPT = 300,
-    SQL_EXISTS = 301,
-    SQL_EXTRACT = 302,
-    SQL_CAST = 303,
-    SQL_FORMAT = 304,
-    SQL_GLOBAL = 305,
-    SQL_HAVING = 306,
-    SQL_IMPORT = 307,
-    SQL_INSERT = 308,
-    SQL_ISNULL = 309,
-    SQL_OFFSET = 310,
-    SQL_RENAME = 311,
-    SQL_SCHEMA = 312,
-    SQL_SELECT = 313,
-    SQL_SORTED = 314,
-    SQL_TABLES = 315,
-    SQL_UNLOAD = 316,
-    SQL_UPDATE = 317,
-    SQL_VALUES = 318,
-    SQL_AFTER = 319,
-    SQL_ALTER = 320,
-    SQL_CROSS = 321,
-    SQL_DELTA = 322,
-    SQL_FLOAT = 323,
-    SQL_GROUP = 324,
-    SQL_INDEX = 325,
-    SQL_INNER = 326,
-    SQL_LIMIT = 327,
-    SQL_LOCAL = 328,
-    SQL_MERGE = 329,
-    SQL_MINUS = 330,
-    SQL_ORDER = 331,
-    SQL_OVER = 332,
-    SQL_OUTER = 333,
-    SQL_RIGHT = 334,
-    SQL_TABLE = 335,
-    SQL_UNION = 336,
-    SQL_USING = 337,
-    SQL_WHERE = 338,
-    SQL_CALL = 339,
-    SQL_CASE = 340,
-    SQL_CHAR = 341,
-    SQL_COPY = 342,
-    SQL_DATE = 343,
-    SQL_DATETIME = 344,
-    SQL_DESC = 345,
-    SQL_DROP = 346,
-    SQL_ELSE = 347,
-    SQL_FILE = 348,
-    SQL_FROM = 349,
-    SQL_FULL = 350,
-    SQL_HASH = 351,
-    SQL_HINT = 352,
-    SQL_INTO = 353,
-    SQL_JOIN = 354,
-    SQL_LEFT = 355,
-    SQL_LIKE = 356,
-    SQL_LOAD = 357,
-    SQL_LONG = 358,
-    SQL_NULL = 359,
-    SQL_PARTITION = 360,
-    SQL_PLAN = 361,
-    SQL_SHOW = 362,
-    SQL_TEXT = 363,
-    SQL_THEN = 364,
-    SQL_TIME = 365,
-    SQL_VIEW = 366,
-    SQL_WHEN = 367,
-    SQL_WITH = 368,
-    SQL_ADD = 369,
-    SQL_ALL = 370,
-    SQL_AND = 371,
-    SQL_ASC = 372,
-    SQL_END = 373,
-    SQL_FOR = 374,
-    SQL_INT = 375,
-    SQL_NOT = 376,
-    SQL_OFF = 377,
-    SQL_SET = 378,
-    SQL_TOP = 379,
-    SQL_AS = 380,
-    SQL_BY = 381,
-    SQL_IF = 382,
-    SQL_IN = 383,
-    SQL_IS = 384,
-    SQL_OF = 385,
-    SQL_ON = 386,
-    SQL_OR = 387,
-    SQL_TO = 388,
-    SQL_NO = 389,
-    SQL_ARRAY = 390,
-    SQL_CONCAT = 391,
-    SQL_ILIKE = 392,
-    SQL_SECOND = 393,
-    SQL_MINUTE = 394,
-    SQL_HOUR = 395,
-    SQL_DAY = 396,
-    SQL_MONTH = 397,
-    SQL_YEAR = 398,
-    SQL_SECONDS = 399,
-    SQL_MINUTES = 400,
-    SQL_HOURS = 401,
-    SQL_DAYS = 402,
-    SQL_MONTHS = 403,
-    SQL_YEARS = 404,
-    SQL_INTERVAL = 405,
-    SQL_TRUE = 406,
-    SQL_FALSE = 407,
-    SQL_BOOLEAN = 408,
-    SQL_TRANSACTION = 409,
-    SQL_BEGIN = 410,
-    SQL_COMMIT = 411,
-    SQL_ROLLBACK = 412,
-    SQL_NOWAIT = 413,
-    SQL_SKIP = 414,
-    SQL_LOCKED = 415,
-    SQL_SHARE = 416,
-    SQL_RANGE = 417,
-    SQL_ROWS = 418,
-    SQL_GROUPS = 419,
-    SQL_UNBOUNDED = 420,
-    SQL_FOLLOWING = 421,
-    SQL_PRECEDING = 422,
-    SQL_CURRENT_ROW = 423,
-    SQL_UNIQUE = 424,
-    SQL_PRIMARY = 425,
-    SQL_FOREIGN = 426,
-    SQL_KEY = 427,
-    SQL_REFERENCES = 428,
-    SQL_EQUALS = 429,
-    SQL_NOTEQUALS = 430,
-    SQL_LESS = 431,
-    SQL_GREATER = 432,
-    SQL_LESSEQ = 433,
-    SQL_GREATEREQ = 434,
-    SQL_NOTNULL = 435,
-    SQL_UMINUS = 436
-  };
-#endif
-
-/* Value type.  */
-#if ! defined HSQL_STYPE && ! defined HSQL_STYPE_IS_DECLARED
-
-union HSQL_STYPE
+#include "bison_parser.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
 {
-#line 102 "bison_parser.y" /* yacc.c:355  */
-
-  // clang-format on
-  bool bval;
-  char* sval;
-  double fval;
-  int64_t ival;
-  uintmax_t uval;
-
-  // statements
-  hsql::AlterStatement* alter_stmt;
-  hsql::CreateStatement* create_stmt;
-  hsql::DeleteStatement* delete_stmt;
-  hsql::DropStatement* drop_stmt;
-  hsql::ExecuteStatement* exec_stmt;
-  hsql::ExportStatement* export_stmt;
-  hsql::ImportStatement* import_stmt;
-  hsql::InsertStatement* insert_stmt;
-  hsql::PrepareStatement* prep_stmt;
-  hsql::SelectStatement* select_stmt;
-  hsql::ShowStatement* show_stmt;
-  hsql::SQLStatement* statement;
-  hsql::TransactionStatement* transaction_stmt;
-  hsql::UpdateStatement* update_stmt;
-
-  hsql::Alias* alias_t;
-  hsql::AlterAction* alter_action_t;
-  hsql::ColumnConstraints* column_constraints_t;
-  hsql::ColumnDefinition* column_t;
-  hsql::ColumnType column_type_t;
-  hsql::ConstraintType column_constraint_t;
-  hsql::DatetimeField datetime_field;
-  hsql::DropColumnAction* drop_action_t;
-  hsql::Expr* expr;
-  hsql::FrameBound* frame_bound;
-  hsql::FrameDescription* frame_description;
-  hsql::FrameType frame_type;
-  hsql::GroupByDescription* group_t;
-  hsql::ImportType import_type_t;
-  hsql::JoinType join_type;
-  hsql::LimitDescription* limit;
-  hsql::LockingClause* locking_t;
-  hsql::OrderDescription* order;
-  hsql::OrderType order_type;
-  hsql::NullOrdering null_ordering_t;
-  hsql::ReferencesSpecification* references_spec_t;
-  hsql::SetOperation* set_operator_t;
-  hsql::TableConstraint* table_constraint_t;
-  hsql::TableElement* table_element_t;
-  hsql::TableName table_name;
-  hsql::TableRef* table;
-  hsql::UpdateClause* update_t;
-  hsql::WindowDescription* window_description;
-  hsql::WithDescription* with_description_t;
-
-  std::vector<char*>* str_vec;
-  std::vector<hsql::Expr*>* expr_vec;
-  std::vector<hsql::OrderDescription*>* order_vec;
-  std::vector<hsql::SQLStatement*>* stmt_vec;
-  std::vector<hsql::TableElement*>* table_element_vec;
-  std::vector<hsql::TableRef*>* table_vec;
-  std::vector<hsql::UpdateClause*>* update_vec;
-  std::vector<hsql::WithDescription*>* with_description_vec;
-  std::vector<hsql::LockingClause*>* locking_clause_vec;
-
-  std::pair<int64_t, int64_t>* ival_pair;
-
-  hsql::RowLockMode lock_mode_t;
-  hsql::RowLockWaitPolicy lock_wait_policy_t;
-
-  hsql::ImportExportOptions* import_export_option_t;
-  std::pair<hsql::CsvOptionType, char*>* csv_option_t;
-
-  // clang-format off
-
-#line 435 "bison_parser.cpp" /* yacc.c:355  */
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_IDENTIFIER = 3,                 /* IDENTIFIER  */
+  YYSYMBOL_STRING = 4,                     /* STRING  */
+  YYSYMBOL_FLOATVAL = 5,                   /* FLOATVAL  */
+  YYSYMBOL_INTVAL = 6,                     /* INTVAL  */
+  YYSYMBOL_DOLLAR_PARAM = 7,               /* DOLLAR_PARAM  */
+  YYSYMBOL_NAMED_PARAM = 8,                /* NAMED_PARAM  */
+  YYSYMBOL_DEALLOCATE = 9,                 /* DEALLOCATE  */
+  YYSYMBOL_PARAMETERS = 10,                /* PARAMETERS  */
+  YYSYMBOL_INTERSECT = 11,                 /* INTERSECT  */
+  YYSYMBOL_TEMPORARY = 12,                 /* TEMPORARY  */
+  YYSYMBOL_TIMESTAMP = 13,                 /* TIMESTAMP  */
+  YYSYMBOL_DISTINCT = 14,                  /* DISTINCT  */
+  YYSYMBOL_NVARCHAR = 15,                  /* NVARCHAR  */
+  YYSYMBOL_RESTRICT = 16,                  /* RESTRICT  */
+  YYSYMBOL_TRUNCATE = 17,                  /* TRUNCATE  */
+  YYSYMBOL_ANALYZE = 18,                   /* ANALYZE  */
+  YYSYMBOL_BETWEEN = 19,                   /* BETWEEN  */
+  YYSYMBOL_CASCADE = 20,                   /* CASCADE  */
+  YYSYMBOL_COLUMNS = 21,                   /* COLUMNS  */
+  YYSYMBOL_CONTROL = 22,                   /* CONTROL  */
+  YYSYMBOL_DEFAULT = 23,                   /* DEFAULT  */
+  YYSYMBOL_EXECUTE = 24,                   /* EXECUTE  */
+  YYSYMBOL_EXPLAIN = 25,                   /* EXPLAIN  */
+  YYSYMBOL_ENCODING = 26,                  /* ENCODING  */
+  YYSYMBOL_INTEGER = 27,                   /* INTEGER  */
+  YYSYMBOL_NATURAL = 28,                   /* NATURAL  */
+  YYSYMBOL_PREPARE = 29,                   /* PREPARE  */
+  YYSYMBOL_SCHEMAS = 30,                   /* SCHEMAS  */
+  YYSYMBOL_CHARACTER_VARYING = 31,         /* CHARACTER_VARYING  */
+  YYSYMBOL_REAL = 32,                      /* REAL  */
+  YYSYMBOL_DECIMAL = 33,                   /* DECIMAL  */
+  YYSYMBOL_SMALLINT = 34,                  /* SMALLINT  */
+  YYSYMBOL_BIGINT = 35,                    /* BIGINT  */
+  YYSYMBOL_SPATIAL = 36,                   /* SPATIAL  */
+  YYSYMBOL_VARCHAR = 37,                   /* VARCHAR  */
+  YYSYMBOL_VIRTUAL = 38,                   /* VIRTUAL  */
+  YYSYMBOL_DESCRIBE = 39,                  /* DESCRIBE  */
+  YYSYMBOL_BEFORE = 40,                    /* BEFORE  */
+  YYSYMBOL_COLUMN = 41,                    /* COLUMN  */
+  YYSYMBOL_CREATE = 42,                    /* CREATE  */
+  YYSYMBOL_DELETE = 43,                    /* DELETE  */
+  YYSYMBOL_DIRECT = 44,                    /* DIRECT  */
+  YYSYMBOL_DOUBLE = 45,                    /* DOUBLE  */
+  YYSYMBOL_ESCAPE = 46,                    /* ESCAPE  */
+  YYSYMBOL_EXCEPT = 47,                    /* EXCEPT  */
+  YYSYMBOL_EXISTS = 48,                    /* EXISTS  */
+  YYSYMBOL_EXTRACT = 49,                   /* EXTRACT  */
+  YYSYMBOL_CAST = 50,                      /* CAST  */
+  YYSYMBOL_FORMAT = 51,                    /* FORMAT  */
+  YYSYMBOL_GLOBAL = 52,                    /* GLOBAL  */
+  YYSYMBOL_HAVING = 53,                    /* HAVING  */
+  YYSYMBOL_IMPORT = 54,                    /* IMPORT  */
+  YYSYMBOL_INSERT = 55,                    /* INSERT  */
+  YYSYMBOL_ISNULL = 56,                    /* ISNULL  */
+  YYSYMBOL_OFFSET = 57,                    /* OFFSET  */
+  YYSYMBOL_RENAME = 58,                    /* RENAME  */
+  YYSYMBOL_SCHEMA = 59,                    /* SCHEMA  */
+  YYSYMBOL_SELECT = 60,                    /* SELECT  */
+  YYSYMBOL_SORTED = 61,                    /* SORTED  */
+  YYSYMBOL_TABLES = 62,                    /* TABLES  */
+  YYSYMBOL_UNLOAD = 63,                    /* UNLOAD  */
+  YYSYMBOL_UPDATE = 64,                    /* UPDATE  */
+  YYSYMBOL_VALUES = 65,                    /* VALUES  */
+  YYSYMBOL_AFTER = 66,                     /* AFTER  */
+  YYSYMBOL_ALTER = 67,                     /* ALTER  */
+  YYSYMBOL_CROSS = 68,                     /* CROSS  */
+  YYSYMBOL_DELTA = 69,                     /* DELTA  */
+  YYSYMBOL_FLOAT = 70,                     /* FLOAT  */
+  YYSYMBOL_GROUP = 71,                     /* GROUP  */
+  YYSYMBOL_INDEX = 72,                     /* INDEX  */
+  YYSYMBOL_INNER = 73,                     /* INNER  */
+  YYSYMBOL_LIMIT = 74,                     /* LIMIT  */
+  YYSYMBOL_LOCAL = 75,                     /* LOCAL  */
+  YYSYMBOL_MERGE = 76,                     /* MERGE  */
+  YYSYMBOL_MINUS = 77,                     /* MINUS  */
+  YYSYMBOL_ORDER = 78,                     /* ORDER  */
+  YYSYMBOL_OVER = 79,                      /* OVER  */
+  YYSYMBOL_OUTER = 80,                     /* OUTER  */
+  YYSYMBOL_RIGHT = 81,                     /* RIGHT  */
+  YYSYMBOL_TABLE = 82,                     /* TABLE  */
+  YYSYMBOL_UNION = 83,                     /* UNION  */
+  YYSYMBOL_USING = 84,                     /* USING  */
+  YYSYMBOL_WHERE = 85,                     /* WHERE  */
+  YYSYMBOL_CALL = 86,                      /* CALL  */
+  YYSYMBOL_CASE = 87,                      /* CASE  */
+  YYSYMBOL_CHAR = 88,                      /* CHAR  */
+  YYSYMBOL_COPY = 89,                      /* COPY  */
+  YYSYMBOL_DATE = 90,                      /* DATE  */
+  YYSYMBOL_DATETIME = 91,                  /* DATETIME  */
+  YYSYMBOL_DESC = 92,                      /* DESC  */
+  YYSYMBOL_DROP = 93,                      /* DROP  */
+  YYSYMBOL_ELSE = 94,                      /* ELSE  */
+  YYSYMBOL_FILE = 95,                      /* FILE  */
+  YYSYMBOL_FROM = 96,                      /* FROM  */
+  YYSYMBOL_FULL = 97,                      /* FULL  */
+  YYSYMBOL_HASH = 98,                      /* HASH  */
+  YYSYMBOL_HINT = 99,                      /* HINT  */
+  YYSYMBOL_INTO = 100,                     /* INTO  */
+  YYSYMBOL_JOIN = 101,                     /* JOIN  */
+  YYSYMBOL_LEFT = 102,                     /* LEFT  */
+  YYSYMBOL_LIKE = 103,                     /* LIKE  */
+  YYSYMBOL_LOAD = 104,                     /* LOAD  */
+  YYSYMBOL_LONG = 105,                     /* LONG  */
+  YYSYMBOL_NULL = 106,                     /* NULL  */
+  YYSYMBOL_PARTITION = 107,                /* PARTITION  */
+  YYSYMBOL_PLAN = 108,                     /* PLAN  */
+  YYSYMBOL_SHOW = 109,                     /* SHOW  */
+  YYSYMBOL_TEXT = 110,                     /* TEXT  */
+  YYSYMBOL_THEN = 111,                     /* THEN  */
+  YYSYMBOL_TIME = 112,                     /* TIME  */
+  YYSYMBOL_VIEW = 113,                     /* VIEW  */
+  YYSYMBOL_WHEN = 114,                     /* WHEN  */
+  YYSYMBOL_WITH = 115,                     /* WITH  */
+  YYSYMBOL_ADD = 116,                      /* ADD  */
+  YYSYMBOL_ALL = 117,                      /* ALL  */
+  YYSYMBOL_AND = 118,                      /* AND  */
+  YYSYMBOL_ASC = 119,                      /* ASC  */
+  YYSYMBOL_END = 120,                      /* END  */
+  YYSYMBOL_FOR = 121,                      /* FOR  */
+  YYSYMBOL_INT = 122,                      /* INT  */
+  YYSYMBOL_NOT = 123,                      /* NOT  */
+  YYSYMBOL_OFF = 124,                      /* OFF  */
+  YYSYMBOL_SET = 125,                      /* SET  */
+  YYSYMBOL_TOP = 126,                      /* TOP  */
+  YYSYMBOL_AS = 127,                       /* AS  */
+  YYSYMBOL_BY = 128,                       /* BY  */
+  YYSYMBOL_IF = 129,                       /* IF  */
+  YYSYMBOL_IN = 130,                       /* IN  */
+  YYSYMBOL_IS = 131,                       /* IS  */
+  YYSYMBOL_OF = 132,                       /* OF  */
+  YYSYMBOL_ON = 133,                       /* ON  */
+  YYSYMBOL_OR = 134,                       /* OR  */
+  YYSYMBOL_TO = 135,                       /* TO  */
+  YYSYMBOL_NO = 136,                       /* NO  */
+  YYSYMBOL_ARRAY = 137,                    /* ARRAY  */
+  YYSYMBOL_CONCAT = 138,                   /* CONCAT  */
+  YYSYMBOL_ILIKE = 139,                    /* ILIKE  */
+  YYSYMBOL_SECOND = 140,                   /* SECOND  */
+  YYSYMBOL_MINUTE = 141,                   /* MINUTE  */
+  YYSYMBOL_HOUR = 142,                     /* HOUR  */
+  YYSYMBOL_DAY = 143,                      /* DAY  */
+  YYSYMBOL_MONTH = 144,                    /* MONTH  */
+  YYSYMBOL_YEAR = 145,                     /* YEAR  */
+  YYSYMBOL_SECONDS = 146,                  /* SECONDS  */
+  YYSYMBOL_MINUTES = 147,                  /* MINUTES  */
+  YYSYMBOL_HOURS = 148,                    /* HOURS  */
+  YYSYMBOL_DAYS = 149,                     /* DAYS  */
+  YYSYMBOL_MONTHS = 150,                   /* MONTHS  */
+  YYSYMBOL_YEARS = 151,                    /* YEARS  */
+  YYSYMBOL_INTERVAL = 152,                 /* INTERVAL  */
+  YYSYMBOL_TRUE = 153,                     /* TRUE  */
+  YYSYMBOL_FALSE = 154,                    /* FALSE  */
+  YYSYMBOL_BOOLEAN = 155,                  /* BOOLEAN  */
+  YYSYMBOL_TRANSACTION = 156,              /* TRANSACTION  */
+  YYSYMBOL_BEGIN = 157,                    /* BEGIN  */
+  YYSYMBOL_COMMIT = 158,                   /* COMMIT  */
+  YYSYMBOL_ROLLBACK = 159,                 /* ROLLBACK  */
+  YYSYMBOL_NOWAIT = 160,                   /* NOWAIT  */
+  YYSYMBOL_SKIP = 161,                     /* SKIP  */
+  YYSYMBOL_LOCKED = 162,                   /* LOCKED  */
+  YYSYMBOL_SHARE = 163,                    /* SHARE  */
+  YYSYMBOL_RANGE = 164,                    /* RANGE  */
+  YYSYMBOL_ROWS = 165,                     /* ROWS  */
+  YYSYMBOL_GROUPS = 166,                   /* GROUPS  */
+  YYSYMBOL_UNBOUNDED = 167,                /* UNBOUNDED  */
+  YYSYMBOL_FOLLOWING = 168,                /* FOLLOWING  */
+  YYSYMBOL_PRECEDING = 169,                /* PRECEDING  */
+  YYSYMBOL_CURRENT_ROW = 170,              /* CURRENT_ROW  */
+  YYSYMBOL_UNIQUE = 171,                   /* UNIQUE  */
+  YYSYMBOL_PRIMARY = 172,                  /* PRIMARY  */
+  YYSYMBOL_FOREIGN = 173,                  /* FOREIGN  */
+  YYSYMBOL_KEY = 174,                      /* KEY  */
+  YYSYMBOL_REFERENCES = 175,               /* REFERENCES  */
+  YYSYMBOL_176_ = 176,                     /* '='  */
+  YYSYMBOL_EQUALS = 177,                   /* EQUALS  */
+  YYSYMBOL_NOTEQUALS = 178,                /* NOTEQUALS  */
+  YYSYMBOL_179_ = 179,                     /* '<'  */
+  YYSYMBOL_180_ = 180,                     /* '>'  */
+  YYSYMBOL_LESS = 181,                     /* LESS  */
+  YYSYMBOL_GREATER = 182,                  /* GREATER  */
+  YYSYMBOL_LESSEQ = 183,                   /* LESSEQ  */
+  YYSYMBOL_GREATEREQ = 184,                /* GREATEREQ  */
+  YYSYMBOL_NOTNULL = 185,                  /* NOTNULL  */
+  YYSYMBOL_186_ = 186,                     /* '+'  */
+  YYSYMBOL_187_ = 187,                     /* '-'  */
+  YYSYMBOL_188_ = 188,                     /* '*'  */
+  YYSYMBOL_189_ = 189,                     /* '/'  */
+  YYSYMBOL_190_ = 190,                     /* '%'  */
+  YYSYMBOL_191_ = 191,                     /* '^'  */
+  YYSYMBOL_UMINUS = 192,                   /* UMINUS  */
+  YYSYMBOL_193_ = 193,                     /* '['  */
+  YYSYMBOL_194_ = 194,                     /* ']'  */
+  YYSYMBOL_195_ = 195,                     /* '('  */
+  YYSYMBOL_196_ = 196,                     /* ')'  */
+  YYSYMBOL_197_ = 197,                     /* '.'  */
+  YYSYMBOL_198_ = 198,                     /* ';'  */
+  YYSYMBOL_199_ = 199,                     /* ','  */
+  YYSYMBOL_200_ = 200,                     /* '?'  */
+  YYSYMBOL_YYACCEPT = 201,                 /* $accept  */
+  YYSYMBOL_input = 202,                    /* input  */
+  YYSYMBOL_statement_list = 203,           /* statement_list  */
+  YYSYMBOL_statement = 204,                /* statement  */
+  YYSYMBOL_preparable_statement = 205,     /* preparable_statement  */
+  YYSYMBOL_opt_hints = 206,                /* opt_hints  */
+  YYSYMBOL_hint_list = 207,                /* hint_list  */
+  YYSYMBOL_hint = 208,                     /* hint  */
+  YYSYMBOL_transaction_statement = 209,    /* transaction_statement  */
+  YYSYMBOL_opt_transaction_keyword = 210,  /* opt_transaction_keyword  */
+  YYSYMBOL_prepare_statement = 211,        /* prepare_statement  */
+  YYSYMBOL_prepare_target_query = 212,     /* prepare_target_query  */
+  YYSYMBOL_execute_statement = 213,        /* execute_statement  */
+  YYSYMBOL_import_statement = 214,         /* import_statement  */
+  YYSYMBOL_file_type = 215,                /* file_type  */
+  YYSYMBOL_file_path = 216,                /* file_path  */
+  YYSYMBOL_opt_import_export_options = 217, /* opt_import_export_options  */
+  YYSYMBOL_import_export_options = 218,    /* import_export_options  */
+  YYSYMBOL_csv_option = 219,               /* csv_option  */
+  YYSYMBOL_export_statement = 220,         /* export_statement  */
+  YYSYMBOL_show_statement = 221,           /* show_statement  */
+  YYSYMBOL_create_statement = 222,         /* create_statement  */
+  YYSYMBOL_opt_not_exists = 223,           /* opt_not_exists  */
+  YYSYMBOL_table_elem_commalist = 224,     /* table_elem_commalist  */
+  YYSYMBOL_table_elem = 225,               /* table_elem  */
+  YYSYMBOL_column_def = 226,               /* column_def  */
+  YYSYMBOL_column_type = 227,              /* column_type  */
+  YYSYMBOL_opt_time_precision = 228,       /* opt_time_precision  */
+  YYSYMBOL_opt_decimal_specification = 229, /* opt_decimal_specification  */
+  YYSYMBOL_opt_column_constraints = 230,   /* opt_column_constraints  */
+  YYSYMBOL_column_constraints = 231,       /* column_constraints  */
+  YYSYMBOL_column_constraint = 232,        /* column_constraint  */
+  YYSYMBOL_table_constraint = 233,         /* table_constraint  */
+  YYSYMBOL_references_spec = 234,          /* references_spec  */
+  YYSYMBOL_drop_statement = 235,           /* drop_statement  */
+  YYSYMBOL_opt_exists = 236,               /* opt_exists  */
+  YYSYMBOL_alter_statement = 237,          /* alter_statement  */
+  YYSYMBOL_alter_action = 238,             /* alter_action  */
+  YYSYMBOL_drop_action = 239,              /* drop_action  */
+  YYSYMBOL_delete_statement = 240,         /* delete_statement  */
+  YYSYMBOL_truncate_statement = 241,       /* truncate_statement  */
+  YYSYMBOL_insert_statement = 242,         /* insert_statement  */
+  YYSYMBOL_opt_column_list = 243,          /* opt_column_list  */
+  YYSYMBOL_update_statement = 244,         /* update_statement  */
+  YYSYMBOL_update_clause_commalist = 245,  /* update_clause_commalist  */
+  YYSYMBOL_update_clause = 246,            /* update_clause  */
+  YYSYMBOL_select_statement = 247,         /* select_statement  */
+  YYSYMBOL_select_within_set_operation = 248, /* select_within_set_operation  */
+  YYSYMBOL_select_within_set_operation_no_parentheses = 249, /* select_within_set_operation_no_parentheses  */
+  YYSYMBOL_select_with_paren = 250,        /* select_with_paren  */
+  YYSYMBOL_select_no_paren = 251,          /* select_no_paren  */
+  YYSYMBOL_set_operator = 252,             /* set_operator  */
+  YYSYMBOL_set_type = 253,                 /* set_type  */
+  YYSYMBOL_opt_all = 254,                  /* opt_all  */
+  YYSYMBOL_select_clause = 255,            /* select_clause  */
+  YYSYMBOL_opt_distinct = 256,             /* opt_distinct  */
+  YYSYMBOL_select_list = 257,              /* select_list  */
+  YYSYMBOL_opt_from_clause = 258,          /* opt_from_clause  */
+  YYSYMBOL_from_clause = 259,              /* from_clause  */
+  YYSYMBOL_opt_where = 260,                /* opt_where  */
+  YYSYMBOL_opt_group = 261,                /* opt_group  */
+  YYSYMBOL_opt_having = 262,               /* opt_having  */
+  YYSYMBOL_opt_order = 263,                /* opt_order  */
+  YYSYMBOL_order_list = 264,               /* order_list  */
+  YYSYMBOL_order_desc = 265,               /* order_desc  */
+  YYSYMBOL_opt_order_type = 266,           /* opt_order_type  */
+  YYSYMBOL_opt_null_ordering = 267,        /* opt_null_ordering  */
+  YYSYMBOL_opt_top = 268,                  /* opt_top  */
+  YYSYMBOL_opt_limit = 269,                /* opt_limit  */
+  YYSYMBOL_expr_list = 270,                /* expr_list  */
+  YYSYMBOL_opt_extended_literal_list = 271, /* opt_extended_literal_list  */
+  YYSYMBOL_extended_literal_list = 272,    /* extended_literal_list  */
+  YYSYMBOL_casted_extended_literal = 273,  /* casted_extended_literal  */
+  YYSYMBOL_extended_literal = 274,         /* extended_literal  */
+  YYSYMBOL_expr_alias = 275,               /* expr_alias  */
+  YYSYMBOL_expr = 276,                     /* expr  */
+  YYSYMBOL_operand = 277,                  /* operand  */
+  YYSYMBOL_scalar_expr = 278,              /* scalar_expr  */
+  YYSYMBOL_unary_expr = 279,               /* unary_expr  */
+  YYSYMBOL_binary_expr = 280,              /* binary_expr  */
+  YYSYMBOL_logic_expr = 281,               /* logic_expr  */
+  YYSYMBOL_in_expr = 282,                  /* in_expr  */
+  YYSYMBOL_case_expr = 283,                /* case_expr  */
+  YYSYMBOL_case_list = 284,                /* case_list  */
+  YYSYMBOL_exists_expr = 285,              /* exists_expr  */
+  YYSYMBOL_comp_expr = 286,                /* comp_expr  */
+  YYSYMBOL_function_expr = 287,            /* function_expr  */
+  YYSYMBOL_opt_window = 288,               /* opt_window  */
+  YYSYMBOL_opt_partition = 289,            /* opt_partition  */
+  YYSYMBOL_opt_frame_clause = 290,         /* opt_frame_clause  */
+  YYSYMBOL_frame_type = 291,               /* frame_type  */
+  YYSYMBOL_frame_bound = 292,              /* frame_bound  */
+  YYSYMBOL_extract_expr = 293,             /* extract_expr  */
+  YYSYMBOL_cast_expr = 294,                /* cast_expr  */
+  YYSYMBOL_datetime_field = 295,           /* datetime_field  */
+  YYSYMBOL_datetime_field_plural = 296,    /* datetime_field_plural  */
+  YYSYMBOL_duration_field = 297,           /* duration_field  */
+  YYSYMBOL_array_expr = 298,               /* array_expr  */
+  YYSYMBOL_array_index = 299,              /* array_index  */
+  YYSYMBOL_between_expr = 300,             /* between_expr  */
+  YYSYMBOL_column_name = 301,              /* column_name  */
+  YYSYMBOL_literal = 302,                  /* literal  */
+  YYSYMBOL_string_literal = 303,           /* string_literal  */
+  YYSYMBOL_bool_literal = 304,             /* bool_literal  */
+  YYSYMBOL_num_literal = 305,              /* num_literal  */
+  YYSYMBOL_int_literal = 306,              /* int_literal  */
+  YYSYMBOL_null_literal = 307,             /* null_literal  */
+  YYSYMBOL_date_literal = 308,             /* date_literal  */
+  YYSYMBOL_interval_literal = 309,         /* interval_literal  */
+  YYSYMBOL_param_expr = 310,               /* param_expr  */
+  YYSYMBOL_table_ref = 311,                /* table_ref  */
+  YYSYMBOL_table_ref_atomic = 312,         /* table_ref_atomic  */
+  YYSYMBOL_nonjoin_table_ref_atomic = 313, /* nonjoin_table_ref_atomic  */
+  YYSYMBOL_table_ref_commalist = 314,      /* table_ref_commalist  */
+  YYSYMBOL_table_ref_name = 315,           /* table_ref_name  */
+  YYSYMBOL_table_ref_name_no_alias = 316,  /* table_ref_name_no_alias  */
+  YYSYMBOL_table_name = 317,               /* table_name  */
+  YYSYMBOL_opt_index_name = 318,           /* opt_index_name  */
+  YYSYMBOL_table_alias = 319,              /* table_alias  */
+  YYSYMBOL_opt_table_alias = 320,          /* opt_table_alias  */
+  YYSYMBOL_alias = 321,                    /* alias  */
+  YYSYMBOL_opt_alias = 322,                /* opt_alias  */
+  YYSYMBOL_opt_locking_clause = 323,       /* opt_locking_clause  */
+  YYSYMBOL_opt_locking_clause_list = 324,  /* opt_locking_clause_list  */
+  YYSYMBOL_locking_clause = 325,           /* locking_clause  */
+  YYSYMBOL_row_lock_mode = 326,            /* row_lock_mode  */
+  YYSYMBOL_opt_row_lock_policy = 327,      /* opt_row_lock_policy  */
+  YYSYMBOL_opt_with_clause = 328,          /* opt_with_clause  */
+  YYSYMBOL_with_clause = 329,              /* with_clause  */
+  YYSYMBOL_with_description_list = 330,    /* with_description_list  */
+  YYSYMBOL_with_description = 331,         /* with_description  */
+  YYSYMBOL_join_clause = 332,              /* join_clause  */
+  YYSYMBOL_opt_join_type = 333,            /* opt_join_type  */
+  YYSYMBOL_join_condition = 334,           /* join_condition  */
+  YYSYMBOL_opt_semicolon = 335,            /* opt_semicolon  */
+  YYSYMBOL_ident_commalist = 336           /* ident_commalist  */
 };
-
-typedef union HSQL_STYPE HSQL_STYPE;
-# define HSQL_STYPE_IS_TRIVIAL 1
-# define HSQL_STYPE_IS_DECLARED 1
-#endif
-
-/* Location type.  */
-#if ! defined HSQL_LTYPE && ! defined HSQL_LTYPE_IS_DECLARED
-typedef struct HSQL_LTYPE HSQL_LTYPE;
-struct HSQL_LTYPE
-{
-  int first_line;
-  int first_column;
-  int last_line;
-  int last_column;
-};
-# define HSQL_LTYPE_IS_DECLARED 1
-# define HSQL_LTYPE_IS_TRIVIAL 1
-#endif
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 
 
-int hsql_parse (hsql::SQLParserResult* result, yyscan_t scanner);
-
-#endif /* !YY_HSQL_BISON_PARSER_H_INCLUDED  */
-
-/* Copy the second part of user declarations.  */
-
-#line 465 "bison_parser.cpp" /* yacc.c:358  */
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
 #else
 typedef signed char yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -496,15 +568,28 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int16 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
@@ -518,47 +603,43 @@ typedef short int yytype_int16;
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE
-# if (defined __GNUC__                                               \
-      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
-     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
-#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
 # else
-#  define YY_ATTRIBUTE(Spec) /* empty */
+#  define YY_ATTRIBUTE_PURE
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE_PURE
-# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
-#endif
-
 #ifndef YY_ATTRIBUTE_UNUSED
-# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
-#endif
-
-#if !defined _Noreturn \
-     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
-# if defined _MSC_VER && 1200 <= _MSC_VER
-#  define _Noreturn __declspec (noreturn)
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
 # else
-#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+#  define YY_ATTRIBUTE_UNUSED
 # endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
-    _Pragma ("GCC diagnostic push") \
-    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
 # define YY_INITIAL_VALUE(Value) Value
@@ -571,8 +652,22 @@ typedef short int yytype_int16;
 # define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if 1
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -637,8 +732,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* 1 */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -648,18 +742,19 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss_alloc;
+  yy_state_t yyss_alloc;
   YYSTYPE yyvs_alloc;
   YYLTYPE yyls_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE) + sizeof (YYLTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE) \
+             + YYSIZEOF (YYLTYPE)) \
       + 2 * YYSTACK_GAP_MAXIMUM)
 
 # define YYCOPY_NEEDED 1
@@ -672,11 +767,11 @@ union yyalloc
 # define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
     do                                                                  \
       {                                                                 \
-        YYSIZE_T yynewbytes;                                            \
+        YYPTRDIFF_T yynewbytes;                                         \
         YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
         Stack = &yyptr->Stack_alloc;                                    \
-        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-        yyptr += yynewbytes / sizeof (*yyptr);                          \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
       }                                                                 \
     while (0)
 
@@ -688,12 +783,12 @@ union yyalloc
 # ifndef YYCOPY
 #  if defined __GNUC__ && 1 < __GNUC__
 #   define YYCOPY(Dst, Src, Count) \
-      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
 #  else
 #   define YYCOPY(Dst, Src, Count)              \
       do                                        \
         {                                       \
-          YYSIZE_T yyi;                         \
+          YYPTRDIFF_T yyi;                      \
           for (yyi = 0; yyi < (Count); yyi++)   \
             (Dst)[yyi] = (Src)[yyi];            \
         }                                       \
@@ -705,39 +800,42 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  69
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   856
+#define YYLAST   929
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  199
+#define YYNTOKENS  201
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  136
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  357
+#define YYNRULES  359
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  656
+#define YYNSTATES  658
 
-/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
-   by yylex, with out-of-bounds checking.  */
-#define YYUNDEFTOK  2
-#define YYMAXUTOK   436
+/* YYMAXUTOK -- Last valid token kind.  */
+#define YYMAXUTOK   438
 
-#define YYTRANSLATE(YYX)                                                \
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, without out-of-bounds checking.  */
+   as returned by yylex.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,   188,     2,     2,
-     193,   194,   186,   184,   197,   185,   195,   187,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,   196,
-     177,   174,   178,   198,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,   190,     2,     2,
+     195,   196,   188,   186,   199,   187,   197,   189,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,   198,
+     179,   176,   180,   200,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,   191,     2,   192,   189,     2,     2,     2,     2,     2,
+       2,   193,     2,   194,   191,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -770,93 +868,101 @@ static const yytype_uint8 yytranslate[] =
      135,   136,   137,   138,   139,   140,   141,   142,   143,   144,
      145,   146,   147,   148,   149,   150,   151,   152,   153,   154,
      155,   156,   157,   158,   159,   160,   161,   162,   163,   164,
-     165,   166,   167,   168,   169,   170,   171,   172,   173,   175,
-     176,   179,   180,   181,   182,   183,   190
+     165,   166,   167,   168,   169,   170,   171,   172,   173,   174,
+     175,   177,   178,   181,   182,   183,   184,   185,   192
 };
 
 #if HSQL_DEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_uint16 yyrline[] =
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static const yytype_int16 yyrline[] =
 {
-       0,   343,   343,   362,   368,   375,   379,   383,   384,   385,
-     387,   388,   389,   390,   391,   392,   393,   394,   395,   396,
-     402,   403,   405,   409,   414,   418,   428,   429,   430,   432,
-     432,   438,   444,   446,   450,   462,   468,   485,   500,   502,
-     503,   504,   506,   520,   524,   534,   538,   562,   570,   583,
-     590,   605,   625,   626,   631,   642,   655,   667,   674,   681,
-     690,   691,   693,   697,   702,   703,   705,   713,   714,   715,
-     716,   717,   718,   719,   723,   724,   725,   726,   727,   728,
-     729,   730,   731,   732,   733,   735,   736,   738,   739,   740,
-     742,   743,   745,   749,   753,   758,   766,   767,   768,   769,
-     771,   772,   773,   775,   783,   789,   795,   801,   807,   808,
-     815,   821,   823,   833,   840,   851,   858,   866,   867,   874,
-     881,   885,   890,   900,   904,   908,   920,   920,   922,   923,
-     932,   933,   935,   949,   961,   966,   970,   974,   979,   980,
-     982,   992,   993,   995,   997,   998,  1000,  1002,  1003,  1005,
-    1010,  1012,  1013,  1015,  1016,  1018,  1022,  1027,  1029,  1030,
-    1031,  1033,  1034,  1056,  1057,  1059,  1060,  1061,  1062,  1063,
-    1064,  1069,  1073,  1079,  1080,  1082,  1086,  1091,  1091,  1095,
-    1103,  1104,  1106,  1115,  1115,  1115,  1115,  1115,  1117,  1118,
-    1118,  1118,  1118,  1118,  1118,  1118,  1118,  1119,  1119,  1123,
-    1123,  1125,  1126,  1127,  1128,  1129,  1131,  1131,  1132,  1133,
-    1134,  1135,  1136,  1137,  1138,  1139,  1140,  1142,  1143,  1145,
-    1146,  1147,  1148,  1152,  1153,  1154,  1155,  1157,  1158,  1160,
-    1161,  1163,  1164,  1165,  1166,  1167,  1168,  1169,  1173,  1174,
-    1175,  1176,  1180,  1181,  1183,  1184,  1189,  1190,  1191,  1195,
-    1196,  1197,  1199,  1200,  1201,  1202,  1203,  1205,  1207,  1209,
-    1210,  1211,  1212,  1213,  1214,  1216,  1217,  1218,  1219,  1220,
-    1221,  1223,  1223,  1225,  1227,  1229,  1231,  1232,  1233,  1234,
-    1236,  1236,  1236,  1236,  1236,  1236,  1236,  1238,  1240,  1241,
-    1243,  1244,  1246,  1248,  1250,  1261,  1262,  1273,  1305,  1314,
-    1314,  1321,  1321,  1323,  1323,  1330,  1334,  1339,  1347,  1353,
-    1357,  1362,  1363,  1365,  1365,  1367,  1367,  1369,  1370,  1372,
-    1372,  1378,  1379,  1381,  1385,  1390,  1396,  1403,  1404,  1405,
-    1406,  1408,  1409,  1410,  1416,  1416,  1418,  1420,  1424,  1429,
-    1439,  1446,  1454,  1463,  1464,  1465,  1466,  1467,  1468,  1469,
-    1470,  1471,  1472,  1474,  1480,  1480,  1483,  1487
+       0,   345,   345,   365,   371,   378,   382,   386,   387,   388,
+     390,   391,   392,   393,   394,   395,   396,   397,   398,   399,
+     405,   406,   408,   412,   417,   421,   431,   432,   433,   435,
+     435,   441,   447,   449,   453,   465,   471,   488,   503,   505,
+     506,   507,   509,   523,   527,   537,   541,   565,   573,   586,
+     593,   608,   628,   629,   634,   645,   658,   670,   677,   684,
+     693,   694,   696,   700,   705,   706,   708,   716,   717,   718,
+     719,   720,   721,   722,   726,   727,   728,   729,   730,   731,
+     732,   733,   734,   735,   736,   738,   739,   741,   742,   743,
+     745,   746,   748,   752,   756,   761,   769,   770,   771,   772,
+     774,   775,   776,   778,   786,   792,   798,   804,   810,   811,
+     818,   824,   826,   836,   843,   854,   861,   869,   870,   877,
+     884,   888,   893,   903,   907,   911,   923,   923,   925,   926,
+     935,   936,   938,   952,   964,   969,   973,   977,   982,   983,
+     985,   995,   996,   998,  1000,  1001,  1003,  1005,  1006,  1008,
+    1013,  1015,  1016,  1018,  1019,  1021,  1025,  1030,  1032,  1033,
+    1034,  1036,  1037,  1059,  1060,  1062,  1063,  1064,  1065,  1066,
+    1067,  1072,  1076,  1082,  1083,  1085,  1089,  1094,  1094,  1098,
+    1106,  1107,  1109,  1118,  1118,  1118,  1118,  1118,  1120,  1121,
+    1121,  1121,  1121,  1121,  1121,  1121,  1121,  1122,  1122,  1126,
+    1126,  1128,  1129,  1130,  1131,  1132,  1134,  1134,  1135,  1136,
+    1137,  1138,  1139,  1140,  1141,  1142,  1143,  1145,  1146,  1148,
+    1149,  1150,  1151,  1155,  1156,  1157,  1158,  1160,  1161,  1163,
+    1164,  1166,  1167,  1168,  1169,  1170,  1171,  1172,  1176,  1177,
+    1178,  1181,  1187,  1188,  1190,  1191,  1196,  1197,  1198,  1202,
+    1203,  1204,  1206,  1207,  1208,  1209,  1210,  1212,  1214,  1216,
+    1217,  1218,  1219,  1220,  1221,  1223,  1224,  1225,  1226,  1227,
+    1228,  1230,  1230,  1232,  1234,  1236,  1238,  1239,  1240,  1241,
+    1243,  1243,  1243,  1243,  1243,  1243,  1243,  1245,  1247,  1248,
+    1250,  1251,  1253,  1255,  1257,  1268,  1269,  1280,  1312,  1317,
+    1325,  1333,  1333,  1340,  1340,  1342,  1342,  1349,  1353,  1358,
+    1366,  1372,  1376,  1381,  1382,  1384,  1384,  1386,  1386,  1388,
+    1389,  1391,  1391,  1397,  1398,  1400,  1404,  1409,  1415,  1422,
+    1423,  1424,  1425,  1427,  1428,  1429,  1435,  1435,  1437,  1439,
+    1443,  1448,  1458,  1465,  1473,  1482,  1483,  1484,  1485,  1486,
+    1487,  1488,  1489,  1490,  1491,  1493,  1499,  1499,  1502,  1506
 };
 #endif
 
-#if HSQL_DEBUG || YYERROR_VERBOSE || 1
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "IDENTIFIER", "STRING", "FLOATVAL",
-  "INTVAL", "DEALLOCATE", "PARAMETERS", "INTERSECT", "TEMPORARY",
-  "TIMESTAMP", "DISTINCT", "NVARCHAR", "RESTRICT", "TRUNCATE", "ANALYZE",
-  "BETWEEN", "CASCADE", "COLUMNS", "CONTROL", "DEFAULT", "EXECUTE",
-  "EXPLAIN", "ENCODING", "INTEGER", "NATURAL", "PREPARE", "SCHEMAS",
-  "CHARACTER_VARYING", "REAL", "DECIMAL", "SMALLINT", "BIGINT", "SPATIAL",
-  "VARCHAR", "VIRTUAL", "DESCRIBE", "BEFORE", "COLUMN", "CREATE", "DELETE",
-  "DIRECT", "DOUBLE", "ESCAPE", "EXCEPT", "EXISTS", "EXTRACT", "CAST",
-  "FORMAT", "GLOBAL", "HAVING", "IMPORT", "INSERT", "ISNULL", "OFFSET",
-  "RENAME", "SCHEMA", "SELECT", "SORTED", "TABLES", "UNLOAD", "UPDATE",
-  "VALUES", "AFTER", "ALTER", "CROSS", "DELTA", "FLOAT", "GROUP", "INDEX",
-  "INNER", "LIMIT", "LOCAL", "MERGE", "MINUS", "ORDER", "OVER", "OUTER",
-  "RIGHT", "TABLE", "UNION", "USING", "WHERE", "CALL", "CASE", "CHAR",
-  "COPY", "DATE", "DATETIME", "DESC", "DROP", "ELSE", "FILE", "FROM",
-  "FULL", "HASH", "HINT", "INTO", "JOIN", "LEFT", "LIKE", "LOAD", "LONG",
-  "NULL", "PARTITION", "PLAN", "SHOW", "TEXT", "THEN", "TIME", "VIEW",
-  "WHEN", "WITH", "ADD", "ALL", "AND", "ASC", "END", "FOR", "INT", "NOT",
-  "OFF", "SET", "TOP", "AS", "BY", "IF", "IN", "IS", "OF", "ON", "OR",
-  "TO", "NO", "ARRAY", "CONCAT", "ILIKE", "SECOND", "MINUTE", "HOUR",
-  "DAY", "MONTH", "YEAR", "SECONDS", "MINUTES", "HOURS", "DAYS", "MONTHS",
-  "YEARS", "INTERVAL", "TRUE", "FALSE", "BOOLEAN", "TRANSACTION", "BEGIN",
-  "COMMIT", "ROLLBACK", "NOWAIT", "SKIP", "LOCKED", "SHARE", "RANGE",
-  "ROWS", "GROUPS", "UNBOUNDED", "FOLLOWING", "PRECEDING", "CURRENT_ROW",
-  "UNIQUE", "PRIMARY", "FOREIGN", "KEY", "REFERENCES", "'='", "EQUALS",
-  "NOTEQUALS", "'<'", "'>'", "LESS", "GREATER", "LESSEQ", "GREATEREQ",
-  "NOTNULL", "'+'", "'-'", "'*'", "'/'", "'%'", "'^'", "UMINUS", "'['",
-  "']'", "'('", "')'", "'.'", "';'", "','", "'?'", "$accept", "input",
-  "statement_list", "statement", "preparable_statement", "opt_hints",
-  "hint_list", "hint", "transaction_statement", "opt_transaction_keyword",
-  "prepare_statement", "prepare_target_query", "execute_statement",
-  "import_statement", "file_type", "file_path",
-  "opt_import_export_options", "import_export_options", "csv_option",
-  "export_statement", "show_statement", "create_statement",
-  "opt_not_exists", "table_elem_commalist", "table_elem", "column_def",
-  "column_type", "opt_time_precision", "opt_decimal_specification",
+  "\"end of file\"", "error", "\"invalid token\"", "IDENTIFIER", "STRING",
+  "FLOATVAL", "INTVAL", "DOLLAR_PARAM", "NAMED_PARAM", "DEALLOCATE",
+  "PARAMETERS", "INTERSECT", "TEMPORARY", "TIMESTAMP", "DISTINCT",
+  "NVARCHAR", "RESTRICT", "TRUNCATE", "ANALYZE", "BETWEEN", "CASCADE",
+  "COLUMNS", "CONTROL", "DEFAULT", "EXECUTE", "EXPLAIN", "ENCODING",
+  "INTEGER", "NATURAL", "PREPARE", "SCHEMAS", "CHARACTER_VARYING", "REAL",
+  "DECIMAL", "SMALLINT", "BIGINT", "SPATIAL", "VARCHAR", "VIRTUAL",
+  "DESCRIBE", "BEFORE", "COLUMN", "CREATE", "DELETE", "DIRECT", "DOUBLE",
+  "ESCAPE", "EXCEPT", "EXISTS", "EXTRACT", "CAST", "FORMAT", "GLOBAL",
+  "HAVING", "IMPORT", "INSERT", "ISNULL", "OFFSET", "RENAME", "SCHEMA",
+  "SELECT", "SORTED", "TABLES", "UNLOAD", "UPDATE", "VALUES", "AFTER",
+  "ALTER", "CROSS", "DELTA", "FLOAT", "GROUP", "INDEX", "INNER", "LIMIT",
+  "LOCAL", "MERGE", "MINUS", "ORDER", "OVER", "OUTER", "RIGHT", "TABLE",
+  "UNION", "USING", "WHERE", "CALL", "CASE", "CHAR", "COPY", "DATE",
+  "DATETIME", "DESC", "DROP", "ELSE", "FILE", "FROM", "FULL", "HASH",
+  "HINT", "INTO", "JOIN", "LEFT", "LIKE", "LOAD", "LONG", "NULL",
+  "PARTITION", "PLAN", "SHOW", "TEXT", "THEN", "TIME", "VIEW", "WHEN",
+  "WITH", "ADD", "ALL", "AND", "ASC", "END", "FOR", "INT", "NOT", "OFF",
+  "SET", "TOP", "AS", "BY", "IF", "IN", "IS", "OF", "ON", "OR", "TO", "NO",
+  "ARRAY", "CONCAT", "ILIKE", "SECOND", "MINUTE", "HOUR", "DAY", "MONTH",
+  "YEAR", "SECONDS", "MINUTES", "HOURS", "DAYS", "MONTHS", "YEARS",
+  "INTERVAL", "TRUE", "FALSE", "BOOLEAN", "TRANSACTION", "BEGIN", "COMMIT",
+  "ROLLBACK", "NOWAIT", "SKIP", "LOCKED", "SHARE", "RANGE", "ROWS",
+  "GROUPS", "UNBOUNDED", "FOLLOWING", "PRECEDING", "CURRENT_ROW", "UNIQUE",
+  "PRIMARY", "FOREIGN", "KEY", "REFERENCES", "'='", "EQUALS", "NOTEQUALS",
+  "'<'", "'>'", "LESS", "GREATER", "LESSEQ", "GREATEREQ", "NOTNULL", "'+'",
+  "'-'", "'*'", "'/'", "'%'", "'^'", "UMINUS", "'['", "']'", "'('", "')'",
+  "'.'", "';'", "','", "'?'", "$accept", "input", "statement_list",
+  "statement", "preparable_statement", "opt_hints", "hint_list", "hint",
+  "transaction_statement", "opt_transaction_keyword", "prepare_statement",
+  "prepare_target_query", "execute_statement", "import_statement",
+  "file_type", "file_path", "opt_import_export_options",
+  "import_export_options", "csv_option", "export_statement",
+  "show_statement", "create_statement", "opt_not_exists",
+  "table_elem_commalist", "table_elem", "column_def", "column_type",
+  "opt_time_precision", "opt_decimal_specification",
   "opt_column_constraints", "column_constraints", "column_constraint",
   "table_constraint", "references_spec", "drop_statement", "opt_exists",
   "alter_statement", "alter_action", "drop_action", "delete_statement",
@@ -887,527 +993,519 @@ static const char *const yytname[] =
   "with_description_list", "with_description", "join_clause",
   "opt_join_type", "join_condition", "opt_semicolon", "ident_commalist", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_uint16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
-     295,   296,   297,   298,   299,   300,   301,   302,   303,   304,
-     305,   306,   307,   308,   309,   310,   311,   312,   313,   314,
-     315,   316,   317,   318,   319,   320,   321,   322,   323,   324,
-     325,   326,   327,   328,   329,   330,   331,   332,   333,   334,
-     335,   336,   337,   338,   339,   340,   341,   342,   343,   344,
-     345,   346,   347,   348,   349,   350,   351,   352,   353,   354,
-     355,   356,   357,   358,   359,   360,   361,   362,   363,   364,
-     365,   366,   367,   368,   369,   370,   371,   372,   373,   374,
-     375,   376,   377,   378,   379,   380,   381,   382,   383,   384,
-     385,   386,   387,   388,   389,   390,   391,   392,   393,   394,
-     395,   396,   397,   398,   399,   400,   401,   402,   403,   404,
-     405,   406,   407,   408,   409,   410,   411,   412,   413,   414,
-     415,   416,   417,   418,   419,   420,   421,   422,   423,   424,
-     425,   426,   427,   428,    61,   429,   430,    60,    62,   431,
-     432,   433,   434,   435,    43,    45,    42,    47,    37,    94,
-     436,    91,    93,    40,    41,    46,    59,    44,    63
-};
-# endif
+#define YYPACT_NINF (-493)
 
-#define YYPACT_NINF -529
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-529)))
+#define YYTABLE_NINF (-357)
 
-#define YYTABLE_NINF -355
+#define yytable_value_is_error(Yyn) \
+  ((Yyn) == YYTABLE_NINF)
 
-#define yytable_value_is_error(Yytable_value) \
-  (!!((Yytable_value) == (-355)))
-
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-     595,    27,    65,    71,    99,    65,   113,    83,   137,   140,
-      65,   190,    21,   195,    37,   292,   120,   120,   120,   287,
-     103,  -529,   221,  -529,   221,  -529,  -529,  -529,  -529,  -529,
-    -529,  -529,  -529,  -529,  -529,  -529,  -529,   -26,  -529,   342,
-     166,  -529,   183,   313,  -529,   251,   251,   251,    65,   415,
-      65,   298,  -529,   297,   -26,   293,   -37,   297,   297,   297,
-      65,  -529,   309,   267,  -529,  -529,  -529,  -529,  -529,  -529,
-     578,  -529,   369,  -529,  -529,   350,   224,  -529,    35,  -529,
-     479,   353,   486,   374,   494,    65,    65,   418,  -529,   413,
-     314,   505,   464,    65,   315,   317,   508,   508,   508,   519,
-      65,    65,  -529,   332,   292,  -529,   333,   521,   518,  -529,
-    -529,  -529,   -26,   420,   410,   -26,    15,  -529,  -529,  -529,
-     707,   344,   535,  -529,   536,  -529,  -529,    45,  -529,   349,
-     347,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,
-    -529,  -529,  -529,  -529,   500,  -529,   416,   -15,   314,   363,
-    -529,   508,   547,   198,   380,   -38,  -529,  -529,   466,  -529,
-    -529,  -529,   -75,   -75,   -75,  -529,  -529,  -529,  -529,  -529,
-     552,  -529,  -529,  -529,   363,   483,  -529,  -529,   224,  -529,
-    -529,   363,   483,   363,   151,   443,  -529,  -529,  -529,  -529,
-    -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,
-    -529,   200,  -529,   248,  -529,  -529,  -529,   353,  -529,    65,
-     561,   454,    19,   441,   129,   375,   381,   382,   244,   367,
-     396,    59,  -529,   335,    69,   395,  -529,  -529,  -529,  -529,
-    -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,
-    -529,  -529,   490,  -529,    38,   397,  -529,   363,   505,  -529,
-     550,  -529,  -529,   398,   193,  -529,   418,  -529,   402,   180,
-    -529,   502,   400,  -529,    44,    15,   -26,   401,  -529,   -31,
-      15,    69,   544,    68,   106,  -529,   443,  -529,   476,  -529,
-    -529,   411,   510,  -529,   668,   414,   434,   436,   205,  -529,
-    -529,  -529,   454,     9,    36,   551,   248,   363,   363,   268,
-     -43,   419,    59,   609,   363,   217,   417,   -23,   363,   363,
-      59,  -529,    59,    24,   421,   -27,    59,    59,    59,    59,
-      59,    59,    59,    59,    59,    59,    59,    59,    59,    59,
-      59,   521,    65,  -529,   610,   353,    69,  -529,   297,   193,
-     612,   616,   415,   617,   222,  -529,  -529,   353,  -529,   552,
-      22,   418,  -529,   363,  -529,   620,  -529,  -529,  -529,  -529,
-     363,  -529,  -529,   621,   443,   363,   363,  -529,   455,  -529,
-     465,   -70,  -529,   668,   547,   508,  -529,  -529,   432,  -529,
-     435,  -529,  -529,   440,  -529,  -529,   444,  -529,  -529,  -529,
-    -529,   445,  -529,  -529,   139,   547,   448,   449,  -529,    19,
-    -529,   557,   363,   451,  -529,   452,   555,   -13,   201,   167,
-     363,   363,  -529,   551,   528,   119,  -529,  -529,  -529,   529,
-     538,   638,    59,   457,   335,  -529,   548,   460,   638,   638,
-     638,   638,   653,   653,   653,   653,   217,   217,    92,    92,
-      92,   -96,   461,  -529,  -529,   228,   652,   234,  -529,  -529,
-    -529,  -529,  -529,   227,   239,  -529,   454,  -529,    87,  -529,
-     459,  -529,    39,  -529,   589,  -529,  -529,  -529,   658,  -529,
-    -529,    69,    69,   600,  -529,   547,  -529,   504,  -529,   472,
-     241,  -529,   662,   664,  -529,   665,   666,   667,  -529,  -529,
-     572,  -529,   506,    65,  -529,   139,  -529,  -529,   246,   547,
-     547,  -529,   484,  -529,   253,    14,  -529,   363,   668,   363,
-     363,  -529,   182,   211,   487,  -529,    59,   638,   335,   489,
-     264,  -529,  -529,  -529,  -529,  -529,   676,   415,  -529,  -529,
-     493,   585,  -529,  -529,  -529,   611,   618,   626,   591,    22,
-     685,  -529,  -529,  -529,   568,  -529,  -529,  -529,   -77,  -529,
-    -529,  -529,   501,   265,   511,   512,   515,  -529,  -529,   314,
-    -529,  -529,  -529,   266,   271,   613,   557,   557,   363,   121,
-     523,    69,   203,  -529,   363,  -529,   609,   527,   278,  -529,
-    -529,  -529,  -529,    39,    22,  -529,  -529,  -529,    22,   247,
-     539,   363,  -529,  -529,  -529,   722,  -529,  -529,  -529,  -529,
-    -529,   558,   614,   483,  -529,  -529,   279,  -529,  -529,  -529,
-      69,  -529,  -529,  -529,  -529,   463,   547,   -22,   543,  -529,
-     363,   330,   557,   549,   363,   284,   363,  -529,  -529,   400,
-    -529,  -529,  -529,   553,    61,  -529,   547,    69,  -529,  -529,
-      69,  -529,    25,    55,   188,  -529,  -529,   286,  -529,  -529,
-     625,  -529,  -529,  -529,    55,  -529
+     650,    26,    86,    90,   128,    86,   -16,    56,    80,    78,
+      86,   150,    20,   229,    41,   241,    94,    94,    94,   275,
+     107,  -493,   194,  -493,   194,  -493,  -493,  -493,  -493,  -493,
+    -493,  -493,  -493,  -493,  -493,  -493,  -493,   -15,  -493,   324,
+     140,  -493,   149,   262,  -493,   242,   242,   242,    86,   380,
+      86,   260,  -493,   261,   -15,   264,    42,   261,   261,   261,
+      86,  -493,   280,   231,  -493,  -493,  -493,  -493,  -493,  -493,
+     627,  -493,   319,  -493,  -493,   302,   219,  -493,   201,  -493,
+     429,   161,   454,   340,   465,    86,    86,   405,  -493,   387,
+     301,   496,   466,    86,   316,   320,   511,   511,   511,   516,
+      86,    86,  -493,   337,   241,  -493,   344,   527,   524,  -493,
+    -493,  -493,   -15,   424,   414,   -15,    16,  -493,  -493,  -493,
+     631,  -493,  -493,   351,   543,  -493,   548,  -493,  -493,    27,
+    -493,   357,   356,  -493,  -493,  -493,  -493,  -493,  -493,  -493,
+    -493,  -493,  -493,  -493,  -493,  -493,   508,  -493,   425,   -35,
+     301,   397,  -493,   511,   554,   235,   388,   -41,  -493,  -493,
+     470,  -493,  -493,  -493,   -62,   -62,   -62,  -493,  -493,  -493,
+    -493,  -493,   563,  -493,  -493,  -493,   397,   489,  -493,  -493,
+     219,  -493,  -493,   397,   489,   397,   187,   447,  -493,  -493,
+    -493,  -493,  -493,  -493,  -493,  -493,  -493,  -493,  -493,  -493,
+    -493,  -493,  -493,    34,  -493,   308,  -493,  -493,  -493,   161,
+    -493,    86,   571,   460,    32,   449,   -23,   383,   384,   391,
+     193,   407,   390,   417,  -493,   348,   144,   442,  -493,  -493,
+    -493,  -493,  -493,  -493,  -493,  -493,  -493,  -493,  -493,  -493,
+    -493,  -493,  -493,  -493,   487,  -493,   132,   393,  -493,   397,
+     496,  -493,   550,  -493,  -493,   398,    75,  -493,   405,  -493,
+     401,   139,  -493,   502,   400,  -493,   131,    16,   -15,   402,
+    -493,   200,    16,   144,   546,    10,    -4,  -493,   447,  -493,
+     473,  -493,  -493,   413,   514,  -493,   700,   418,   440,   441,
+     171,  -493,  -493,  -493,   460,    12,    18,   556,   308,   397,
+     397,   250,   192,   428,   417,   711,   397,    64,   438,   -59,
+     397,   397,   417,  -493,   417,   -34,   443,   116,   417,   417,
+     417,   417,   417,   417,   417,   417,   417,   417,   417,   417,
+     417,   417,   417,   527,    86,  -493,   621,   161,   144,  -493,
+     261,    75,   633,   635,   380,   636,   173,  -493,  -493,   161,
+    -493,   563,    22,   405,  -493,   397,  -493,   638,  -493,  -493,
+    -493,  -493,   397,  -493,  -493,   639,   447,   397,   397,  -493,
+     469,  -493,   482,    99,  -493,   700,   554,   511,  -493,  -493,
+     451,  -493,   452,  -493,  -493,   453,  -493,  -493,   455,  -493,
+    -493,  -493,  -493,   457,  -493,  -493,   -36,   554,   458,   459,
+    -493,    32,  -493,   570,   397,   462,  -493,   467,   559,   -39,
+     215,   209,   397,   397,  -493,   556,   555,    95,  -493,  -493,
+    -493,   542,   693,   736,   417,   476,   348,  -493,   558,   468,
+     736,   736,   736,   736,   338,   338,   338,   338,    64,    64,
+      47,    47,    47,   -66,   471,  -493,  -493,   190,   659,   196,
+    -493,  -493,  -493,  -493,  -493,   120,   210,  -493,   460,  -493,
+     363,  -493,   474,  -493,    46,  -493,   597,  -493,  -493,  -493,
+     669,  -493,  -493,   144,   144,   611,  -493,   554,  -493,   515,
+    -493,   480,   220,  -493,   672,   674,  -493,   677,   678,   679,
+    -493,  -493,   580,  -493,   513,    86,  -493,   -36,  -493,  -493,
+     230,   554,   554,  -493,   493,  -493,   238,    14,  -493,   397,
+     700,   397,   397,  -493,    29,   232,   494,  -493,   417,   736,
+     348,   499,   243,  -493,  -493,  -493,  -493,  -493,   692,   380,
+    -493,  -493,   501,   598,  -493,  -493,  -493,   618,   620,   622,
+     600,    22,   703,  -493,  -493,  -493,   575,  -493,  -493,  -493,
+     121,  -493,  -493,  -493,   519,   263,   522,   523,   525,  -493,
+    -493,   301,  -493,  -493,  -493,   276,   282,   602,   570,   570,
+     397,   -53,   526,   144,   239,  -493,   397,  -493,   711,   528,
+     284,  -493,  -493,  -493,  -493,    46,    22,  -493,  -493,  -493,
+      22,   509,   512,   397,  -493,  -493,  -493,   704,  -493,  -493,
+    -493,  -493,  -493,   536,   584,   489,  -493,  -493,   290,  -493,
+    -493,  -493,   144,  -493,  -493,  -493,  -493,   188,   554,   -10,
+     529,  -493,   397,   213,   570,   531,   397,   292,   397,  -493,
+    -493,   400,  -493,  -493,  -493,   532,    58,  -493,   554,   144,
+    -493,  -493,   144,  -493,   272,    57,   305,  -493,  -493,   296,
+    -493,  -493,   605,  -493,  -493,  -493,    57,  -493
 };
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
-static const yytype_uint16 yydefact[] =
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
+static const yytype_int16 yydefact[] =
 {
-     335,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     337,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,    30,    30,    30,     0,
-     355,     3,    21,    19,    21,    18,     8,     9,     7,    11,
-      16,    17,    13,    14,    12,    15,    10,     0,   334,     0,
-     309,   114,    33,     0,    54,    61,    61,    61,     0,     0,
-       0,     0,   308,   109,     0,     0,     0,   109,   109,   109,
-       0,    52,     0,   336,   337,    29,    26,    28,    27,     1,
-     335,     2,     0,     6,     5,   164,   123,   124,   154,   106,
-       0,   174,     0,     0,   312,     0,     0,   148,    37,     0,
+     357,     3,    21,    19,    21,    18,     8,     9,     7,    11,
+      16,    17,    13,    14,    12,    15,    10,     0,   336,     0,
+     311,   114,    33,     0,    54,    61,    61,    61,     0,     0,
+       0,     0,   310,   109,     0,     0,     0,   109,   109,   109,
+       0,    52,     0,   338,   339,    29,    26,    28,    27,     1,
+     337,     2,     0,     6,     5,   164,   123,   124,   154,   106,
+       0,   174,     0,     0,   314,     0,     0,   148,    37,     0,
      118,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,    53,     0,     0,     4,     0,     0,   142,   136,
-     137,   135,     0,   139,     0,     0,   170,   310,   287,   290,
-     292,     0,     0,   293,     0,   288,   289,     0,   298,     0,
-     173,   175,   177,   179,   280,   281,   282,   291,   283,   284,
-     285,   286,    32,    31,     0,   311,     0,     0,   118,     0,
-     113,     0,     0,     0,     0,   148,   120,   108,     0,   131,
-     130,    38,    41,    41,    41,   107,   104,   105,   339,   338,
-       0,   292,   163,   141,     0,   154,   127,   126,   128,   138,
-     134,     0,   154,     0,     0,   322,   259,   260,   261,   262,
-     263,   264,   265,   266,   267,   268,   269,   270,   271,   272,
-     295,     0,   294,   297,   180,   181,    34,     0,    60,     0,
-       0,   335,     0,     0,   276,     0,     0,     0,     0,     0,
-       0,     0,   278,     0,   147,   183,   190,   191,   192,   185,
-     187,   193,   186,   206,   194,   195,   196,   197,   189,   184,
-     199,   200,     0,   356,     0,     0,   116,     0,     0,   119,
-       0,   110,   111,     0,     0,    51,   148,    50,    24,     0,
-      22,   145,   143,   171,   320,   170,     0,   153,   155,   160,
-     170,   166,   168,   165,     0,   132,   321,   323,     0,   296,
-     176,     0,     0,    57,     0,     0,     0,     0,     0,    62,
-      64,    65,   335,   142,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   202,     0,   201,     0,     0,     0,     0,
-       0,   203,     0,     0,     0,     0,     0,     0,     0,     0,
+     137,   135,     0,   139,     0,     0,   170,   312,   287,   290,
+     292,   299,   300,     0,     0,   293,     0,   288,   289,     0,
+     298,     0,   173,   175,   177,   179,   280,   281,   282,   291,
+     283,   284,   285,   286,    32,    31,     0,   313,     0,     0,
+     118,     0,   113,     0,     0,     0,     0,   148,   120,   108,
+       0,   131,   130,    38,    41,    41,    41,   107,   104,   105,
+     341,   340,     0,   292,   163,   141,     0,   154,   127,   126,
+     128,   138,   134,     0,   154,     0,     0,   324,   259,   260,
+     261,   262,   263,   264,   265,   266,   267,   268,   269,   270,
+     271,   272,   295,     0,   294,   297,   180,   181,    34,     0,
+      60,     0,     0,   337,     0,     0,   276,     0,     0,     0,
+       0,     0,     0,     0,   278,     0,   147,   183,   190,   191,
+     192,   185,   187,   193,   186,   206,   194,   195,   196,   197,
+     189,   184,   199,   200,     0,   358,     0,     0,   116,     0,
+       0,   119,     0,   110,   111,     0,     0,    51,   148,    50,
+      24,     0,    22,   145,   143,   171,   322,   170,     0,   153,
+     155,   160,   170,   166,   168,   165,     0,   132,   323,   325,
+       0,   296,   176,     0,     0,    57,     0,     0,     0,     0,
+       0,    62,    64,    65,   337,   142,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   202,     0,   201,     0,     0,
+       0,     0,     0,   203,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   117,     0,     0,   122,   121,   109,     0,
-       0,     0,     0,     0,     0,    47,    36,     0,    20,     0,
-       0,   148,   144,     0,   318,     0,   319,   182,   125,   129,
-       0,   159,   158,   161,   322,     0,     0,   327,     0,   329,
-       0,   333,   324,     0,     0,     0,    83,    77,     0,    79,
-      89,    80,    67,     0,    74,    75,     0,    71,    72,    78,
-      81,    86,    76,    68,    91,     0,     0,     0,    56,     0,
-      59,   243,     0,   277,   279,     0,     0,     0,     0,     0,
-       0,     0,   225,     0,     0,     0,   198,   188,   217,   218,
-       0,   213,     0,     0,     0,   204,     0,   216,   215,   231,
-     232,   233,   234,   235,   236,   237,   208,   207,   210,   209,
-     211,   212,     0,    35,   357,     0,     0,     0,    48,    45,
-      43,    49,    40,     0,     0,    23,   335,   146,   299,   301,
-       0,   303,   316,   302,   150,   172,   317,   156,     0,   157,
-     133,   169,   167,     0,   330,     0,   332,     0,   325,     0,
-       0,    55,     0,     0,    73,     0,     0,     0,    82,    98,
-       0,    97,     0,     0,    66,    90,    92,    94,     0,     0,
-       0,    63,     0,   238,     0,   142,   229,     0,     0,     0,
-       0,   223,     0,     0,     0,   273,     0,   214,     0,     0,
-       0,   205,   274,   115,   112,    39,     0,     0,    46,    25,
-       0,     0,   351,   343,   349,   347,   350,   345,     0,     0,
-       0,   315,   307,   313,     0,   140,   162,   328,   333,   331,
-     178,    58,     0,     0,     0,     0,     0,    99,    96,   118,
-      93,    95,   101,     0,     0,   245,   243,   243,     0,     0,
-       0,   227,     0,   226,     0,   230,   275,     0,     0,   221,
-     219,    44,    42,   316,     0,   346,   348,   344,     0,   300,
-     317,     0,   326,    70,    88,     0,    84,    69,    85,   103,
-     100,     0,     0,   154,   239,   240,     0,   257,   258,   224,
-     228,   222,   220,   304,   340,   352,     0,   152,     0,   102,
-       0,   248,   243,     0,     0,     0,     0,   149,    87,   244,
-     249,   250,   251,     0,     0,   241,     0,   353,   341,   314,
-     151,   242,     0,     0,     0,   256,   246,     0,   255,   253,
-       0,   254,   252,   342,     0,   247
+       0,     0,     0,     0,     0,   117,     0,     0,   122,   121,
+     109,     0,     0,     0,     0,     0,     0,    47,    36,     0,
+      20,     0,     0,   148,   144,     0,   320,     0,   321,   182,
+     125,   129,     0,   159,   158,   161,   324,     0,     0,   329,
+       0,   331,     0,   335,   326,     0,     0,     0,    83,    77,
+       0,    79,    89,    80,    67,     0,    74,    75,     0,    71,
+      72,    78,    81,    86,    76,    68,    91,     0,     0,     0,
+      56,     0,    59,   243,     0,   277,   279,     0,     0,     0,
+       0,     0,     0,     0,   225,     0,     0,     0,   198,   188,
+     217,   218,     0,   213,     0,     0,     0,   204,     0,   216,
+     215,   231,   232,   233,   234,   235,   236,   237,   208,   207,
+     210,   209,   211,   212,     0,    35,   359,     0,     0,     0,
+      48,    45,    43,    49,    40,     0,     0,    23,   337,   146,
+     301,   303,     0,   305,   318,   304,   150,   172,   319,   156,
+       0,   157,   133,   169,   167,     0,   332,     0,   334,     0,
+     327,     0,     0,    55,     0,     0,    73,     0,     0,     0,
+      82,    98,     0,    97,     0,     0,    66,    90,    92,    94,
+       0,     0,     0,    63,     0,   238,     0,   142,   229,     0,
+       0,     0,     0,   223,     0,     0,     0,   273,     0,   214,
+       0,     0,     0,   205,   274,   115,   112,    39,     0,     0,
+      46,    25,     0,     0,   353,   345,   351,   349,   352,   347,
+       0,     0,     0,   317,   309,   315,     0,   140,   162,   330,
+     335,   333,   178,    58,     0,     0,     0,     0,     0,    99,
+      96,   118,    93,    95,   101,     0,     0,   245,   243,   243,
+       0,     0,     0,   227,     0,   226,     0,   230,   275,     0,
+       0,   221,   219,    44,    42,   318,     0,   348,   350,   346,
+       0,   302,   319,     0,   328,    70,    88,     0,    84,    69,
+      85,   103,   100,     0,     0,   154,   239,   240,     0,   257,
+     258,   224,   228,   222,   220,   306,   342,   354,     0,   152,
+       0,   102,     0,   248,   243,     0,     0,     0,     0,   149,
+      87,   244,   249,   250,   251,     0,     0,   241,     0,   355,
+     343,   316,   151,   242,     0,     0,     0,   256,   246,     0,
+     255,   253,     0,   254,   252,   344,     0,   247
 };
 
-  /* YYPGOTO[NTERM-NUM].  */
+/* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-    -529,  -529,  -529,   673,  -529,   720,  -529,   399,  -529,   428,
-    -529,  -529,  -529,  -529,  -325,   -79,   290,   422,   296,  -529,
-    -529,  -529,   453,  -529,   354,  -529,  -338,  -529,  -529,  -529,
-    -529,   260,  -529,  -429,  -529,   -45,  -529,  -529,  -529,  -529,
-    -529,  -529,  -142,  -529,  -529,   514,  -202,   -87,  -529,   204,
-     -49,    -5,  -529,  -529,   -85,  -278,  -529,  -529,  -529,  -139,
-    -529,  -529,  -171,  -529,   403,  -529,  -529,  -529,   127,  -297,
-    -529,   -67,   559,   563,   405,  -147,  -188,  -529,  -529,  -529,
-    -529,  -529,  -529,   469,  -529,  -529,  -529,  -514,  -529,  -529,
-    -529,  -528,  -529,  -529,  -148,  -529,  -529,  -529,  -529,  -529,
-    -529,   -58,  -529,  -529,   632,  -106,  -529,  -529,   633,  -529,
-    -529,  -496,   181,  -529,  -529,  -529,    -2,  -529,  -529,   186,
-     509,  -529,   406,  -529,   496,  -529,   229,  -529,  -529,  -529,
-     675,  -529,  -529,  -529,  -529,  -354
+    -493,  -493,  -493,   660,  -493,   705,  -493,   389,  -493,   488,
+    -493,  -493,  -493,  -493,  -322,   -79,   343,   403,   283,  -493,
+    -493,  -493,   464,  -493,   345,  -493,  -328,  -493,  -493,  -493,
+    -493,   244,  -493,  -446,  -493,   -43,  -493,  -493,  -493,  -493,
+    -493,  -493,  -144,  -493,  -493,   497,  -212,   -84,  -493,   233,
+     -50,   -24,  -493,  -493,   -85,  -278,  -493,  -493,  -493,  -133,
+    -493,  -493,  -172,  -493,   386,  -493,  -493,  -493,    50,  -297,
+    -493,  -269,   541,   549,   396,  -149,  -210,  -493,  -493,  -493,
+    -493,  -493,  -493,   456,  -493,  -493,  -493,  -483,  -493,  -493,
+    -493,  -492,  -493,  -493,  -153,  -493,  -493,  -493,  -493,  -493,
+    -493,   -61,  -493,  -493,   624,  -100,  -493,  -493,   625,  -493,
+    -493,  -484,   169,  -493,  -493,  -493,    -2,  -493,  -493,   175,
+     490,  -493,   392,  -493,   483,  -493,   212,  -493,  -493,  -493,
+     662,  -493,  -493,  -493,  -493,  -347
 };
 
-  /* YYDEFGOTO[NTERM-NUM].  */
+/* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
-      -1,    19,    20,    21,    22,    73,   259,   260,    23,    66,
-      24,   143,    25,    26,    89,   162,   255,   344,   345,    27,
-      28,    29,    84,   288,   289,   290,   394,   488,   484,   494,
-     495,   496,   291,   497,    30,    93,    31,   251,   252,    32,
-      33,    34,   153,    35,   155,   156,    36,   175,   176,   177,
-      77,   112,   113,   180,    78,   174,   261,   351,   352,   150,
-     545,   627,   116,   267,   268,   363,   469,   108,   185,   262,
-     129,   130,   131,   132,   263,   264,   225,   226,   227,   228,
-     229,   230,   231,   300,   232,   233,   234,   503,   603,   633,
-     634,   646,   235,   236,   198,   199,   200,   237,   238,   239,
-     240,   241,   134,   135,   136,   137,   138,   139,   140,   141,
-     457,   458,   459,   460,   461,    51,   462,   146,   541,   542,
-     543,   357,   275,   276,   277,   371,   478,    37,    38,    63,
-      64,   463,   538,   638,    71,   244
+       0,    19,    20,    21,    22,    73,   261,   262,    23,    66,
+      24,   145,    25,    26,    89,   164,   257,   346,   347,    27,
+      28,    29,    84,   290,   291,   292,   396,   490,   486,   496,
+     497,   498,   293,   499,    30,    93,    31,   253,   254,    32,
+      33,    34,   155,    35,   157,   158,    36,   177,   178,   179,
+      77,   112,   113,   182,    78,   176,   263,   353,   354,   152,
+     547,   629,   116,   269,   270,   365,   471,   108,   187,   264,
+     131,   132,   133,   134,   265,   266,   227,   228,   229,   230,
+     231,   232,   233,   302,   234,   235,   236,   505,   605,   635,
+     636,   648,   237,   238,   200,   201,   202,   239,   240,   241,
+     242,   243,   136,   137,   138,   139,   140,   141,   142,   143,
+     459,   460,   461,   462,   463,    51,   464,   148,   543,   544,
+     545,   359,   277,   278,   279,   373,   480,    37,    38,    63,
+      64,   465,   540,   640,    71,   246
 };
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      41,   172,   224,    44,   265,    95,   213,   415,    52,   283,
-      56,   270,    99,   100,   101,   402,   249,   450,   163,   164,
-     480,   173,   284,   133,    40,    40,   173,   178,   182,   626,
-     178,   303,    75,   305,   269,   479,   271,   273,   253,   403,
-     316,   498,   354,   589,   109,   149,    87,   354,    90,   410,
-     119,   120,   604,   605,    39,   279,    60,    97,   102,   361,
-     475,   642,   214,   118,   119,   120,   561,   642,    40,   411,
-     183,   299,   242,   115,    42,   412,   307,   425,   643,   210,
-     110,   476,   477,   147,   148,   308,   362,   184,   476,   477,
-     400,   158,   615,   308,   426,   331,    98,    61,   166,   167,
-     336,   309,    43,   308,   246,   504,   216,   217,   635,   309,
-     211,   114,   508,   531,   303,   650,   111,   346,   254,   309,
-     334,   548,   420,   366,   421,   422,   655,   520,   427,   428,
-     429,   430,   431,   432,   433,   434,   435,   436,   437,   438,
-     439,   440,   441,   133,   218,   563,   564,   122,   406,   133,
-     407,   408,   423,   532,   214,   118,   119,   120,   533,   248,
-     308,   418,   419,   123,   540,   534,   535,    54,   367,   355,
-     570,   417,   619,   266,   306,   353,   309,    48,   212,   359,
-     302,   178,   536,    45,   308,   308,  -352,   537,   285,   286,
-     287,   648,   649,    46,   220,   124,   340,   215,   216,   217,
-     309,   309,   582,   401,   118,   119,   120,   281,   567,   124,
-     125,   126,   464,   269,    54,   456,    55,   341,   471,   472,
-     644,   578,   404,   645,    47,   442,   644,   568,   316,   645,
-     340,    49,   333,   109,   517,   334,   218,   308,    50,   122,
-     368,    76,   342,   489,   221,   222,   405,   214,   118,   119,
-     120,   526,   223,   309,   530,   123,    75,   128,    94,   510,
-     490,   245,   625,   512,   513,    57,   272,   369,   445,   110,
-      53,   606,   219,   531,    65,    58,   527,   133,   370,   411,
-     454,   330,   647,   331,  -305,   511,   220,    69,   122,   133,
-     215,   216,   217,   446,   617,    62,   481,   343,   308,    70,
-     573,   124,   125,   126,   123,   111,    59,   168,   491,   492,
-     509,   515,   493,   532,   309,   607,   353,   308,   533,   308,
-     574,   609,   293,   629,   294,   534,   535,   308,   576,   218,
-     443,   343,   122,   309,    72,   309,   221,   222,   214,   118,
-     119,   120,   536,   309,   223,    79,  -352,   537,   123,   128,
-     124,   125,   126,   316,   651,   652,   298,   118,   119,   120,
-     569,    80,   571,   572,   514,   219,   214,   118,   119,   120,
-     214,   118,   119,   120,   348,   519,    81,   349,    83,   220,
-     298,   215,   216,   217,   308,   127,   186,   187,   188,   189,
-     190,   191,   358,    75,   124,   125,   126,   364,   128,   398,
-     309,   121,   399,   327,   328,   329,   330,    82,   331,   215,
-     216,   217,   310,   301,   216,   217,   452,   599,    88,   453,
-     218,    91,   523,   122,    92,   207,    96,   610,   525,   221,
-     222,   453,   621,   529,   103,   551,   207,   223,   334,   123,
-     562,   122,   128,   334,  -306,    67,    68,   566,   218,   311,
-     353,   122,   218,   256,   257,   122,   219,   123,   580,   594,
-     600,   353,   595,   334,   104,   601,   106,   123,   334,   577,
-     220,   123,   612,   622,   107,   353,   353,   637,   639,   640,
-     653,   334,   117,   334,   219,   124,   125,   126,   302,   531,
-     142,   559,   630,   631,   632,   144,   312,   145,   220,    85,
-      86,   149,   220,   124,   125,   126,   151,   152,   154,   159,
-     157,   160,   161,   124,   125,   126,   313,   124,   125,   126,
-     221,   222,   165,   314,   315,    54,   170,   171,   223,   532,
-     173,   316,   317,   128,   533,   179,   181,   201,   127,   202,
-     203,   534,   535,   206,   207,   623,   208,   209,   221,   222,
-     243,   128,   221,   222,   247,   258,   223,   250,   536,   114,
-     223,   128,   274,   537,   282,   128,   292,    15,   295,   318,
-     319,   320,   321,   322,   296,   297,   323,   324,  -354,   325,
-     326,   327,   328,   329,   330,     1,   331,   304,   332,   338,
-     335,   339,   311,     2,   624,   347,   350,   353,   360,   365,
-       3,   373,     1,   375,   374,     4,   396,   395,   397,    75,
-       2,   416,   413,   444,   424,     5,   448,     3,     6,     7,
-     449,   451,     4,   466,   468,   482,   474,   473,   483,   422,
-       8,     9,     5,   485,   502,     6,     7,   486,   487,   312,
-      10,   499,   500,    11,   505,   308,   506,     8,     9,   507,
-     518,   331,   521,   522,   516,   524,   539,    10,   544,   414,
-      11,   546,   547,   311,   549,    12,   550,   315,   552,    13,
-     553,   554,   555,   556,   316,   317,   557,   565,   558,   376,
-     581,   575,    12,   579,   584,    14,    13,   583,   590,   585,
-     588,    15,   311,   377,   591,   593,   586,   378,   379,   380,
-     381,   382,    14,   383,   587,   596,   597,   311,    15,   598,
-     312,   384,   318,   319,   320,   321,   322,   608,   602,   323,
-     324,   611,   325,   326,   327,   328,   329,   330,   618,   331,
-     414,   493,   616,    16,    17,    18,   385,   628,   315,  -355,
-     620,   654,   636,   105,    74,   316,   317,   641,   455,   528,
-      16,    17,    18,   501,   386,   560,   387,   388,   465,   204,
-     205,   447,   337,   467,   278,   614,   280,   315,   409,   613,
-     470,   389,   372,   356,   316,  -355,   390,   592,   391,   169,
-       0,     0,   315,   318,   319,   320,   321,   322,   392,   316,
-     323,   324,     0,   325,   326,   327,   328,   329,   330,     0,
-     331,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,  -355,  -355,  -355,   321,   322,     0,     0,   323,
-     324,   393,   325,   326,   327,   328,   329,   330,     0,   331,
-    -355,  -355,     0,     0,  -355,  -355,     0,   325,   326,   327,
-     328,   329,   330,     0,   331,   186,   187,   188,   189,   190,
-     191,   192,   193,   194,   195,   196,   197
+      41,   285,   226,    44,    95,   267,   215,   174,    52,   417,
+      56,   305,   272,   307,    99,   100,   101,   404,   165,   166,
+     135,   405,   452,    40,   251,    40,   175,   180,   175,   482,
+     180,   184,   119,   120,   271,   286,   273,   275,   118,   119,
+     120,   121,   122,   628,   151,    75,    87,   481,    90,   356,
+     500,   563,   281,   255,   115,    39,    45,   591,   102,   310,
+     369,   212,    60,   644,   644,   310,    46,   368,   447,   424,
+     491,   301,   318,   185,   244,   311,   309,   645,   342,   310,
+     456,   311,   402,   149,   150,   606,   607,   492,   510,    40,
+     186,   160,   213,    42,   305,   311,   425,    47,   168,   169,
+     338,   343,   422,    61,   423,   248,   617,   506,   429,   430,
+     431,   432,   433,   434,   435,   436,   437,   438,   439,   440,
+     441,   442,   443,   342,   124,   348,   344,   333,   310,   522,
+     550,    43,   370,   256,   356,   493,   494,   419,    97,   495,
+     125,   637,   135,   609,   311,   408,   528,   310,   135,   575,
+     409,   410,    48,   652,   565,   566,   268,   621,   250,   371,
+     214,   420,   421,   311,   657,   118,   119,   120,   121,   122,
+     372,   529,   295,   542,   296,   308,    49,    98,    50,   126,
+      54,   345,   572,   180,   361,   318,   126,   127,   128,   355,
+     216,   118,   119,   120,   121,   122,   216,   118,   119,   120,
+     121,   122,   318,   287,   288,   289,   406,   584,   403,   283,
+     569,   123,   109,   271,   519,    54,   533,   458,   473,   474,
+     466,   129,   427,   580,   646,   646,   345,   647,   647,   570,
+     109,   477,    53,   444,   130,   217,   218,   219,   332,   428,
+     333,   217,   218,   219,    62,    55,   532,   407,   110,   310,
+      65,   124,   329,   330,   331,   332,   534,   333,   357,   478,
+     479,   535,   310,   514,   515,   311,   110,   125,   536,   537,
+      76,   627,   625,   608,   220,    69,   135,   124,   311,   114,
+     220,   478,   479,   124,   111,   538,   412,    94,   135,   517,
+     539,   649,   363,   125,   355,    75,   619,   448,   483,   125,
+     247,    57,   111,   512,   274,    70,   413,   300,   578,    72,
+     221,    58,   414,   126,   127,   128,   221,   360,   310,   364,
+     336,   626,   366,   413,   222,   631,   511,    79,   335,   513,
+     222,   336,   445,   310,   311,   350,   170,    80,   351,   126,
+     127,   128,    59,   576,    81,   126,   127,   128,   129,   311,
+     310,   216,   118,   119,   120,   121,   122,   310,    82,   611,
+     571,   130,   573,   574,   300,   516,   311,   400,   310,   454,
+     401,    83,   455,   311,   223,   224,   521,   632,   633,   634,
+     223,   224,   225,    88,   311,    91,   525,   130,   225,   209,
+      92,   533,   527,   130,   313,   455,   217,   218,   219,    96,
+     216,   118,   119,   120,   121,   122,   531,   103,    75,   209,
+     216,   118,   119,   120,   121,   122,   553,   601,   106,   336,
+     216,   118,   119,   120,   121,   122,   564,   612,   107,   336,
+     104,   534,   117,   623,   568,   220,   535,   355,   124,   582,
+     650,   651,   355,   536,   537,   217,   218,   219,   188,   189,
+     190,   191,   192,   193,   125,   303,   218,   219,   144,   596,
+     538,   312,   597,   146,  -354,   539,   218,   219,   147,   317,
+     579,   221,   602,   653,   654,   336,   318,   639,   603,   642,
+     614,   336,   153,   355,   220,   222,   624,   124,   641,   355,
+     151,   336,   655,   561,   220,   336,   154,   124,   313,   156,
+     126,   127,   128,   125,   220,    67,    68,   124,   258,   259,
+      85,    86,   161,   125,   159,   163,   162,  -357,  -357,   167,
+     221,  -357,  -357,   125,   327,   328,   329,   330,   331,   332,
+     304,   333,    54,   173,   222,   223,   224,   533,   175,   172,
+     304,   181,   183,   225,   222,   314,   203,   204,   130,   126,
+     127,   128,   205,   208,   222,   209,   210,   245,   211,   126,
+     127,   128,  -307,   252,   249,   315,   260,   114,   276,   126,
+     127,   128,   316,   317,   284,    15,   294,   534,   297,   298,
+     318,   319,   535,   306,   223,   224,   299,   334,   337,   536,
+     537,   340,   225,   341,   223,   224,   349,   130,   352,   355,
+     375,   362,   225,   367,   223,   224,   538,   130,   376,   377,
+    -354,   539,   225,   397,   398,   399,    75,   130,   320,   321,
+     322,   323,   324,   415,   446,   325,   326,  -356,   327,   328,
+     329,   330,   331,   332,   418,   333,     1,   450,   426,   451,
+     453,   468,   470,   475,     2,   476,   484,   485,   487,   504,
+     488,     3,   489,   501,   502,   509,     4,   507,   424,     1,
+     310,   333,   526,   508,   523,   524,     5,     2,   546,     6,
+       7,   520,   548,   541,     3,   549,   552,   551,   554,     4,
+     555,     8,     9,   556,   557,   558,   559,   560,   567,     5,
+     577,    10,     6,     7,    11,   581,   583,   585,   587,   586,
+     588,   590,   589,   593,     8,     9,   592,   618,  -308,   604,
+     620,   495,   622,   378,    10,   595,    12,    11,   598,   599,
+      13,   600,   610,   656,   613,   630,   638,   379,   643,    74,
+     105,   380,   381,   382,   383,   384,    14,   385,   530,    12,
+     457,   562,    15,    13,   449,   386,   503,   339,   469,   313,
+     282,   467,   280,   206,   207,   616,   358,   411,   472,    14,
+     615,   374,   594,     0,     0,    15,   171,   313,     0,     0,
+     387,   188,   189,   190,   191,   192,   193,   194,   195,   196,
+     197,   198,   199,     0,    16,    17,    18,     0,   388,     0,
+     389,   390,   313,     0,     0,     0,   314,     0,     0,     0,
+       0,     0,     0,     0,     0,   391,     0,    16,    17,    18,
+     392,   518,   393,     0,   314,     0,   416,     0,     0,     0,
+       0,     0,   394,     0,   317,     0,     0,     0,     0,     0,
+       0,   318,   319,     0,   416,     0,     0,     0,     0,  -357,
+       0,     0,   317,     0,     0,     0,     0,     0,     0,   318,
+     319,     0,     0,     0,     0,   395,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   317,     0,   320,
+     321,   322,   323,   324,   318,  -357,   325,   326,     0,   327,
+     328,   329,   330,   331,   332,     0,   333,   320,   321,   322,
+     323,   324,     0,     0,   325,   326,     0,   327,   328,   329,
+     330,   331,   332,     0,   333,     0,     0,     0,     0,     0,
+       0,     0,  -357,  -357,  -357,   323,   324,     0,     0,   325,
+     326,     0,   327,   328,   329,   330,   331,   332,     0,   333
 };
 
 static const yytype_int16 yycheck[] =
 {
-       2,   107,   149,     5,   175,    54,   148,   304,    10,   211,
-      12,   182,    57,    58,    59,   293,   155,   342,    97,    98,
-     374,    12,     3,    81,     3,     3,    12,   112,   115,    51,
-     115,   219,    58,   221,   181,   373,   183,   184,   113,     3,
-     136,   395,     3,   539,     9,    83,    48,     3,    50,    92,
-       5,     6,   566,   567,    27,   203,    19,    94,    60,    90,
-     130,     6,     3,     4,     5,     6,   495,     6,     3,   112,
-      55,   218,   151,    78,     3,   118,   223,   104,    17,    94,
-      45,   158,   159,    85,    86,   116,   117,    72,   158,   159,
-     292,    93,   588,   116,   121,   191,   133,    60,   100,   101,
-     247,   132,     3,   116,   153,   402,    47,    48,   622,   132,
-     125,    76,   125,    26,   302,   643,    81,   256,   193,   132,
-     197,   475,   310,    55,   312,   101,   654,   424,   316,   317,
-     318,   319,   320,   321,   322,   323,   324,   325,   326,   327,
-     328,   329,   330,   201,    85,   499,   500,    88,   296,   207,
-     297,   298,   128,    66,     3,     4,     5,     6,    71,   197,
-     116,   308,   309,   104,   125,    78,    79,   193,    62,   125,
-     508,   194,   601,   178,   223,   197,   132,    94,   193,   266,
-     121,   266,    95,    70,   116,   116,    99,   100,   169,   170,
-     171,   166,   167,    80,   135,   150,     3,    46,    47,    48,
-     132,   132,   527,   194,     4,     5,     6,   209,   194,   150,
-     151,   152,   351,   360,   193,   193,    12,    24,   365,   366,
-     165,   518,   186,   168,   111,   331,   165,   505,   136,   168,
-       3,    94,   194,     9,   422,   197,    85,   116,    98,    88,
-     134,    37,    49,   104,   185,   186,   295,     3,     4,     5,
-       6,    24,   193,   132,   456,   104,    58,   198,    54,    92,
-     121,    63,   616,   410,   411,    70,   115,   161,   335,    45,
-      80,   568,   121,    26,   154,    80,    49,   335,   172,   112,
-     347,   189,   636,   191,   197,   118,   135,     0,    88,   347,
-      46,    47,    48,   338,   591,     3,   375,   104,   116,   196,
-     118,   150,   151,   152,   104,    81,   111,   103,   169,   170,
-     109,   192,   173,    66,   132,   194,   197,   116,    71,   116,
-     109,   118,   193,   620,   195,    78,    79,   116,   516,    85,
-     332,   104,    88,   132,   113,   132,   185,   186,     3,     4,
-       5,     6,    95,   132,   193,     3,    99,   100,   104,   198,
-     150,   151,   152,   136,   166,   167,   112,     4,     5,     6,
-     507,   195,   509,   510,   413,   121,     3,     4,     5,     6,
-       3,     4,     5,     6,   194,   424,   193,   197,   127,   135,
-     112,    46,    47,    48,   116,   185,   138,   139,   140,   141,
-     142,   143,   265,    58,   150,   151,   152,   270,   198,   194,
-     132,    48,   197,   186,   187,   188,   189,    94,   191,    46,
-      47,    48,    17,    46,    47,    48,   194,   559,     3,   197,
-      85,   123,   194,    88,   127,   197,   133,   574,   194,   185,
-     186,   197,   603,   194,   125,   194,   197,   193,   197,   104,
-     194,    88,   198,   197,   197,    17,    18,   194,    85,    54,
-     197,    88,    85,   163,   164,    88,   121,   104,   194,   194,
-     194,   197,   197,   197,   197,   194,    97,   104,   197,   518,
-     135,   104,   194,   194,   124,   197,   197,   624,   194,   626,
-     194,   197,     3,   197,   121,   150,   151,   152,   121,    26,
-       4,   493,   162,   163,   164,   121,   101,     3,   135,    46,
-      47,    83,   135,   150,   151,   152,    93,   193,     3,   194,
-      46,   194,     4,   150,   151,   152,   121,   150,   151,   152,
-     185,   186,     3,   128,   129,   193,   193,     6,   193,    66,
-      12,   136,   137,   198,    71,   115,   126,   193,   185,     4,
-       4,    78,    79,   194,   197,    82,    46,   131,   185,   186,
-       3,   198,   185,   186,   174,     3,   193,    91,    95,    76,
-     193,   198,   119,   100,     3,   198,   125,   113,   193,   174,
-     175,   176,   177,   178,   193,   193,   181,   182,     0,   184,
-     185,   186,   187,   188,   189,     7,   191,   191,    98,    39,
-     193,   193,    54,    15,   131,   193,    94,   197,   197,    55,
-      22,   125,     7,    93,   193,    27,   172,   193,   172,    58,
-      15,   194,   193,     3,   193,    37,     4,    22,    40,    41,
-       4,     4,    27,     3,     3,   193,   161,   172,   193,   101,
-      52,    53,    37,   193,    77,    40,    41,   193,   193,   101,
-      62,   193,   193,    65,   193,   116,   194,    52,    53,    94,
-     193,   191,   104,   192,   116,     3,   197,    62,    69,   121,
-      65,     3,    62,    54,   160,    87,   194,   129,     6,    91,
-       6,     6,     6,     6,   136,   137,   104,   193,   172,    11,
-       4,   194,    87,   194,    99,   107,    91,   194,     3,    78,
-      99,   113,    54,    25,   126,   194,    78,    29,    30,    31,
-      32,    33,   107,    35,    78,   194,   194,    54,   113,   194,
-     101,    43,   174,   175,   176,   177,   178,   194,   105,   181,
-     182,   194,   184,   185,   186,   187,   188,   189,     6,   191,
-     121,   173,   193,   155,   156,   157,    68,   194,   129,   101,
-     126,   116,   193,    70,    24,   136,   137,   194,   349,   453,
-     155,   156,   157,   399,    86,   495,    88,    89,   353,   127,
-     127,   339,   248,   360,   201,   584,   207,   129,   299,   583,
-     364,   103,   276,   264,   136,   137,   108,   548,   110,   104,
-      -1,    -1,   129,   174,   175,   176,   177,   178,   120,   136,
-     181,   182,    -1,   184,   185,   186,   187,   188,   189,    -1,
-     191,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   174,   175,   176,   177,   178,    -1,    -1,   181,
-     182,   153,   184,   185,   186,   187,   188,   189,    -1,   191,
-     177,   178,    -1,    -1,   181,   182,    -1,   184,   185,   186,
-     187,   188,   189,    -1,   191,   138,   139,   140,   141,   142,
-     143,   144,   145,   146,   147,   148,   149
+       2,   213,   151,     5,    54,   177,   150,   107,    10,   306,
+      12,   221,   184,   223,    57,    58,    59,   295,    97,    98,
+      81,     3,   344,     3,   157,     3,    14,   112,    14,   376,
+     115,   115,     5,     6,   183,     3,   185,   186,     4,     5,
+       6,     7,     8,    53,    85,    60,    48,   375,    50,     3,
+     397,   497,   205,   115,    78,    29,    72,   541,    60,   118,
+      64,    96,    21,     6,     6,   118,    82,    57,   337,   103,
+     106,   220,   138,    57,   153,   134,   225,    19,     3,   118,
+     349,   134,   294,    85,    86,   568,   569,   123,   127,     3,
+      74,    93,   127,     3,   304,   134,   130,   113,   100,   101,
+     249,    26,   312,    62,   314,   155,   590,   404,   318,   319,
+     320,   321,   322,   323,   324,   325,   326,   327,   328,   329,
+     330,   331,   332,     3,    90,   258,    51,   193,   118,   426,
+     477,     3,   136,   195,     3,   171,   172,   196,    96,   175,
+     106,   624,   203,   196,   134,   298,    26,   118,   209,   120,
+     299,   300,    96,   645,   501,   502,   180,   603,   199,   163,
+     195,   310,   311,   134,   656,     4,     5,     6,     7,     8,
+     174,    51,   195,   127,   197,   225,    96,   135,   100,   152,
+     195,   106,   510,   268,   268,   138,   152,   153,   154,   199,
+       3,     4,     5,     6,     7,     8,     3,     4,     5,     6,
+       7,     8,   138,   171,   172,   173,   188,   529,   196,   211,
+     196,    50,    11,   362,   424,   195,    28,   195,   367,   368,
+     353,   187,   106,   520,   167,   167,   106,   170,   170,   507,
+      11,   132,    82,   333,   200,    48,    49,    50,   191,   123,
+     193,    48,    49,    50,     3,    12,   458,   297,    47,   118,
+     156,    90,   188,   189,   190,   191,    68,   193,   127,   160,
+     161,    73,   118,   412,   413,   134,    47,   106,    80,    81,
+      37,   618,    84,   570,    87,     0,   337,    90,   134,    78,
+      87,   160,   161,    90,    83,    97,    94,    54,   349,   194,
+     102,   638,    92,   106,   199,    60,   593,   340,   377,   106,
+      65,    72,    83,    94,   117,   198,   114,   114,   518,   115,
+     123,    82,   120,   152,   153,   154,   123,   267,   118,   119,
+     199,   133,   272,   114,   137,   622,   111,     3,   196,   120,
+     137,   199,   334,   118,   134,   196,   103,   197,   199,   152,
+     153,   154,   113,   111,   195,   152,   153,   154,   187,   134,
+     118,     3,     4,     5,     6,     7,     8,   118,    96,   120,
+     509,   200,   511,   512,   114,   415,   134,   196,   118,   196,
+     199,   129,   199,   134,   187,   188,   426,   164,   165,   166,
+     187,   188,   195,     3,   134,   125,   196,   200,   195,   199,
+     129,    28,   196,   200,    56,   199,    48,    49,    50,   135,
+       3,     4,     5,     6,     7,     8,   196,   127,    60,   199,
+       3,     4,     5,     6,     7,     8,   196,   561,    99,   199,
+       3,     4,     5,     6,     7,     8,   196,   576,   126,   199,
+     199,    68,     3,   605,   196,    87,    73,   199,    90,   196,
+     168,   169,   199,    80,    81,    48,    49,    50,   140,   141,
+     142,   143,   144,   145,   106,    48,    49,    50,     4,   196,
+      97,    19,   199,   123,   101,   102,    49,    50,     3,   131,
+     520,   123,   196,   168,   169,   199,   138,   626,   196,   628,
+     196,   199,    95,   199,    87,   137,   196,    90,   196,   199,
+      85,   199,   196,   495,    87,   199,   195,    90,    56,     3,
+     152,   153,   154,   106,    87,    17,    18,    90,   165,   166,
+      46,    47,   196,   106,    48,     4,   196,   179,   180,     3,
+     123,   183,   184,   106,   186,   187,   188,   189,   190,   191,
+     123,   193,   195,     6,   137,   187,   188,    28,    14,   195,
+     123,   117,   128,   195,   137,   103,   195,     4,   200,   152,
+     153,   154,     4,   196,   137,   199,    48,     3,   133,   152,
+     153,   154,   199,    93,   176,   123,     3,    78,   121,   152,
+     153,   154,   130,   131,     3,   115,   127,    68,   195,   195,
+     138,   139,    73,   193,   187,   188,   195,   100,   195,    80,
+      81,    41,   195,   195,   187,   188,   195,   200,    96,   199,
+     127,   199,   195,    57,   187,   188,    97,   200,   195,    95,
+     101,   102,   195,   195,   174,   174,    60,   200,   176,   177,
+     178,   179,   180,   195,     3,   183,   184,     0,   186,   187,
+     188,   189,   190,   191,   196,   193,     9,     4,   195,     4,
+       4,     3,     3,   174,    17,   163,   195,   195,   195,    79,
+     195,    24,   195,   195,   195,    96,    29,   195,   103,     9,
+     118,   193,     3,   196,   106,   194,    39,    17,    71,    42,
+      43,   195,     3,   199,    24,    64,   196,   162,     6,    29,
+       6,    54,    55,     6,     6,     6,   106,   174,   195,    39,
+     196,    64,    42,    43,    67,   196,     4,   196,    80,   101,
+      80,   101,    80,   128,    54,    55,     3,   195,   199,   107,
+       6,   175,   128,    13,    64,   196,    89,    67,   196,   196,
+      93,   196,   196,   118,   196,   196,   195,    27,   196,    24,
+      70,    31,    32,    33,    34,    35,   109,    37,   455,    89,
+     351,   497,   115,    93,   341,    45,   401,   250,   362,    56,
+     209,   355,   203,   129,   129,   586,   266,   301,   366,   109,
+     585,   278,   550,    -1,    -1,   115,   104,    56,    -1,    -1,
+      70,   140,   141,   142,   143,   144,   145,   146,   147,   148,
+     149,   150,   151,    -1,   157,   158,   159,    -1,    88,    -1,
+      90,    91,    56,    -1,    -1,    -1,   103,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   105,    -1,   157,   158,   159,
+     110,   118,   112,    -1,   103,    -1,   123,    -1,    -1,    -1,
+      -1,    -1,   122,    -1,   131,    -1,    -1,    -1,    -1,    -1,
+      -1,   138,   139,    -1,   123,    -1,    -1,    -1,    -1,   103,
+      -1,    -1,   131,    -1,    -1,    -1,    -1,    -1,    -1,   138,
+     139,    -1,    -1,    -1,    -1,   155,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   131,    -1,   176,
+     177,   178,   179,   180,   138,   139,   183,   184,    -1,   186,
+     187,   188,   189,   190,   191,    -1,   193,   176,   177,   178,
+     179,   180,    -1,    -1,   183,   184,    -1,   186,   187,   188,
+     189,   190,   191,    -1,   193,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   176,   177,   178,   179,   180,    -1,    -1,   183,
+     184,    -1,   186,   187,   188,   189,   190,   191,    -1,   193
 };
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
-static const yytype_uint16 yystos[] =
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int16 yystos[] =
 {
-       0,     7,    15,    22,    27,    37,    40,    41,    52,    53,
-      62,    65,    87,    91,   107,   113,   155,   156,   157,   200,
-     201,   202,   203,   207,   209,   211,   212,   218,   219,   220,
-     233,   235,   238,   239,   240,   242,   245,   326,   327,    27,
-       3,   315,     3,     3,   315,    70,    80,   111,    94,    94,
-      98,   314,   315,    80,   193,   248,   315,    70,    80,   111,
-      19,    60,     3,   328,   329,   154,   208,   208,   208,     0,
-     196,   333,   113,   204,   204,    58,   248,   249,   253,     3,
-     195,   193,    94,   127,   221,   221,   221,   315,     3,   213,
-     315,   123,   127,   234,   248,   249,   133,    94,   133,   234,
-     234,   234,   315,   125,   197,   202,    97,   124,   266,     9,
-      45,    81,   250,   251,    76,   250,   261,     3,     4,     5,
-       6,    48,    88,   104,   150,   151,   152,   185,   198,   269,
-     270,   271,   272,   300,   301,   302,   303,   304,   305,   306,
-     307,   308,     4,   210,   121,     3,   316,   315,   315,    83,
-     258,    93,   193,   241,     3,   243,   244,    46,   315,   194,
-     194,     4,   214,   214,   214,     3,   315,   315,   248,   329,
-     193,     6,   304,    12,   254,   246,   247,   248,   253,   115,
-     252,   126,   246,    55,    72,   267,   138,   139,   140,   141,
-     142,   143,   144,   145,   146,   147,   148,   149,   293,   294,
-     295,   193,     4,     4,   303,   307,   194,   197,    46,   131,
-      94,   125,   193,   241,     3,    46,    47,    48,    85,   121,
-     135,   185,   186,   193,   274,   275,   276,   277,   278,   279,
-     280,   281,   283,   284,   285,   291,   292,   296,   297,   298,
-     299,   300,   214,     3,   334,    63,   249,   174,   197,   258,
-      91,   236,   237,   113,   193,   215,   215,   215,     3,   205,
-     206,   255,   268,   273,   274,   261,   250,   262,   263,   274,
-     261,   274,   115,   274,   119,   321,   322,   323,   272,   293,
-     271,   315,     3,   245,     3,   169,   170,   171,   222,   223,
-     224,   231,   125,   193,   195,   193,   193,   193,   112,   274,
-     282,    46,   121,   275,   191,   275,   249,   274,   116,   132,
-      17,    54,   101,   121,   128,   129,   136,   137,   174,   175,
-     176,   177,   178,   181,   182,   184,   185,   186,   187,   188,
-     189,   191,    98,   194,   197,   193,   274,   244,    39,   193,
-       3,    24,    49,   104,   216,   217,   258,   193,   194,   197,
-      94,   256,   257,   197,     3,   125,   319,   320,   267,   246,
-     197,    90,   117,   264,   267,    55,    55,    62,   134,   161,
-     172,   324,   323,   125,   193,    93,    11,    25,    29,    30,
-      31,    32,    33,    35,    43,    68,    86,    88,    89,   103,
-     108,   110,   120,   153,   225,   193,   172,   172,   194,   197,
-     245,   194,   254,     3,   186,   249,   293,   274,   274,   282,
-      92,   112,   118,   193,   121,   268,   194,   194,   274,   274,
-     275,   275,   101,   128,   193,   104,   121,   275,   275,   275,
-     275,   275,   275,   275,   275,   275,   275,   275,   275,   275,
-     275,   275,   304,   315,     3,   270,   234,   216,     4,     4,
-     213,     4,   194,   197,   270,   206,   193,   309,   310,   311,
-     312,   313,   315,   330,   258,   273,     3,   263,     3,   265,
-     321,   274,   274,   172,   161,   130,   158,   159,   325,   225,
-     334,   214,   193,   193,   227,   193,   193,   193,   226,   104,
-     121,   169,   170,   173,   228,   229,   230,   232,   334,   193,
-     193,   223,    77,   286,   268,   193,   194,    94,   125,   109,
-      92,   118,   274,   274,   249,   192,   116,   275,   193,   249,
-     268,   104,   192,   194,     3,   194,    24,    49,   217,   194,
-     245,    26,    66,    71,    78,    79,    95,   100,   331,   197,
-     125,   317,   318,   319,    69,   259,     3,    62,   334,   160,
-     194,   194,     6,     6,     6,     6,     6,   104,   172,   315,
-     230,   232,   194,   334,   334,   193,   194,   194,   254,   274,
-     225,   274,   274,   118,   109,   194,   275,   249,   268,   194,
-     194,     4,   213,   194,    99,    78,    78,    78,    99,   310,
-       3,   126,   325,   194,   194,   197,   194,   194,   194,   241,
-     194,   194,   105,   287,   286,   286,   268,   194,   194,   118,
-     274,   194,   194,   318,   311,   310,   193,   268,     6,   232,
-     126,   261,   194,    82,   131,   334,    51,   260,   194,   268,
-     162,   163,   164,   288,   289,   286,   193,   274,   332,   194,
-     274,   194,     6,    17,   165,   168,   290,   334,   166,   167,
-     290,   166,   167,   194,   116,   290
+       0,     9,    17,    24,    29,    39,    42,    43,    54,    55,
+      64,    67,    89,    93,   109,   115,   157,   158,   159,   202,
+     203,   204,   205,   209,   211,   213,   214,   220,   221,   222,
+     235,   237,   240,   241,   242,   244,   247,   328,   329,    29,
+       3,   317,     3,     3,   317,    72,    82,   113,    96,    96,
+     100,   316,   317,    82,   195,   250,   317,    72,    82,   113,
+      21,    62,     3,   330,   331,   156,   210,   210,   210,     0,
+     198,   335,   115,   206,   206,    60,   250,   251,   255,     3,
+     197,   195,    96,   129,   223,   223,   223,   317,     3,   215,
+     317,   125,   129,   236,   250,   251,   135,    96,   135,   236,
+     236,   236,   317,   127,   199,   204,    99,   126,   268,    11,
+      47,    83,   252,   253,    78,   252,   263,     3,     4,     5,
+       6,     7,     8,    50,    90,   106,   152,   153,   154,   187,
+     200,   271,   272,   273,   274,   302,   303,   304,   305,   306,
+     307,   308,   309,   310,     4,   212,   123,     3,   318,   317,
+     317,    85,   260,    95,   195,   243,     3,   245,   246,    48,
+     317,   196,   196,     4,   216,   216,   216,     3,   317,   317,
+     250,   331,   195,     6,   306,    14,   256,   248,   249,   250,
+     255,   117,   254,   128,   248,    57,    74,   269,   140,   141,
+     142,   143,   144,   145,   146,   147,   148,   149,   150,   151,
+     295,   296,   297,   195,     4,     4,   305,   309,   196,   199,
+      48,   133,    96,   127,   195,   243,     3,    48,    49,    50,
+      87,   123,   137,   187,   188,   195,   276,   277,   278,   279,
+     280,   281,   282,   283,   285,   286,   287,   293,   294,   298,
+     299,   300,   301,   302,   216,     3,   336,    65,   251,   176,
+     199,   260,    93,   238,   239,   115,   195,   217,   217,   217,
+       3,   207,   208,   257,   270,   275,   276,   263,   252,   264,
+     265,   276,   263,   276,   117,   276,   121,   323,   324,   325,
+     274,   295,   273,   317,     3,   247,     3,   171,   172,   173,
+     224,   225,   226,   233,   127,   195,   197,   195,   195,   195,
+     114,   276,   284,    48,   123,   277,   193,   277,   251,   276,
+     118,   134,    19,    56,   103,   123,   130,   131,   138,   139,
+     176,   177,   178,   179,   180,   183,   184,   186,   187,   188,
+     189,   190,   191,   193,   100,   196,   199,   195,   276,   246,
+      41,   195,     3,    26,    51,   106,   218,   219,   260,   195,
+     196,   199,    96,   258,   259,   199,     3,   127,   321,   322,
+     269,   248,   199,    92,   119,   266,   269,    57,    57,    64,
+     136,   163,   174,   326,   325,   127,   195,    95,    13,    27,
+      31,    32,    33,    34,    35,    37,    45,    70,    88,    90,
+      91,   105,   110,   112,   122,   155,   227,   195,   174,   174,
+     196,   199,   247,   196,   256,     3,   188,   251,   295,   276,
+     276,   284,    94,   114,   120,   195,   123,   270,   196,   196,
+     276,   276,   277,   277,   103,   130,   195,   106,   123,   277,
+     277,   277,   277,   277,   277,   277,   277,   277,   277,   277,
+     277,   277,   277,   277,   306,   317,     3,   272,   236,   218,
+       4,     4,   215,     4,   196,   199,   272,   208,   195,   311,
+     312,   313,   314,   315,   317,   332,   260,   275,     3,   265,
+       3,   267,   323,   276,   276,   174,   163,   132,   160,   161,
+     327,   227,   336,   216,   195,   195,   229,   195,   195,   195,
+     228,   106,   123,   171,   172,   175,   230,   231,   232,   234,
+     336,   195,   195,   225,    79,   288,   270,   195,   196,    96,
+     127,   111,    94,   120,   276,   276,   251,   194,   118,   277,
+     195,   251,   270,   106,   194,   196,     3,   196,    26,    51,
+     219,   196,   247,    28,    68,    73,    80,    81,    97,   102,
+     333,   199,   127,   319,   320,   321,    71,   261,     3,    64,
+     336,   162,   196,   196,     6,     6,     6,     6,     6,   106,
+     174,   317,   232,   234,   196,   336,   336,   195,   196,   196,
+     256,   276,   227,   276,   276,   120,   111,   196,   277,   251,
+     270,   196,   196,     4,   215,   196,   101,    80,    80,    80,
+     101,   312,     3,   128,   327,   196,   196,   199,   196,   196,
+     196,   243,   196,   196,   107,   289,   288,   288,   270,   196,
+     196,   120,   276,   196,   196,   320,   313,   312,   195,   270,
+       6,   234,   128,   263,   196,    84,   133,   336,    53,   262,
+     196,   270,   164,   165,   166,   290,   291,   288,   195,   276,
+     334,   196,   276,   196,     6,    19,   167,   170,   292,   336,
+     168,   169,   292,   168,   169,   196,   118,   292
 };
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint16 yyr1[] =
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int16 yyr1[] =
 {
-       0,   199,   200,   201,   201,   202,   202,   202,   202,   202,
-     203,   203,   203,   203,   203,   203,   203,   203,   203,   203,
-     204,   204,   205,   205,   206,   206,   207,   207,   207,   208,
-     208,   209,   210,   211,   211,   212,   212,   213,   214,   215,
-     215,   215,   216,   216,   216,   216,   216,   216,   217,   217,
-     218,   218,   219,   219,   219,   220,   220,   220,   220,   220,
-     221,   221,   222,   222,   223,   223,   224,   225,   225,   225,
-     225,   225,   225,   225,   225,   225,   225,   225,   225,   225,
-     225,   225,   225,   225,   225,   226,   226,   227,   227,   227,
-     228,   228,   229,   229,   229,   229,   230,   230,   230,   230,
-     231,   231,   231,   232,   233,   233,   233,   233,   234,   234,
-     235,   236,   237,   238,   239,   240,   240,   241,   241,   242,
-     243,   243,   244,   245,   245,   245,   246,   246,   247,   247,
-     248,   248,   249,   249,   250,   251,   251,   251,   252,   252,
-     253,   254,   254,   255,   256,   256,   257,   258,   258,   259,
-     259,   260,   260,   261,   261,   262,   262,   263,   264,   264,
-     264,   265,   265,   266,   266,   267,   267,   267,   267,   267,
-     267,   268,   268,   269,   269,   270,   270,   271,   271,   272,
-     272,   272,   273,   274,   274,   274,   274,   274,   275,   275,
-     275,   275,   275,   275,   275,   275,   275,   275,   275,   276,
-     276,   277,   277,   277,   277,   277,   278,   278,   278,   278,
-     278,   278,   278,   278,   278,   278,   278,   279,   279,   280,
-     280,   280,   280,   281,   281,   281,   281,   282,   282,   283,
-     283,   284,   284,   284,   284,   284,   284,   284,   285,   285,
-     285,   285,   286,   286,   287,   287,   288,   288,   288,   289,
-     289,   289,   290,   290,   290,   290,   290,   291,   292,   293,
-     293,   293,   293,   293,   293,   294,   294,   294,   294,   294,
-     294,   295,   295,   296,   297,   298,   299,   299,   299,   299,
-     300,   300,   300,   300,   300,   300,   300,   301,   302,   302,
-     303,   303,   304,   305,   306,   307,   307,   307,   308,   309,
-     309,   310,   310,   311,   311,   312,   312,   313,   314,   315,
-     315,   316,   316,   317,   317,   318,   318,   319,   319,   320,
-     320,   321,   321,   322,   322,   323,   323,   324,   324,   324,
-     324,   325,   325,   325,   326,   326,   327,   328,   328,   329,
-     330,   330,   330,   331,   331,   331,   331,   331,   331,   331,
-     331,   331,   331,   332,   333,   333,   334,   334
+       0,   201,   202,   203,   203,   204,   204,   204,   204,   204,
+     205,   205,   205,   205,   205,   205,   205,   205,   205,   205,
+     206,   206,   207,   207,   208,   208,   209,   209,   209,   210,
+     210,   211,   212,   213,   213,   214,   214,   215,   216,   217,
+     217,   217,   218,   218,   218,   218,   218,   218,   219,   219,
+     220,   220,   221,   221,   221,   222,   222,   222,   222,   222,
+     223,   223,   224,   224,   225,   225,   226,   227,   227,   227,
+     227,   227,   227,   227,   227,   227,   227,   227,   227,   227,
+     227,   227,   227,   227,   227,   228,   228,   229,   229,   229,
+     230,   230,   231,   231,   231,   231,   232,   232,   232,   232,
+     233,   233,   233,   234,   235,   235,   235,   235,   236,   236,
+     237,   238,   239,   240,   241,   242,   242,   243,   243,   244,
+     245,   245,   246,   247,   247,   247,   248,   248,   249,   249,
+     250,   250,   251,   251,   252,   253,   253,   253,   254,   254,
+     255,   256,   256,   257,   258,   258,   259,   260,   260,   261,
+     261,   262,   262,   263,   263,   264,   264,   265,   266,   266,
+     266,   267,   267,   268,   268,   269,   269,   269,   269,   269,
+     269,   270,   270,   271,   271,   272,   272,   273,   273,   274,
+     274,   274,   275,   276,   276,   276,   276,   276,   277,   277,
+     277,   277,   277,   277,   277,   277,   277,   277,   277,   278,
+     278,   279,   279,   279,   279,   279,   280,   280,   280,   280,
+     280,   280,   280,   280,   280,   280,   280,   281,   281,   282,
+     282,   282,   282,   283,   283,   283,   283,   284,   284,   285,
+     285,   286,   286,   286,   286,   286,   286,   286,   287,   287,
+     287,   287,   288,   288,   289,   289,   290,   290,   290,   291,
+     291,   291,   292,   292,   292,   292,   292,   293,   294,   295,
+     295,   295,   295,   295,   295,   296,   296,   296,   296,   296,
+     296,   297,   297,   298,   299,   300,   301,   301,   301,   301,
+     302,   302,   302,   302,   302,   302,   302,   303,   304,   304,
+     305,   305,   306,   307,   308,   309,   309,   309,   310,   310,
+     310,   311,   311,   312,   312,   313,   313,   314,   314,   315,
+     316,   317,   317,   318,   318,   319,   319,   320,   320,   321,
+     321,   322,   322,   323,   323,   324,   324,   325,   325,   326,
+     326,   326,   326,   327,   327,   327,   328,   328,   329,   330,
+     330,   331,   332,   332,   332,   333,   333,   333,   333,   333,
+     333,   333,   333,   333,   333,   334,   335,   335,   336,   336
 };
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
 {
        0,     2,     2,     1,     3,     2,     2,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
@@ -1439,48 +1537,48 @@ static const yytype_uint8 yyr2[] =
        1,     1,     1,     4,     4,     5,     1,     3,     1,     3,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     2,     2,     3,     2,     1,     1,
-       3,     1,     1,     1,     4,     1,     3,     2,     1,     1,
-       3,     1,     0,     1,     5,     1,     0,     2,     1,     1,
-       0,     1,     0,     1,     2,     3,     5,     1,     3,     1,
-       2,     2,     1,     0,     1,     0,     2,     1,     3,     3,
-       4,     6,     8,     1,     2,     1,     2,     1,     2,     1,
-       1,     1,     0,     1,     1,     0,     1,     3
+       1,     1,     3,     1,     1,     1,     4,     1,     3,     2,
+       1,     1,     3,     1,     0,     1,     5,     1,     0,     2,
+       1,     1,     0,     1,     0,     1,     2,     3,     5,     1,
+       3,     1,     2,     2,     1,     0,     1,     0,     2,     1,
+       3,     3,     4,     6,     8,     1,     2,     1,     2,     1,
+       2,     1,     1,     1,     0,     1,     1,     0,     1,     3
 };
 
 
+enum { YYENOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
-#define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
+#define yyclearin       (yychar = SQL_HSQL_EMPTY)
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
 #define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
 
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      yyerror (&yylloc, result, scanner, YY_("syntax error: cannot back up")); \
-      YYERROR;                                                  \
-    }                                                           \
-while (0)
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == SQL_HSQL_EMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (&yylloc, result, scanner, YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
+/* Backward compatibility with an undocumented macro.
+   Use SQL_HSQL_error or SQL_HSQL_UNDEF. */
+#define YYERRCODE SQL_HSQL_UNDEF
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
    If N is 0, then set CURRENT to the empty location which ends
@@ -1524,20 +1622,27 @@ do {                                            \
 } while (0)
 
 
-/* YY_LOCATION_PRINT -- Print the location on the stream.
+/* YYLOCATION_PRINT -- Print the location on the stream.
    This macro was not mandated originally: define only if we know
    we won't break user code: when these are the locations we know.  */
 
-#ifndef YY_LOCATION_PRINT
-# if defined HSQL_LTYPE_IS_TRIVIAL && HSQL_LTYPE_IS_TRIVIAL
+# ifndef YYLOCATION_PRINT
+
+#  if defined YY_LOCATION_PRINT
+
+   /* Temporary convenience wrapper in case some people defined the
+      undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YYLOCATION_PRINT(File, Loc)  YY_LOCATION_PRINT(File, *(Loc))
+
+#  elif defined HSQL_LTYPE_IS_TRIVIAL && HSQL_LTYPE_IS_TRIVIAL
 
 /* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
 
 YY_ATTRIBUTE_UNUSED
-static unsigned
+static int
 yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
 {
-  unsigned res = 0;
+  int res = 0;
   int end_col = 0 != yylocp->last_column ? yylocp->last_column - 1 : 0;
   if (0 <= yylocp->first_line)
     {
@@ -1557,65 +1662,73 @@ yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
         res += YYFPRINTF (yyo, "-%d", end_col);
     }
   return res;
- }
+}
 
-#  define YY_LOCATION_PRINT(File, Loc)          \
-  yy_location_print_ (File, &(Loc))
+#   define YYLOCATION_PRINT  yy_location_print_
 
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT(File, Loc)  YYLOCATION_PRINT(File, &(Loc))
+
+#  else
+
+#   define YYLOCATION_PRINT(File, Loc) ((void) 0)
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT  YYLOCATION_PRINT
+
+#  endif
+# endif /* !defined YYLOCATION_PRINT */
 
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
 do {                                                                      \
   if (yydebug)                                                            \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, Location, result, scanner); \
+                  Kind, Value, Location, result, scanner); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
 
 
-/*----------------------------------------.
-| Print this symbol's value on YYOUTPUT.  |
-`----------------------------------------*/
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
-  YYUSE (yylocationp);
-  YYUSE (result);
-  YYUSE (scanner);
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
+  YY_USE (yylocationp);
+  YY_USE (result);
+  YY_USE (scanner);
   if (!yyvaluep)
     return;
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# endif
-  YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
 {
-  YYFPRINTF (yyoutput, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  YY_LOCATION_PRINT (yyoutput, *yylocationp);
-  YYFPRINTF (yyoutput, ": ");
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp, result, scanner);
-  YYFPRINTF (yyoutput, ")");
+  YYLOCATION_PRINT (yyo, yylocationp);
+  YYFPRINTF (yyo, ": ");
+  yy_symbol_value_print (yyo, yykind, yyvaluep, yylocationp, result, scanner);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -1624,7 +1737,7 @@ yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYL
 `------------------------------------------------------------------*/
 
 static void
-yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -1647,21 +1760,22 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, hsql::SQLParserResult* result, yyscan_t scanner)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
+                 int yyrule, hsql::SQLParserResult* result, yyscan_t scanner)
 {
-  unsigned long int yylno = yyrline[yyrule];
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
              yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[yyssp[yyi + 1 - yynrhs]],
-                       &(yyvsp[(yyi + 1) - (yynrhs)])
-                       , &(yylsp[(yyi + 1) - (yynrhs)])                       , result, scanner);
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)],
+                       &(yylsp[(yyi + 1) - (yynrhs)]), result, scanner);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -1676,8 +1790,8 @@ do {                                    \
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !HSQL_DEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !HSQL_DEBUG */
@@ -1700,28 +1814,77 @@ int yydebug;
 #endif
 
 
-#if YYERROR_VERBOSE
+/* Context of a parse error.  */
+typedef struct
+{
+  yy_state_t *yyssp;
+  yysymbol_kind_t yytoken;
+  YYLTYPE *yylloc;
+} yypcontext_t;
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
-#  else
+/* Put in YYARG at most YYARGN of the expected tokens given the
+   current YYCTX, and return the number of tokens stored in YYARG.  If
+   YYARG is null, return the number of expected tokens (guaranteed to
+   be less than YYNTOKENS).  Return YYENOMEM on memory exhaustion.
+   Return 0 if there are more than YYARGN expected tokens, yet fill
+   YYARG up to YYARGN. */
+static int
+yypcontext_expected_tokens (const yypcontext_t *yyctx,
+                            yysymbol_kind_t yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  int yyn = yypact[+*yyctx->yyssp];
+  if (!yypact_value_is_default (yyn))
+    {
+      /* Start YYX at -YYN if negative to avoid negative indexes in
+         YYCHECK.  In other words, skip the first -YYN actions for
+         this state because they are default actions.  */
+      int yyxbegin = yyn < 0 ? -yyn : 0;
+      /* Stay within bounds of both yycheck and yytname.  */
+      int yychecklim = YYLAST - yyn + 1;
+      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+      int yyx;
+      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYerror
+            && !yytable_value_is_error (yytable[yyx + yyn]))
+          {
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = YY_CAST (yysymbol_kind_t, yyx);
+          }
+    }
+  if (yyarg && yycount == 0 && 0 < yyargn)
+    yyarg[0] = YYSYMBOL_YYEMPTY;
+  return yycount;
+}
+
+
+
+
+#ifndef yystrlen
+# if defined __GLIBC__ && defined _STRING_H
+#  define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
+# else
 /* Return the length of YYSTR.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yystrlen (const char *yystr)
 {
-  YYSIZE_T yylen;
+  YYPTRDIFF_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
     continue;
   return yylen;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
+#ifndef yystpcpy
+# if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
+#  define yystpcpy stpcpy
+# else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
 static char *
@@ -1735,10 +1898,10 @@ yystpcpy (char *yydest, const char *yysrc)
 
   return yyd - 1;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yytnamerr
+#ifndef yytnamerr
 /* Copy to YYRES the contents of YYSTR after stripping away unnecessary
    quotes and backslashes, so that it's suitable for yyerror.  The
    heuristic is that double-quoting is unnecessary unless the string
@@ -1746,14 +1909,13 @@ yystpcpy (char *yydest, const char *yysrc)
    backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
    null, do not copy; instead, return the length of what the result
    would have been.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yytnamerr (char *yyres, const char *yystr)
 {
   if (*yystr == '"')
     {
-      YYSIZE_T yyn = 0;
+      YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
-
       for (;;)
         switch (*++yyp)
           {
@@ -1764,7 +1926,10 @@ yytnamerr (char *yyres, const char *yystr)
           case '\\':
             if (*++yyp != '\\')
               goto do_not_strip_quotes;
-            /* Fall through.  */
+            else
+              goto append;
+
+          append:
           default:
             if (yyres)
               yyres[yyn] = *yyp;
@@ -1779,36 +1944,20 @@ yytnamerr (char *yyres, const char *yystr)
     do_not_strip_quotes: ;
     }
 
-  if (! yyres)
+  if (yyres)
+    return yystpcpy (yyres, yystr) - yyres;
+  else
     return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
 }
-# endif
+#endif
 
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
 
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
 static int
-yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
-                yytype_int16 *yyssp, int yytoken)
+yy_syntax_error_arguments (const yypcontext_t *yyctx,
+                           yysymbol_kind_t yyarg[], int yyargn)
 {
-  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-  YYSIZE_T yysize = yysize0;
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat. */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Number of reported tokens (one for the "unexpected", one per
-     "expected"). */
+  /* Actual size of YYARG. */
   int yycount = 0;
-
   /* There are many possibilities here to consider:
      - If this state is a consistent state with a default action, then
        the only way this function was invoked is if the default action
@@ -1832,63 +1981,78 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
        one exception: it will still contain any token that will not be
        accepted due to an error action in a later state.
   */
-  if (yytoken != YYEMPTY)
+  if (yyctx->yytoken != YYSYMBOL_YYEMPTY)
     {
-      int yyn = yypact[*yyssp];
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-                    return 2;
-                  yysize = yysize1;
-                }
-              }
-        }
+      int yyn;
+      if (yyarg)
+        yyarg[yycount] = yyctx->yytoken;
+      ++yycount;
+      yyn = yypcontext_expected_tokens (yyctx,
+                                        yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == YYENOMEM)
+        return YYENOMEM;
+      else
+        yycount += yyn;
     }
+  return yycount;
+}
+
+/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
+   about the unexpected token YYTOKEN for the state stack whose top is
+   YYSSP.
+
+   Return 0 if *YYMSG was successfully written.  Return -1 if *YYMSG is
+   not large enough to hold the message.  In that case, also set
+   *YYMSG_ALLOC to the required number of bytes.  Return YYENOMEM if the
+   required number of bytes is too large to store.  */
+static int
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                const yypcontext_t *yyctx)
+{
+  enum { YYARGS_MAX = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
+  yysymbol_kind_t yyarg[YYARGS_MAX];
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
+
+  /* Actual size of YYARG. */
+  int yycount = yy_syntax_error_arguments (yyctx, yyarg, YYARGS_MAX);
+  if (yycount == YYENOMEM)
+    return YYENOMEM;
 
   switch (yycount)
     {
-# define YYCASE_(N, S)                      \
+#define YYCASE_(N, S)                       \
       case N:                               \
         yyformat = S;                       \
-      break
+        break
+    default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
       YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
       YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
       YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
       YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
+#undef YYCASE_
     }
 
+  /* Compute error message size.  Don't count the "%s"s, but reserve
+     room for the terminator.  */
+  yysize = yystrlen (yyformat) - 2 * yycount + 1;
   {
-    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-      return 2;
-    yysize = yysize1;
+    int yyi;
+    for (yyi = 0; yyi < yycount; ++yyi)
+      {
+        YYPTRDIFF_T yysize1
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
+        if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+          yysize = yysize1;
+        else
+          return YYENOMEM;
+      }
   }
 
   if (*yymsg_alloc < yysize)
@@ -1897,7 +2061,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
       if (! (yysize <= *yymsg_alloc
              && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
         *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
+      return -1;
     }
 
   /* Avoid sprintf, as that infringes on the user's name space.
@@ -1909,64 +2073,77 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
     while ((*yyp = *yyformat) != '\0')
       if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
         {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
           yyformat += 2;
         }
       else
         {
-          yyp++;
-          yyformat++;
+          ++yyp;
+          ++yyformat;
         }
   }
   return 0;
 }
-#endif /* YYERROR_VERBOSE */
+
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
 {
-  YYUSE (yyvaluep);
-  YYUSE (yylocationp);
-  YYUSE (result);
-  YYUSE (scanner);
+  YY_USE (yyvaluep);
+  YY_USE (yylocationp);
+  YY_USE (result);
+  YY_USE (scanner);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  switch (yytype)
+  switch (yykind)
     {
-          case 3: /* IDENTIFIER  */
-#line 194 "bison_parser.y" /* yacc.c:1257  */
-      { free(((*yyvaluep).sval)); }
-#line 1947 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_IDENTIFIER: /* IDENTIFIER  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2112 "bison_parser.cpp"
         break;
 
-    case 4: /* STRING  */
-#line 194 "bison_parser.y" /* yacc.c:1257  */
-      { free(((*yyvaluep).sval)); }
-#line 1953 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_STRING: /* STRING  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2118 "bison_parser.cpp"
         break;
 
-    case 5: /* FLOATVAL  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 1959 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_FLOATVAL: /* FLOATVAL  */
+#line 181 "bison_parser.y"
+            { }
+#line 2124 "bison_parser.cpp"
         break;
 
-    case 6: /* INTVAL  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 1965 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_INTVAL: /* INTVAL  */
+#line 181 "bison_parser.y"
+            { }
+#line 2130 "bison_parser.cpp"
         break;
 
-    case 201: /* statement_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_DOLLAR_PARAM: /* DOLLAR_PARAM  */
+#line 181 "bison_parser.y"
+            { }
+#line 2136 "bison_parser.cpp"
+        break;
+
+    case YYSYMBOL_NAMED_PARAM: /* NAMED_PARAM  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2142 "bison_parser.cpp"
+        break;
+
+    case YYSYMBOL_statement_list: /* statement_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).stmt_vec)) {
     for (auto ptr : *(((*yyvaluep).stmt_vec))) {
       delete ptr;
@@ -1974,24 +2151,24 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).stmt_vec));
 }
-#line 1978 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2155 "bison_parser.cpp"
         break;
 
-    case 202: /* statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).statement)); }
-#line 1984 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_statement: /* statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).statement)); }
+#line 2161 "bison_parser.cpp"
         break;
 
-    case 203: /* preparable_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).statement)); }
-#line 1990 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_preparable_statement: /* preparable_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).statement)); }
+#line 2167 "bison_parser.cpp"
         break;
 
-    case 204: /* opt_hints  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_opt_hints: /* opt_hints  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -1999,12 +2176,12 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2003 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2180 "bison_parser.cpp"
         break;
 
-    case 205: /* hint_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_hint_list: /* hint_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2012,105 +2189,105 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2016 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2193 "bison_parser.cpp"
         break;
 
-    case 206: /* hint  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2022 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_hint: /* hint  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2199 "bison_parser.cpp"
         break;
 
-    case 207: /* transaction_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).transaction_stmt)); }
-#line 2028 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_transaction_statement: /* transaction_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).transaction_stmt)); }
+#line 2205 "bison_parser.cpp"
         break;
 
-    case 209: /* prepare_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).prep_stmt)); }
-#line 2034 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_prepare_statement: /* prepare_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).prep_stmt)); }
+#line 2211 "bison_parser.cpp"
         break;
 
-    case 210: /* prepare_target_query  */
-#line 194 "bison_parser.y" /* yacc.c:1257  */
-      { free(((*yyvaluep).sval)); }
-#line 2040 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_prepare_target_query: /* prepare_target_query  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2217 "bison_parser.cpp"
         break;
 
-    case 211: /* execute_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).exec_stmt)); }
-#line 2046 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_execute_statement: /* execute_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).exec_stmt)); }
+#line 2223 "bison_parser.cpp"
         break;
 
-    case 212: /* import_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).import_stmt)); }
-#line 2052 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_import_statement: /* import_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).import_stmt)); }
+#line 2229 "bison_parser.cpp"
         break;
 
-    case 213: /* file_type  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2058 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_file_type: /* file_type  */
+#line 181 "bison_parser.y"
+            { }
+#line 2235 "bison_parser.cpp"
         break;
 
-    case 214: /* file_path  */
-#line 194 "bison_parser.y" /* yacc.c:1257  */
-      { free(((*yyvaluep).sval)); }
-#line 2064 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_file_path: /* file_path  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2241 "bison_parser.cpp"
         break;
 
-    case 215: /* opt_import_export_options  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).import_export_option_t)); }
-#line 2070 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_import_export_options: /* opt_import_export_options  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).import_export_option_t)); }
+#line 2247 "bison_parser.cpp"
         break;
 
-    case 216: /* import_export_options  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).import_export_option_t)); }
-#line 2076 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_import_export_options: /* import_export_options  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).import_export_option_t)); }
+#line 2253 "bison_parser.cpp"
         break;
 
-    case 217: /* csv_option  */
-#line 203 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_csv_option: /* csv_option  */
+#line 203 "bison_parser.y"
+            {
   free(((*yyvaluep).csv_option_t)->second);
   delete (((*yyvaluep).csv_option_t));
 }
-#line 2085 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2262 "bison_parser.cpp"
         break;
 
-    case 218: /* export_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).export_stmt)); }
-#line 2091 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_export_statement: /* export_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).export_stmt)); }
+#line 2268 "bison_parser.cpp"
         break;
 
-    case 219: /* show_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).show_stmt)); }
-#line 2097 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_show_statement: /* show_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).show_stmt)); }
+#line 2274 "bison_parser.cpp"
         break;
 
-    case 220: /* create_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).create_stmt)); }
-#line 2103 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_create_statement: /* create_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).create_stmt)); }
+#line 2280 "bison_parser.cpp"
         break;
 
-    case 221: /* opt_not_exists  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2109 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_not_exists: /* opt_not_exists  */
+#line 181 "bison_parser.y"
+            { }
+#line 2286 "bison_parser.cpp"
         break;
 
-    case 222: /* table_elem_commalist  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_table_elem_commalist: /* table_elem_commalist  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).table_element_vec)) {
     for (auto ptr : *(((*yyvaluep).table_element_vec))) {
       delete ptr;
@@ -2118,120 +2295,120 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).table_element_vec));
 }
-#line 2122 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2299 "bison_parser.cpp"
         break;
 
-    case 223: /* table_elem  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table_element_t)); }
-#line 2128 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_elem: /* table_elem  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table_element_t)); }
+#line 2305 "bison_parser.cpp"
         break;
 
-    case 224: /* column_def  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).column_t)); }
-#line 2134 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_column_def: /* column_def  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).column_t)); }
+#line 2311 "bison_parser.cpp"
         break;
 
-    case 225: /* column_type  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2140 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_column_type: /* column_type  */
+#line 181 "bison_parser.y"
+            { }
+#line 2317 "bison_parser.cpp"
         break;
 
-    case 226: /* opt_time_precision  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2146 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_time_precision: /* opt_time_precision  */
+#line 181 "bison_parser.y"
+            { }
+#line 2323 "bison_parser.cpp"
         break;
 
-    case 227: /* opt_decimal_specification  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).ival_pair)); }
-#line 2152 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_decimal_specification: /* opt_decimal_specification  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).ival_pair)); }
+#line 2329 "bison_parser.cpp"
         break;
 
-    case 228: /* opt_column_constraints  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).column_constraints_t)); }
-#line 2158 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_column_constraints: /* opt_column_constraints  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).column_constraints_t)); }
+#line 2335 "bison_parser.cpp"
         break;
 
-    case 229: /* column_constraints  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).column_constraints_t)); }
-#line 2164 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_column_constraints: /* column_constraints  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).column_constraints_t)); }
+#line 2341 "bison_parser.cpp"
         break;
 
-    case 230: /* column_constraint  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2170 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_column_constraint: /* column_constraint  */
+#line 181 "bison_parser.y"
+            { }
+#line 2347 "bison_parser.cpp"
         break;
 
-    case 231: /* table_constraint  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table_constraint_t)); }
-#line 2176 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_constraint: /* table_constraint  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table_constraint_t)); }
+#line 2353 "bison_parser.cpp"
         break;
 
-    case 232: /* references_spec  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).references_spec_t)); }
-#line 2182 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_references_spec: /* references_spec  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).references_spec_t)); }
+#line 2359 "bison_parser.cpp"
         break;
 
-    case 233: /* drop_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).drop_stmt)); }
-#line 2188 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_drop_statement: /* drop_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).drop_stmt)); }
+#line 2365 "bison_parser.cpp"
         break;
 
-    case 234: /* opt_exists  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2194 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_exists: /* opt_exists  */
+#line 181 "bison_parser.y"
+            { }
+#line 2371 "bison_parser.cpp"
         break;
 
-    case 235: /* alter_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alter_stmt)); }
-#line 2200 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_alter_statement: /* alter_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alter_stmt)); }
+#line 2377 "bison_parser.cpp"
         break;
 
-    case 236: /* alter_action  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alter_action_t)); }
-#line 2206 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_alter_action: /* alter_action  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alter_action_t)); }
+#line 2383 "bison_parser.cpp"
         break;
 
-    case 237: /* drop_action  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).drop_action_t)); }
-#line 2212 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_drop_action: /* drop_action  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).drop_action_t)); }
+#line 2389 "bison_parser.cpp"
         break;
 
-    case 238: /* delete_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).delete_stmt)); }
-#line 2218 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_delete_statement: /* delete_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).delete_stmt)); }
+#line 2395 "bison_parser.cpp"
         break;
 
-    case 239: /* truncate_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).delete_stmt)); }
-#line 2224 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_truncate_statement: /* truncate_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).delete_stmt)); }
+#line 2401 "bison_parser.cpp"
         break;
 
-    case 240: /* insert_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).insert_stmt)); }
-#line 2230 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_insert_statement: /* insert_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).insert_stmt)); }
+#line 2407 "bison_parser.cpp"
         break;
 
-    case 241: /* opt_column_list  */
-#line 186 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_opt_column_list: /* opt_column_list  */
+#line 186 "bison_parser.y"
+            {
   if (((*yyvaluep).str_vec)) {
     for (auto ptr : *(((*yyvaluep).str_vec))) {
       free(ptr);
@@ -2239,18 +2416,18 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).str_vec));
 }
-#line 2243 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2420 "bison_parser.cpp"
         break;
 
-    case 242: /* update_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).update_stmt)); }
-#line 2249 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_update_statement: /* update_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).update_stmt)); }
+#line 2426 "bison_parser.cpp"
         break;
 
-    case 243: /* update_clause_commalist  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_update_clause_commalist: /* update_clause_commalist  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).update_vec)) {
     for (auto ptr : *(((*yyvaluep).update_vec))) {
       delete ptr;
@@ -2258,78 +2435,78 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).update_vec));
 }
-#line 2262 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2439 "bison_parser.cpp"
         break;
 
-    case 244: /* update_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).update_t)); }
-#line 2268 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_update_clause: /* update_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).update_t)); }
+#line 2445 "bison_parser.cpp"
         break;
 
-    case 245: /* select_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2274 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_statement: /* select_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2451 "bison_parser.cpp"
         break;
 
-    case 246: /* select_within_set_operation  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2280 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_within_set_operation: /* select_within_set_operation  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2457 "bison_parser.cpp"
         break;
 
-    case 247: /* select_within_set_operation_no_parentheses  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2286 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_within_set_operation_no_parentheses: /* select_within_set_operation_no_parentheses  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2463 "bison_parser.cpp"
         break;
 
-    case 248: /* select_with_paren  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2292 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_with_paren: /* select_with_paren  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2469 "bison_parser.cpp"
         break;
 
-    case 249: /* select_no_paren  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2298 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_no_paren: /* select_no_paren  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2475 "bison_parser.cpp"
         break;
 
-    case 250: /* set_operator  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).set_operator_t)); }
-#line 2304 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_set_operator: /* set_operator  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).set_operator_t)); }
+#line 2481 "bison_parser.cpp"
         break;
 
-    case 251: /* set_type  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).set_operator_t)); }
-#line 2310 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_set_type: /* set_type  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).set_operator_t)); }
+#line 2487 "bison_parser.cpp"
         break;
 
-    case 252: /* opt_all  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2316 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_all: /* opt_all  */
+#line 181 "bison_parser.y"
+            { }
+#line 2493 "bison_parser.cpp"
         break;
 
-    case 253: /* select_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2322 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_clause: /* select_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2499 "bison_parser.cpp"
         break;
 
-    case 254: /* opt_distinct  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2328 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_distinct: /* opt_distinct  */
+#line 181 "bison_parser.y"
+            { }
+#line 2505 "bison_parser.cpp"
         break;
 
-    case 255: /* select_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_select_list: /* select_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2337,42 +2514,42 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2341 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2518 "bison_parser.cpp"
         break;
 
-    case 256: /* opt_from_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2347 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_from_clause: /* opt_from_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2524 "bison_parser.cpp"
         break;
 
-    case 257: /* from_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2353 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_from_clause: /* from_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2530 "bison_parser.cpp"
         break;
 
-    case 258: /* opt_where  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2359 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_where: /* opt_where  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2536 "bison_parser.cpp"
         break;
 
-    case 259: /* opt_group  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).group_t)); }
-#line 2365 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_group: /* opt_group  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).group_t)); }
+#line 2542 "bison_parser.cpp"
         break;
 
-    case 260: /* opt_having  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2371 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_having: /* opt_having  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2548 "bison_parser.cpp"
         break;
 
-    case 261: /* opt_order  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_opt_order: /* opt_order  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).order_vec)) {
     for (auto ptr : *(((*yyvaluep).order_vec))) {
       delete ptr;
@@ -2380,12 +2557,12 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).order_vec));
 }
-#line 2384 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2561 "bison_parser.cpp"
         break;
 
-    case 262: /* order_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_order_list: /* order_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).order_vec)) {
     for (auto ptr : *(((*yyvaluep).order_vec))) {
       delete ptr;
@@ -2393,42 +2570,42 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).order_vec));
 }
-#line 2397 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2574 "bison_parser.cpp"
         break;
 
-    case 263: /* order_desc  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).order)); }
-#line 2403 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_order_desc: /* order_desc  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).order)); }
+#line 2580 "bison_parser.cpp"
         break;
 
-    case 264: /* opt_order_type  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2409 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_order_type: /* opt_order_type  */
+#line 181 "bison_parser.y"
+            { }
+#line 2586 "bison_parser.cpp"
         break;
 
-    case 265: /* opt_null_ordering  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2415 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_null_ordering: /* opt_null_ordering  */
+#line 181 "bison_parser.y"
+            { }
+#line 2592 "bison_parser.cpp"
         break;
 
-    case 266: /* opt_top  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).limit)); }
-#line 2421 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_top: /* opt_top  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).limit)); }
+#line 2598 "bison_parser.cpp"
         break;
 
-    case 267: /* opt_limit  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).limit)); }
-#line 2427 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_limit: /* opt_limit  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).limit)); }
+#line 2604 "bison_parser.cpp"
         break;
 
-    case 268: /* expr_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_expr_list: /* expr_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2436,12 +2613,12 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2440 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2617 "bison_parser.cpp"
         break;
 
-    case 269: /* opt_extended_literal_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_opt_extended_literal_list: /* opt_extended_literal_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2449,12 +2626,12 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2453 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2630 "bison_parser.cpp"
         break;
 
-    case 270: /* extended_literal_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_extended_literal_list: /* extended_literal_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2462,108 +2639,108 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2466 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2643 "bison_parser.cpp"
         break;
 
-    case 271: /* casted_extended_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2472 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_casted_extended_literal: /* casted_extended_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2649 "bison_parser.cpp"
         break;
 
-    case 272: /* extended_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2478 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_extended_literal: /* extended_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2655 "bison_parser.cpp"
         break;
 
-    case 273: /* expr_alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2484 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_expr_alias: /* expr_alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2661 "bison_parser.cpp"
         break;
 
-    case 274: /* expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2490 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_expr: /* expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2667 "bison_parser.cpp"
         break;
 
-    case 275: /* operand  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2496 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_operand: /* operand  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2673 "bison_parser.cpp"
         break;
 
-    case 276: /* scalar_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2502 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_scalar_expr: /* scalar_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2679 "bison_parser.cpp"
         break;
 
-    case 277: /* unary_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2508 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_unary_expr: /* unary_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2685 "bison_parser.cpp"
         break;
 
-    case 278: /* binary_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2514 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_binary_expr: /* binary_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2691 "bison_parser.cpp"
         break;
 
-    case 279: /* logic_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2520 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_logic_expr: /* logic_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2697 "bison_parser.cpp"
         break;
 
-    case 280: /* in_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2526 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_in_expr: /* in_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2703 "bison_parser.cpp"
         break;
 
-    case 281: /* case_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2532 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_case_expr: /* case_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2709 "bison_parser.cpp"
         break;
 
-    case 282: /* case_list  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2538 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_case_list: /* case_list  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2715 "bison_parser.cpp"
         break;
 
-    case 283: /* exists_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2544 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_exists_expr: /* exists_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2721 "bison_parser.cpp"
         break;
 
-    case 284: /* comp_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2550 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_comp_expr: /* comp_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2727 "bison_parser.cpp"
         break;
 
-    case 285: /* function_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2556 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_function_expr: /* function_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2733 "bison_parser.cpp"
         break;
 
-    case 286: /* opt_window  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).window_description)); }
-#line 2562 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_window: /* opt_window  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).window_description)); }
+#line 2739 "bison_parser.cpp"
         break;
 
-    case 287: /* opt_partition  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_opt_partition: /* opt_partition  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2571,156 +2748,156 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2575 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2752 "bison_parser.cpp"
         break;
 
-    case 288: /* opt_frame_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).frame_description)); }
-#line 2581 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_frame_clause: /* opt_frame_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).frame_description)); }
+#line 2758 "bison_parser.cpp"
         break;
 
-    case 289: /* frame_type  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2587 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_frame_type: /* frame_type  */
+#line 181 "bison_parser.y"
+            { }
+#line 2764 "bison_parser.cpp"
         break;
 
-    case 290: /* frame_bound  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).frame_bound)); }
-#line 2593 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_frame_bound: /* frame_bound  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).frame_bound)); }
+#line 2770 "bison_parser.cpp"
         break;
 
-    case 291: /* extract_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2599 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_extract_expr: /* extract_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2776 "bison_parser.cpp"
         break;
 
-    case 292: /* cast_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2605 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_cast_expr: /* cast_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2782 "bison_parser.cpp"
         break;
 
-    case 293: /* datetime_field  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2611 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_datetime_field: /* datetime_field  */
+#line 181 "bison_parser.y"
+            { }
+#line 2788 "bison_parser.cpp"
         break;
 
-    case 294: /* datetime_field_plural  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2617 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_datetime_field_plural: /* datetime_field_plural  */
+#line 181 "bison_parser.y"
+            { }
+#line 2794 "bison_parser.cpp"
         break;
 
-    case 295: /* duration_field  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2623 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_duration_field: /* duration_field  */
+#line 181 "bison_parser.y"
+            { }
+#line 2800 "bison_parser.cpp"
         break;
 
-    case 296: /* array_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2629 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_array_expr: /* array_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2806 "bison_parser.cpp"
         break;
 
-    case 297: /* array_index  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2635 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_array_index: /* array_index  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2812 "bison_parser.cpp"
         break;
 
-    case 298: /* between_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2641 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_between_expr: /* between_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2818 "bison_parser.cpp"
         break;
 
-    case 299: /* column_name  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2647 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_column_name: /* column_name  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2824 "bison_parser.cpp"
         break;
 
-    case 300: /* literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2653 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_literal: /* literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2830 "bison_parser.cpp"
         break;
 
-    case 301: /* string_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2659 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_string_literal: /* string_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2836 "bison_parser.cpp"
         break;
 
-    case 302: /* bool_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2665 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_bool_literal: /* bool_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2842 "bison_parser.cpp"
         break;
 
-    case 303: /* num_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2671 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_num_literal: /* num_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2848 "bison_parser.cpp"
         break;
 
-    case 304: /* int_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2677 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_int_literal: /* int_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2854 "bison_parser.cpp"
         break;
 
-    case 305: /* null_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2683 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_null_literal: /* null_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2860 "bison_parser.cpp"
         break;
 
-    case 306: /* date_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2689 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_date_literal: /* date_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2866 "bison_parser.cpp"
         break;
 
-    case 307: /* interval_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2695 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_interval_literal: /* interval_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2872 "bison_parser.cpp"
         break;
 
-    case 308: /* param_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2701 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_param_expr: /* param_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2878 "bison_parser.cpp"
         break;
 
-    case 309: /* table_ref  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2707 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_ref: /* table_ref  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2884 "bison_parser.cpp"
         break;
 
-    case 310: /* table_ref_atomic  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2713 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_ref_atomic: /* table_ref_atomic  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2890 "bison_parser.cpp"
         break;
 
-    case 311: /* nonjoin_table_ref_atomic  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2719 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_nonjoin_table_ref_atomic: /* nonjoin_table_ref_atomic  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2896 "bison_parser.cpp"
         break;
 
-    case 312: /* table_ref_commalist  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_table_ref_commalist: /* table_ref_commalist  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).table_vec)) {
     for (auto ptr : *(((*yyvaluep).table_vec))) {
       delete ptr;
@@ -2728,135 +2905,135 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).table_vec));
 }
-#line 2732 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2909 "bison_parser.cpp"
         break;
 
-    case 313: /* table_ref_name  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2738 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_ref_name: /* table_ref_name  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2915 "bison_parser.cpp"
         break;
 
-    case 314: /* table_ref_name_no_alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2744 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_ref_name_no_alias: /* table_ref_name_no_alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2921 "bison_parser.cpp"
         break;
 
-    case 315: /* table_name  */
-#line 182 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_table_name: /* table_name  */
+#line 182 "bison_parser.y"
+            {
   free(((*yyvaluep).table_name).name);
   free(((*yyvaluep).table_name).schema);
 }
-#line 2753 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2930 "bison_parser.cpp"
         break;
 
-    case 316: /* opt_index_name  */
-#line 194 "bison_parser.y" /* yacc.c:1257  */
-      { free(((*yyvaluep).sval)); }
-#line 2759 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_index_name: /* opt_index_name  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2936 "bison_parser.cpp"
         break;
 
-    case 317: /* table_alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alias_t)); }
-#line 2765 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_alias: /* table_alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alias_t)); }
+#line 2942 "bison_parser.cpp"
         break;
 
-    case 318: /* opt_table_alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alias_t)); }
-#line 2771 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_table_alias: /* opt_table_alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alias_t)); }
+#line 2948 "bison_parser.cpp"
         break;
 
-    case 319: /* alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alias_t)); }
-#line 2777 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_alias: /* alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alias_t)); }
+#line 2954 "bison_parser.cpp"
         break;
 
-    case 320: /* opt_alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alias_t)); }
-#line 2783 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_alias: /* opt_alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alias_t)); }
+#line 2960 "bison_parser.cpp"
         break;
 
-    case 321: /* opt_locking_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).locking_clause_vec)); }
-#line 2789 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_locking_clause: /* opt_locking_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).locking_clause_vec)); }
+#line 2966 "bison_parser.cpp"
         break;
 
-    case 322: /* opt_locking_clause_list  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).locking_clause_vec)); }
-#line 2795 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_locking_clause_list: /* opt_locking_clause_list  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).locking_clause_vec)); }
+#line 2972 "bison_parser.cpp"
         break;
 
-    case 323: /* locking_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).locking_t)); }
-#line 2801 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_locking_clause: /* locking_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).locking_t)); }
+#line 2978 "bison_parser.cpp"
         break;
 
-    case 324: /* row_lock_mode  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2807 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_row_lock_mode: /* row_lock_mode  */
+#line 181 "bison_parser.y"
+            { }
+#line 2984 "bison_parser.cpp"
         break;
 
-    case 325: /* opt_row_lock_policy  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2813 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_row_lock_policy: /* opt_row_lock_policy  */
+#line 181 "bison_parser.y"
+            { }
+#line 2990 "bison_parser.cpp"
         break;
 
-    case 326: /* opt_with_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).with_description_vec)); }
-#line 2819 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_with_clause: /* opt_with_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).with_description_vec)); }
+#line 2996 "bison_parser.cpp"
         break;
 
-    case 327: /* with_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).with_description_vec)); }
-#line 2825 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_with_clause: /* with_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).with_description_vec)); }
+#line 3002 "bison_parser.cpp"
         break;
 
-    case 328: /* with_description_list  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).with_description_vec)); }
-#line 2831 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_with_description_list: /* with_description_list  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).with_description_vec)); }
+#line 3008 "bison_parser.cpp"
         break;
 
-    case 329: /* with_description  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).with_description_t)); }
-#line 2837 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_with_description: /* with_description  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).with_description_t)); }
+#line 3014 "bison_parser.cpp"
         break;
 
-    case 330: /* join_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2843 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_join_clause: /* join_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 3020 "bison_parser.cpp"
         break;
 
-    case 331: /* opt_join_type  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2849 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_join_type: /* opt_join_type  */
+#line 181 "bison_parser.y"
+            { }
+#line 3026 "bison_parser.cpp"
         break;
 
-    case 332: /* join_condition  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2855 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_join_condition: /* join_condition  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 3032 "bison_parser.cpp"
         break;
 
-    case 334: /* ident_commalist  */
-#line 186 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_ident_commalist: /* ident_commalist  */
+#line 186 "bison_parser.y"
+            {
   if (((*yyvaluep).str_vec)) {
     for (auto ptr : *(((*yyvaluep).str_vec))) {
       free(ptr);
@@ -2864,15 +3041,16 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).str_vec));
 }
-#line 2868 "bison_parser.cpp" /* yacc.c:1257  */
+#line 3045 "bison_parser.cpp"
         break;
-
 
       default:
         break;
     }
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
+
+
 
 
 
@@ -2884,7 +3062,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
 int
 yyparse (hsql::SQLParserResult* result, yyscan_t scanner)
 {
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
 
@@ -2903,55 +3081,50 @@ static YYLTYPE yyloc_default
 YYLTYPE yylloc = yyloc_default;
 
     /* Number of syntax errors so far.  */
-    int yynerrs;
+    int yynerrs = 0;
 
-    int yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-       'yyls': related to locations.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
-    yytype_int16 yyssa[YYINITDEPTH];
-    yytype_int16 *yyss;
-    yytype_int16 *yyssp;
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
 
-    /* The semantic value stack.  */
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
+
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
-    /* The location stack.  */
+    /* The location stack: array, bottom, top.  */
     YYLTYPE yylsa[YYINITDEPTH];
-    YYLTYPE *yyls;
-    YYLTYPE *yylsp;
-
-    /* The locations where the error started and ended.  */
-    YYLTYPE yyerror_range[3];
-
-    YYSIZE_T yystacksize;
+    YYLTYPE *yyls = yylsa;
+    YYLTYPE *yylsp = yyls;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
   YYLTYPE yyloc;
 
-#if YYERROR_VERBOSE
+  /* The locations where the error started and ended.  */
+  YYLTYPE yyerror_range[3];
+
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N), yylsp -= (N))
 
@@ -2959,20 +3132,13 @@ YYLTYPE yylloc = yyloc_default;
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yylsp = yyls = yylsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
-  yychar = YYEMPTY; /* Cause a token to be read.  */
+  yychar = SQL_HSQL_EMPTY; /* Cause a token to be read.  */
+
 
 /* User initialization code.  */
-#line 81 "bison_parser.y" /* yacc.c:1429  */
+#line 81 "bison_parser.y"
 {
   // Initialize
   yylloc.first_column = 0;
@@ -2983,33 +3149,47 @@ YYLTYPE yylloc = yyloc_default;
   yylloc.string_length = 0;
 }
 
-#line 2987 "bison_parser.cpp" /* yacc.c:1429  */
+#line 3153 "bison_parser.cpp"
+
   yylsp[0] = yylloc;
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    YYNOMEM;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
         /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
            memory.  */
+        yy_state_t *yyss1 = yyss;
         YYSTYPE *yyvs1 = yyvs;
-        yytype_int16 *yyss1 = yyss;
         YYLTYPE *yyls1 = yyls;
 
         /* Each stack pointer address is followed by the size of the
@@ -3017,32 +3197,29 @@ YYLTYPE yylloc = yyloc_default;
            conditional around just the two extra args, but that might
            be undefined if yyoverflow is a macro.  */
         yyoverflow (YY_("memory exhausted"),
-                    &yyss1, yysize * sizeof (*yyssp),
-                    &yyvs1, yysize * sizeof (*yyvsp),
-                    &yyls1, yysize * sizeof (*yylsp),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
+                    &yyls1, yysize * YYSIZEOF (*yylsp),
                     &yystacksize);
-
-        yyls = yyls1;
         yyss = yyss1;
         yyvs = yyvs1;
+        yyls = yyls1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
         yystacksize = YYMAXDEPTH;
 
       {
-        yytype_int16 *yyss1 = yyss;
+        yy_state_t *yyss1 = yyss;
         union yyalloc *yyptr =
-          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
-          goto yyexhaustedlab;
+          YYNOMEM;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
         YYSTACK_RELOCATE (yyls_alloc, yyls);
@@ -3051,31 +3228,32 @@ YYLTYPE yylloc = yyloc_default;
           YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
       yylsp = yyls + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
 
   if (yystate == YYFINAL)
     YYACCEPT;
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -3086,17 +3264,29 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
-  if (yychar == YYEMPTY)
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
+  if (yychar == SQL_HSQL_EMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
+      YYDPRINTF ((stderr, "Reading a token\n"));
       yychar = yylex (&yylval, &yylloc, scanner);
     }
 
-  if (yychar <= YYEOF)
+  if (yychar <= SQL_YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = SQL_YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == SQL_HSQL_error)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = SQL_HSQL_UNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      yyerror_range[1] = yylloc;
+      goto yyerrlab1;
     }
   else
     {
@@ -3125,15 +3315,14 @@ yybackup:
 
   /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-
-  /* Discard the shifted token.  */
-  yychar = YYEMPTY;
-
   yystate = yyn;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
   YY_IGNORE_MAYBE_UNINITIALIZED_END
   *++yylsp = yylloc;
+
+  /* Discard the shifted token.  */
+  yychar = SQL_HSQL_EMPTY;
   goto yynewstate;
 
 
@@ -3148,7 +3337,7 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
@@ -3164,14 +3353,15 @@ yyreduce:
      GCC warning that YYVAL may be used uninitialized.  */
   yyval = yyvsp[1-yylen];
 
-  /* Default location.  */
+  /* Default location. */
   YYLLOC_DEFAULT (yyloc, (yylsp - yylen), yylen);
+  yyerror_range[1] = yyloc;
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 2:
-#line 343 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 2: /* input: statement_list opt_semicolon  */
+#line 345 "bison_parser.y"
+                                     {
   for (SQLStatement* stmt : *(yyvsp[-1].stmt_vec)) {
     // Transfers ownership of the statement.
     result->addStatement(stmt);
@@ -3181,244 +3371,245 @@ yyreduce:
   for (void* param : yyloc.param_list) {
     if (param) {
       Expr* expr = (Expr*)param;
-      expr->ival = param_id;
+      if (expr->type == kExprParameter) {
+        expr->ival = param_id++;
+      }
       result->addParameter(expr);
-      ++param_id;
     }
   }
     delete (yyvsp[-1].stmt_vec);
   }
-#line 3192 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3383 "bison_parser.cpp"
     break;
 
-  case 3:
-#line 362 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 3: /* statement_list: statement  */
+#line 365 "bison_parser.y"
+                           {
   (yyvsp[0].statement)->stringLength = yylloc.string_length;
   yylloc.string_length = 0;
   (yyval.stmt_vec) = new std::vector<SQLStatement*>();
   (yyval.stmt_vec)->push_back((yyvsp[0].statement));
 }
-#line 3203 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3394 "bison_parser.cpp"
     break;
 
-  case 4:
-#line 368 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 4: /* statement_list: statement_list ';' statement  */
+#line 371 "bison_parser.y"
+                               {
   (yyvsp[0].statement)->stringLength = yylloc.string_length;
   yylloc.string_length = 0;
   (yyvsp[-2].stmt_vec)->push_back((yyvsp[0].statement));
   (yyval.stmt_vec) = (yyvsp[-2].stmt_vec);
 }
-#line 3214 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3405 "bison_parser.cpp"
     break;
 
-  case 5:
-#line 375 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 5: /* statement: prepare_statement opt_hints  */
+#line 378 "bison_parser.y"
+                                        {
   (yyval.statement) = (yyvsp[-1].prep_stmt);
   (yyval.statement)->hints = (yyvsp[0].expr_vec);
 }
-#line 3223 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3414 "bison_parser.cpp"
     break;
 
-  case 6:
-#line 379 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 6: /* statement: preparable_statement opt_hints  */
+#line 382 "bison_parser.y"
+                                 {
   (yyval.statement) = (yyvsp[-1].statement);
   (yyval.statement)->hints = (yyvsp[0].expr_vec);
 }
-#line 3232 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3423 "bison_parser.cpp"
     break;
 
-  case 7:
-#line 383 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].show_stmt); }
-#line 3238 "bison_parser.cpp" /* yacc.c:1646  */
+  case 7: /* statement: show_statement  */
+#line 386 "bison_parser.y"
+                 { (yyval.statement) = (yyvsp[0].show_stmt); }
+#line 3429 "bison_parser.cpp"
     break;
 
-  case 8:
-#line 384 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].import_stmt); }
-#line 3244 "bison_parser.cpp" /* yacc.c:1646  */
+  case 8: /* statement: import_statement  */
+#line 387 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].import_stmt); }
+#line 3435 "bison_parser.cpp"
     break;
 
-  case 9:
-#line 385 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].export_stmt); }
-#line 3250 "bison_parser.cpp" /* yacc.c:1646  */
+  case 9: /* statement: export_statement  */
+#line 388 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].export_stmt); }
+#line 3441 "bison_parser.cpp"
     break;
 
-  case 10:
-#line 387 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].select_stmt); }
-#line 3256 "bison_parser.cpp" /* yacc.c:1646  */
+  case 10: /* preparable_statement: select_statement  */
+#line 390 "bison_parser.y"
+                                        { (yyval.statement) = (yyvsp[0].select_stmt); }
+#line 3447 "bison_parser.cpp"
     break;
 
-  case 11:
-#line 388 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].create_stmt); }
-#line 3262 "bison_parser.cpp" /* yacc.c:1646  */
+  case 11: /* preparable_statement: create_statement  */
+#line 391 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].create_stmt); }
+#line 3453 "bison_parser.cpp"
     break;
 
-  case 12:
-#line 389 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].insert_stmt); }
-#line 3268 "bison_parser.cpp" /* yacc.c:1646  */
+  case 12: /* preparable_statement: insert_statement  */
+#line 392 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].insert_stmt); }
+#line 3459 "bison_parser.cpp"
     break;
 
-  case 13:
-#line 390 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 3274 "bison_parser.cpp" /* yacc.c:1646  */
+  case 13: /* preparable_statement: delete_statement  */
+#line 393 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].delete_stmt); }
+#line 3465 "bison_parser.cpp"
     break;
 
-  case 14:
-#line 391 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 3280 "bison_parser.cpp" /* yacc.c:1646  */
+  case 14: /* preparable_statement: truncate_statement  */
+#line 394 "bison_parser.y"
+                     { (yyval.statement) = (yyvsp[0].delete_stmt); }
+#line 3471 "bison_parser.cpp"
     break;
 
-  case 15:
-#line 392 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].update_stmt); }
-#line 3286 "bison_parser.cpp" /* yacc.c:1646  */
+  case 15: /* preparable_statement: update_statement  */
+#line 395 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].update_stmt); }
+#line 3477 "bison_parser.cpp"
     break;
 
-  case 16:
-#line 393 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].drop_stmt); }
-#line 3292 "bison_parser.cpp" /* yacc.c:1646  */
+  case 16: /* preparable_statement: drop_statement  */
+#line 396 "bison_parser.y"
+                 { (yyval.statement) = (yyvsp[0].drop_stmt); }
+#line 3483 "bison_parser.cpp"
     break;
 
-  case 17:
-#line 394 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].alter_stmt); }
-#line 3298 "bison_parser.cpp" /* yacc.c:1646  */
+  case 17: /* preparable_statement: alter_statement  */
+#line 397 "bison_parser.y"
+                  { (yyval.statement) = (yyvsp[0].alter_stmt); }
+#line 3489 "bison_parser.cpp"
     break;
 
-  case 18:
-#line 395 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].exec_stmt); }
-#line 3304 "bison_parser.cpp" /* yacc.c:1646  */
+  case 18: /* preparable_statement: execute_statement  */
+#line 398 "bison_parser.y"
+                    { (yyval.statement) = (yyvsp[0].exec_stmt); }
+#line 3495 "bison_parser.cpp"
     break;
 
-  case 19:
-#line 396 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].transaction_stmt); }
-#line 3310 "bison_parser.cpp" /* yacc.c:1646  */
+  case 19: /* preparable_statement: transaction_statement  */
+#line 399 "bison_parser.y"
+                        { (yyval.statement) = (yyvsp[0].transaction_stmt); }
+#line 3501 "bison_parser.cpp"
     break;
 
-  case 20:
-#line 402 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = (yyvsp[-1].expr_vec); }
-#line 3316 "bison_parser.cpp" /* yacc.c:1646  */
+  case 20: /* opt_hints: WITH HINT '(' hint_list ')'  */
+#line 405 "bison_parser.y"
+                                        { (yyval.expr_vec) = (yyvsp[-1].expr_vec); }
+#line 3507 "bison_parser.cpp"
     break;
 
-  case 21:
-#line 403 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = nullptr; }
-#line 3322 "bison_parser.cpp" /* yacc.c:1646  */
+  case 21: /* opt_hints: %empty  */
+#line 406 "bison_parser.y"
+              { (yyval.expr_vec) = nullptr; }
+#line 3513 "bison_parser.cpp"
     break;
 
-  case 22:
-#line 405 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 22: /* hint_list: hint  */
+#line 408 "bison_parser.y"
+                 {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 3331 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3522 "bison_parser.cpp"
     break;
 
-  case 23:
-#line 409 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 23: /* hint_list: hint_list ',' hint  */
+#line 412 "bison_parser.y"
+                     {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 3340 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3531 "bison_parser.cpp"
     break;
 
-  case 24:
-#line 414 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 24: /* hint: IDENTIFIER  */
+#line 417 "bison_parser.y"
+                  {
   (yyval.expr) = Expr::make(kExprHint);
   (yyval.expr)->name = (yyvsp[0].sval);
 }
-#line 3349 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3540 "bison_parser.cpp"
     break;
 
-  case 25:
-#line 418 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 25: /* hint: IDENTIFIER '(' extended_literal_list ')'  */
+#line 421 "bison_parser.y"
+                                           {
   (yyval.expr) = Expr::make(kExprHint);
   (yyval.expr)->name = (yyvsp[-3].sval);
   (yyval.expr)->exprList = (yyvsp[-1].expr_vec);
 }
-#line 3359 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3550 "bison_parser.cpp"
     break;
 
-  case 26:
-#line 428 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.transaction_stmt) = new TransactionStatement(kBeginTransaction); }
-#line 3365 "bison_parser.cpp" /* yacc.c:1646  */
+  case 26: /* transaction_statement: BEGIN opt_transaction_keyword  */
+#line 431 "bison_parser.y"
+                                                      { (yyval.transaction_stmt) = new TransactionStatement(kBeginTransaction); }
+#line 3556 "bison_parser.cpp"
     break;
 
-  case 27:
-#line 429 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.transaction_stmt) = new TransactionStatement(kRollbackTransaction); }
-#line 3371 "bison_parser.cpp" /* yacc.c:1646  */
+  case 27: /* transaction_statement: ROLLBACK opt_transaction_keyword  */
+#line 432 "bison_parser.y"
+                                   { (yyval.transaction_stmt) = new TransactionStatement(kRollbackTransaction); }
+#line 3562 "bison_parser.cpp"
     break;
 
-  case 28:
-#line 430 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.transaction_stmt) = new TransactionStatement(kCommitTransaction); }
-#line 3377 "bison_parser.cpp" /* yacc.c:1646  */
+  case 28: /* transaction_statement: COMMIT opt_transaction_keyword  */
+#line 433 "bison_parser.y"
+                                 { (yyval.transaction_stmt) = new TransactionStatement(kCommitTransaction); }
+#line 3568 "bison_parser.cpp"
     break;
 
-  case 31:
-#line 438 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 31: /* prepare_statement: PREPARE IDENTIFIER FROM prepare_target_query  */
+#line 441 "bison_parser.y"
+                                                                 {
   (yyval.prep_stmt) = new PrepareStatement();
   (yyval.prep_stmt)->name = (yyvsp[-2].sval);
   (yyval.prep_stmt)->query = (yyvsp[0].sval);
 }
-#line 3387 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3578 "bison_parser.cpp"
     break;
 
-  case 33:
-#line 446 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 33: /* execute_statement: EXECUTE IDENTIFIER  */
+#line 449 "bison_parser.y"
+                                       {
   (yyval.exec_stmt) = new ExecuteStatement();
   (yyval.exec_stmt)->name = (yyvsp[0].sval);
 }
-#line 3396 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3587 "bison_parser.cpp"
     break;
 
-  case 34:
-#line 450 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 34: /* execute_statement: EXECUTE IDENTIFIER '(' opt_extended_literal_list ')'  */
+#line 453 "bison_parser.y"
+                                                       {
   (yyval.exec_stmt) = new ExecuteStatement();
   (yyval.exec_stmt)->name = (yyvsp[-3].sval);
   (yyval.exec_stmt)->parameters = (yyvsp[-1].expr_vec);
 }
-#line 3406 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3597 "bison_parser.cpp"
     break;
 
-  case 35:
-#line 462 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 35: /* import_statement: IMPORT FROM file_type FILE file_path INTO table_name  */
+#line 465 "bison_parser.y"
+                                                                        {
   (yyval.import_stmt) = new ImportStatement((yyvsp[-4].import_type_t));
   (yyval.import_stmt)->filePath = (yyvsp[-2].sval);
   (yyval.import_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.import_stmt)->tableName = (yyvsp[0].table_name).name;
 }
-#line 3417 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3608 "bison_parser.cpp"
     break;
 
-  case 36:
-#line 468 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 36: /* import_statement: COPY table_name FROM file_path opt_import_export_options opt_where  */
+#line 471 "bison_parser.y"
+                                                                     {
   (yyval.import_stmt) = new ImportStatement((yyvsp[-1].import_export_option_t)->format);
   (yyval.import_stmt)->filePath = (yyvsp[-2].sval);
   (yyval.import_stmt)->schema = (yyvsp[-4].table_name).schema;
@@ -3434,12 +3625,12 @@ yyreduce:
   }
   delete (yyvsp[-1].import_export_option_t);
 }
-#line 3438 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3629 "bison_parser.cpp"
     break;
 
-  case 37:
-#line 485 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 37: /* file_type: IDENTIFIER  */
+#line 488 "bison_parser.y"
+                       {
   if (strcasecmp((yyvsp[0].sval), "csv") == 0) {
     (yyval.import_type_t) = kImportCSV;
   } else if (strcasecmp((yyvsp[0].sval), "tbl") == 0) {
@@ -3453,36 +3644,36 @@ yyreduce:
   }
   free((yyvsp[0].sval));
 }
-#line 3457 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3648 "bison_parser.cpp"
     break;
 
-  case 38:
-#line 500 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.sval) = (yyvsp[0].sval); }
-#line 3463 "bison_parser.cpp" /* yacc.c:1646  */
+  case 38: /* file_path: STRING  */
+#line 503 "bison_parser.y"
+                   { (yyval.sval) = (yyvsp[0].sval); }
+#line 3654 "bison_parser.cpp"
     break;
 
-  case 39:
-#line 502 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
-#line 3469 "bison_parser.cpp" /* yacc.c:1646  */
+  case 39: /* opt_import_export_options: WITH '(' import_export_options ')'  */
+#line 505 "bison_parser.y"
+                                                               { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
+#line 3660 "bison_parser.cpp"
     break;
 
-  case 40:
-#line 503 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
-#line 3475 "bison_parser.cpp" /* yacc.c:1646  */
+  case 40: /* opt_import_export_options: '(' import_export_options ')'  */
+#line 506 "bison_parser.y"
+                                { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
+#line 3666 "bison_parser.cpp"
     break;
 
-  case 41:
-#line 504 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.import_export_option_t) = new ImportExportOptions{}; }
-#line 3481 "bison_parser.cpp" /* yacc.c:1646  */
+  case 41: /* opt_import_export_options: %empty  */
+#line 507 "bison_parser.y"
+              { (yyval.import_export_option_t) = new ImportExportOptions{}; }
+#line 3672 "bison_parser.cpp"
     break;
 
-  case 42:
-#line 506 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 42: /* import_export_options: import_export_options ',' FORMAT file_type  */
+#line 509 "bison_parser.y"
+                                                                   {
   if ((yyvsp[-3].import_export_option_t)->format != kImportAuto) {
     delete (yyvsp[-3].import_export_option_t);
     yyerror(&yyloc, result, scanner, "File type must only be provided once.");
@@ -3496,21 +3687,21 @@ yyreduce:
   (yyvsp[-3].import_export_option_t)->format = (yyvsp[0].import_type_t);
   (yyval.import_export_option_t) = (yyvsp[-3].import_export_option_t);
 }
-#line 3500 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3691 "bison_parser.cpp"
     break;
 
-  case 43:
-#line 520 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 43: /* import_export_options: FORMAT file_type  */
+#line 523 "bison_parser.y"
+                   {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->format = (yyvsp[0].import_type_t);
 }
-#line 3509 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3700 "bison_parser.cpp"
     break;
 
-  case 44:
-#line 524 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 44: /* import_export_options: import_export_options ',' ENCODING STRING  */
+#line 527 "bison_parser.y"
+                                            {
   if ((yyvsp[-3].import_export_option_t)->encoding) {
     delete (yyvsp[-3].import_export_option_t);
     free((yyvsp[0].sval));
@@ -3520,21 +3711,21 @@ yyreduce:
   (yyvsp[-3].import_export_option_t)->encoding = (yyvsp[0].sval);
   (yyval.import_export_option_t) = (yyvsp[-3].import_export_option_t);
 }
-#line 3524 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3715 "bison_parser.cpp"
     break;
 
-  case 45:
-#line 534 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 45: /* import_export_options: ENCODING STRING  */
+#line 537 "bison_parser.y"
+                  {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->encoding = (yyvsp[0].sval);
 }
-#line 3533 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3724 "bison_parser.cpp"
     break;
 
-  case 46:
-#line 538 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 46: /* import_export_options: import_export_options ',' csv_option  */
+#line 541 "bison_parser.y"
+                                       {
   if ((yyvsp[-2].import_export_option_t)->format != kImportAuto && (yyvsp[-2].import_export_option_t)->format != kImportCSV) {
     delete (yyvsp[-2].import_export_option_t);
     free((yyvsp[0].csv_option_t)->second);
@@ -3558,24 +3749,24 @@ yyreduce:
   delete (yyvsp[0].csv_option_t);
   (yyval.import_export_option_t) = (yyvsp[-2].import_export_option_t);
 }
-#line 3562 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3753 "bison_parser.cpp"
     break;
 
-  case 47:
-#line 562 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 47: /* import_export_options: csv_option  */
+#line 565 "bison_parser.y"
+             {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->csv_options = new CsvOptions{};
   (yyval.import_export_option_t)->csv_options->accept_csv_option((yyvsp[0].csv_option_t));
 
   delete (yyvsp[0].csv_option_t);
 }
-#line 3574 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3765 "bison_parser.cpp"
     break;
 
-  case 48:
-#line 570 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 48: /* csv_option: IDENTIFIER STRING  */
+#line 573 "bison_parser.y"
+                               {
   if (strcasecmp((yyvsp[-1].sval), "DELIMITER") == 0) {
     (yyval.csv_option_t) = new std::pair<CsvOptionType, char*>(CsvOptionType::Delimiter, (yyvsp[0].sval));
   } else if (strcasecmp((yyvsp[-1].sval), "QUOTE") == 0) {
@@ -3588,18 +3779,18 @@ yyreduce:
   }
   free((yyvsp[-1].sval));
 }
-#line 3592 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3783 "bison_parser.cpp"
     break;
 
-  case 49:
-#line 583 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.csv_option_t) = new std::pair<CsvOptionType, char*>(CsvOptionType::Null, (yyvsp[0].sval)); }
-#line 3598 "bison_parser.cpp" /* yacc.c:1646  */
+  case 49: /* csv_option: NULL STRING  */
+#line 586 "bison_parser.y"
+              { (yyval.csv_option_t) = new std::pair<CsvOptionType, char*>(CsvOptionType::Null, (yyvsp[0].sval)); }
+#line 3789 "bison_parser.cpp"
     break;
 
-  case 50:
-#line 590 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 50: /* export_statement: COPY table_name TO file_path opt_import_export_options  */
+#line 593 "bison_parser.y"
+                                                                          {
   (yyval.export_stmt) = new ExportStatement((yyvsp[0].import_export_option_t)->format);
   (yyval.export_stmt)->filePath = (yyvsp[-1].sval);
   (yyval.export_stmt)->schema = (yyvsp[-3].table_name).schema;
@@ -3614,12 +3805,12 @@ yyreduce:
   }
   delete (yyvsp[0].import_export_option_t);
 }
-#line 3618 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3809 "bison_parser.cpp"
     break;
 
-  case 51:
-#line 605 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 51: /* export_statement: COPY select_with_paren TO file_path opt_import_export_options  */
+#line 608 "bison_parser.y"
+                                                                {
   (yyval.export_stmt) = new ExportStatement((yyvsp[0].import_export_option_t)->format);
   (yyval.export_stmt)->filePath = (yyvsp[-1].sval);
   (yyval.export_stmt)->select = (yyvsp[-3].select_stmt);
@@ -3633,38 +3824,38 @@ yyreduce:
   }
   delete (yyvsp[0].import_export_option_t);
 }
-#line 3637 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3828 "bison_parser.cpp"
     break;
 
-  case 52:
-#line 625 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.show_stmt) = new ShowStatement(kShowTables); }
-#line 3643 "bison_parser.cpp" /* yacc.c:1646  */
+  case 52: /* show_statement: SHOW TABLES  */
+#line 628 "bison_parser.y"
+                             { (yyval.show_stmt) = new ShowStatement(kShowTables); }
+#line 3834 "bison_parser.cpp"
     break;
 
-  case 53:
-#line 626 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 53: /* show_statement: SHOW COLUMNS table_name  */
+#line 629 "bison_parser.y"
+                          {
   (yyval.show_stmt) = new ShowStatement(kShowColumns);
   (yyval.show_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.show_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 3653 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3844 "bison_parser.cpp"
     break;
 
-  case 54:
-#line 631 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 54: /* show_statement: DESCRIBE table_name  */
+#line 634 "bison_parser.y"
+                      {
   (yyval.show_stmt) = new ShowStatement(kShowColumns);
   (yyval.show_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.show_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 3663 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3854 "bison_parser.cpp"
     break;
 
-  case 55:
-#line 642 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 55: /* create_statement: CREATE TABLE opt_not_exists table_name FROM IDENTIFIER FILE file_path  */
+#line 645 "bison_parser.y"
+                                                                                         {
   (yyval.create_stmt) = new CreateStatement(kCreateTableFromTbl);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-5].bval);
   (yyval.create_stmt)->schema = (yyvsp[-4].table_name).schema;
@@ -3677,12 +3868,12 @@ yyreduce:
   free((yyvsp[-2].sval));
   (yyval.create_stmt)->filePath = (yyvsp[0].sval);
 }
-#line 3681 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3872 "bison_parser.cpp"
     break;
 
-  case 56:
-#line 655 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 56: /* create_statement: CREATE TABLE opt_not_exists table_name '(' table_elem_commalist ')'  */
+#line 658 "bison_parser.y"
+                                                                      {
   (yyval.create_stmt) = new CreateStatement(kCreateTable);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
   (yyval.create_stmt)->schema = (yyvsp[-3].table_name).schema;
@@ -3694,36 +3885,36 @@ yyreduce:
     YYERROR;
   }
 }
-#line 3698 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3889 "bison_parser.cpp"
     break;
 
-  case 57:
-#line 667 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 57: /* create_statement: CREATE TABLE opt_not_exists table_name AS select_statement  */
+#line 670 "bison_parser.y"
+                                                             {
   (yyval.create_stmt) = new CreateStatement(kCreateTable);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-3].bval);
   (yyval.create_stmt)->schema = (yyvsp[-2].table_name).schema;
   (yyval.create_stmt)->tableName = (yyvsp[-2].table_name).name;
   (yyval.create_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 3710 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3901 "bison_parser.cpp"
     break;
 
-  case 58:
-#line 674 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 58: /* create_statement: CREATE INDEX opt_not_exists opt_index_name ON table_name '(' ident_commalist ')'  */
+#line 677 "bison_parser.y"
+                                                                                   {
   (yyval.create_stmt) = new CreateStatement(kCreateIndex);
   (yyval.create_stmt)->indexName = (yyvsp[-5].sval);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-6].bval);
   (yyval.create_stmt)->tableName = (yyvsp[-3].table_name).name;
   (yyval.create_stmt)->indexColumns = (yyvsp[-1].str_vec);
 }
-#line 3722 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3913 "bison_parser.cpp"
     break;
 
-  case 59:
-#line 681 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 59: /* create_statement: CREATE VIEW opt_not_exists table_name opt_column_list AS select_statement  */
+#line 684 "bison_parser.y"
+                                                                            {
   (yyval.create_stmt) = new CreateStatement(kCreateView);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
   (yyval.create_stmt)->schema = (yyvsp[-3].table_name).schema;
@@ -3731,500 +3922,500 @@ yyreduce:
   (yyval.create_stmt)->viewColumns = (yyvsp[-2].str_vec);
   (yyval.create_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 3735 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3926 "bison_parser.cpp"
     break;
 
-  case 60:
-#line 690 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = true; }
-#line 3741 "bison_parser.cpp" /* yacc.c:1646  */
+  case 60: /* opt_not_exists: IF NOT EXISTS  */
+#line 693 "bison_parser.y"
+                               { (yyval.bval) = true; }
+#line 3932 "bison_parser.cpp"
     break;
 
-  case 61:
-#line 691 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = false; }
-#line 3747 "bison_parser.cpp" /* yacc.c:1646  */
+  case 61: /* opt_not_exists: %empty  */
+#line 694 "bison_parser.y"
+              { (yyval.bval) = false; }
+#line 3938 "bison_parser.cpp"
     break;
 
-  case 62:
-#line 693 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 62: /* table_elem_commalist: table_elem  */
+#line 696 "bison_parser.y"
+                                  {
   (yyval.table_element_vec) = new std::vector<TableElement*>();
   (yyval.table_element_vec)->push_back((yyvsp[0].table_element_t));
 }
-#line 3756 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3947 "bison_parser.cpp"
     break;
 
-  case 63:
-#line 697 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 63: /* table_elem_commalist: table_elem_commalist ',' table_elem  */
+#line 700 "bison_parser.y"
+                                      {
   (yyvsp[-2].table_element_vec)->push_back((yyvsp[0].table_element_t));
   (yyval.table_element_vec) = (yyvsp[-2].table_element_vec);
 }
-#line 3765 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3956 "bison_parser.cpp"
     break;
 
-  case 64:
-#line 702 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table_element_t) = (yyvsp[0].column_t); }
-#line 3771 "bison_parser.cpp" /* yacc.c:1646  */
+  case 64: /* table_elem: column_def  */
+#line 705 "bison_parser.y"
+                        { (yyval.table_element_t) = (yyvsp[0].column_t); }
+#line 3962 "bison_parser.cpp"
     break;
 
-  case 65:
-#line 703 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table_element_t) = (yyvsp[0].table_constraint_t); }
-#line 3777 "bison_parser.cpp" /* yacc.c:1646  */
+  case 65: /* table_elem: table_constraint  */
+#line 706 "bison_parser.y"
+                   { (yyval.table_element_t) = (yyvsp[0].table_constraint_t); }
+#line 3968 "bison_parser.cpp"
     break;
 
-  case 66:
-#line 705 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 66: /* column_def: IDENTIFIER column_type opt_column_constraints  */
+#line 708 "bison_parser.y"
+                                                           {
   (yyval.column_t) = new ColumnDefinition((yyvsp[-2].sval), (yyvsp[-1].column_type_t), (yyvsp[0].column_constraints_t)->constraints, (yyvsp[0].column_constraints_t)->references);
   if (!(yyval.column_t)->trySetNullableExplicit()) {
     yyerror(&yyloc, result, scanner, ("Conflicting nullability constraints for " + std::string{(yyvsp[-2].sval)}).c_str());
   }
   delete (yyvsp[0].column_constraints_t);
 }
-#line 3789 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3980 "bison_parser.cpp"
     break;
 
-  case 67:
-#line 713 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::BIGINT}; }
-#line 3795 "bison_parser.cpp" /* yacc.c:1646  */
+  case 67: /* column_type: BIGINT  */
+#line 716 "bison_parser.y"
+                     { (yyval.column_type_t) = ColumnType{DataType::BIGINT}; }
+#line 3986 "bison_parser.cpp"
     break;
 
-  case 68:
-#line 714 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::BOOLEAN}; }
-#line 3801 "bison_parser.cpp" /* yacc.c:1646  */
+  case 68: /* column_type: BOOLEAN  */
+#line 717 "bison_parser.y"
+          { (yyval.column_type_t) = ColumnType{DataType::BOOLEAN}; }
+#line 3992 "bison_parser.cpp"
     break;
 
-  case 69:
-#line 715 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::CHAR, (yyvsp[-1].ival)}; }
-#line 3807 "bison_parser.cpp" /* yacc.c:1646  */
+  case 69: /* column_type: CHAR '(' INTVAL ')'  */
+#line 718 "bison_parser.y"
+                      { (yyval.column_type_t) = ColumnType{DataType::CHAR, (yyvsp[-1].ival)}; }
+#line 3998 "bison_parser.cpp"
     break;
 
-  case 70:
-#line 716 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
-#line 3813 "bison_parser.cpp" /* yacc.c:1646  */
+  case 70: /* column_type: CHARACTER_VARYING '(' INTVAL ')'  */
+#line 719 "bison_parser.y"
+                                   { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
+#line 4004 "bison_parser.cpp"
     break;
 
-  case 71:
-#line 717 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::DATE}; }
-#line 3819 "bison_parser.cpp" /* yacc.c:1646  */
+  case 71: /* column_type: DATE  */
+#line 720 "bison_parser.y"
+       { (yyval.column_type_t) = ColumnType{DataType::DATE}; }
+#line 4010 "bison_parser.cpp"
     break;
 
-  case 72:
-#line 718 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
-#line 3825 "bison_parser.cpp" /* yacc.c:1646  */
+  case 72: /* column_type: DATETIME  */
+#line 721 "bison_parser.y"
+           { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
+#line 4016 "bison_parser.cpp"
     break;
 
-  case 73:
-#line 719 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 73: /* column_type: DECIMAL opt_decimal_specification  */
+#line 722 "bison_parser.y"
+                                    {
   (yyval.column_type_t) = ColumnType{DataType::DECIMAL, 0, (yyvsp[0].ival_pair)->first, (yyvsp[0].ival_pair)->second};
   delete (yyvsp[0].ival_pair);
 }
-#line 3834 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4025 "bison_parser.cpp"
     break;
 
-  case 74:
-#line 723 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::DOUBLE}; }
-#line 3840 "bison_parser.cpp" /* yacc.c:1646  */
+  case 74: /* column_type: DOUBLE  */
+#line 726 "bison_parser.y"
+         { (yyval.column_type_t) = ColumnType{DataType::DOUBLE}; }
+#line 4031 "bison_parser.cpp"
     break;
 
-  case 75:
-#line 724 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::FLOAT}; }
-#line 3846 "bison_parser.cpp" /* yacc.c:1646  */
+  case 75: /* column_type: FLOAT  */
+#line 727 "bison_parser.y"
+        { (yyval.column_type_t) = ColumnType{DataType::FLOAT}; }
+#line 4037 "bison_parser.cpp"
     break;
 
-  case 76:
-#line 725 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::INT}; }
-#line 3852 "bison_parser.cpp" /* yacc.c:1646  */
+  case 76: /* column_type: INT  */
+#line 728 "bison_parser.y"
+      { (yyval.column_type_t) = ColumnType{DataType::INT}; }
+#line 4043 "bison_parser.cpp"
     break;
 
-  case 77:
-#line 726 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::INT}; }
-#line 3858 "bison_parser.cpp" /* yacc.c:1646  */
+  case 77: /* column_type: INTEGER  */
+#line 729 "bison_parser.y"
+          { (yyval.column_type_t) = ColumnType{DataType::INT}; }
+#line 4049 "bison_parser.cpp"
     break;
 
-  case 78:
-#line 727 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::LONG}; }
-#line 3864 "bison_parser.cpp" /* yacc.c:1646  */
+  case 78: /* column_type: LONG  */
+#line 730 "bison_parser.y"
+       { (yyval.column_type_t) = ColumnType{DataType::LONG}; }
+#line 4055 "bison_parser.cpp"
     break;
 
-  case 79:
-#line 728 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::REAL}; }
-#line 3870 "bison_parser.cpp" /* yacc.c:1646  */
+  case 79: /* column_type: REAL  */
+#line 731 "bison_parser.y"
+       { (yyval.column_type_t) = ColumnType{DataType::REAL}; }
+#line 4061 "bison_parser.cpp"
     break;
 
-  case 80:
-#line 729 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::SMALLINT}; }
-#line 3876 "bison_parser.cpp" /* yacc.c:1646  */
+  case 80: /* column_type: SMALLINT  */
+#line 732 "bison_parser.y"
+           { (yyval.column_type_t) = ColumnType{DataType::SMALLINT}; }
+#line 4067 "bison_parser.cpp"
     break;
 
-  case 81:
-#line 730 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::TEXT}; }
-#line 3882 "bison_parser.cpp" /* yacc.c:1646  */
+  case 81: /* column_type: TEXT  */
+#line 733 "bison_parser.y"
+       { (yyval.column_type_t) = ColumnType{DataType::TEXT}; }
+#line 4073 "bison_parser.cpp"
     break;
 
-  case 82:
-#line 731 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::TIME, 0, (yyvsp[0].ival)}; }
-#line 3888 "bison_parser.cpp" /* yacc.c:1646  */
+  case 82: /* column_type: TIME opt_time_precision  */
+#line 734 "bison_parser.y"
+                          { (yyval.column_type_t) = ColumnType{DataType::TIME, 0, (yyvsp[0].ival)}; }
+#line 4079 "bison_parser.cpp"
     break;
 
-  case 83:
-#line 732 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
-#line 3894 "bison_parser.cpp" /* yacc.c:1646  */
+  case 83: /* column_type: TIMESTAMP  */
+#line 735 "bison_parser.y"
+            { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
+#line 4085 "bison_parser.cpp"
     break;
 
-  case 84:
-#line 733 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
-#line 3900 "bison_parser.cpp" /* yacc.c:1646  */
+  case 84: /* column_type: VARCHAR '(' INTVAL ')'  */
+#line 736 "bison_parser.y"
+                         { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
+#line 4091 "bison_parser.cpp"
     break;
 
-  case 85:
-#line 735 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-1].ival); }
-#line 3906 "bison_parser.cpp" /* yacc.c:1646  */
+  case 85: /* opt_time_precision: '(' INTVAL ')'  */
+#line 738 "bison_parser.y"
+                                    { (yyval.ival) = (yyvsp[-1].ival); }
+#line 4097 "bison_parser.cpp"
     break;
 
-  case 86:
-#line 736 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.ival) = 0; }
-#line 3912 "bison_parser.cpp" /* yacc.c:1646  */
+  case 86: /* opt_time_precision: %empty  */
+#line 739 "bison_parser.y"
+              { (yyval.ival) = 0; }
+#line 4103 "bison_parser.cpp"
     break;
 
-  case 87:
-#line 738 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-3].ival), (yyvsp[-1].ival)}; }
-#line 3918 "bison_parser.cpp" /* yacc.c:1646  */
+  case 87: /* opt_decimal_specification: '(' INTVAL ',' INTVAL ')'  */
+#line 741 "bison_parser.y"
+                                                      { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-3].ival), (yyvsp[-1].ival)}; }
+#line 4109 "bison_parser.cpp"
     break;
 
-  case 88:
-#line 739 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-1].ival), 0}; }
-#line 3924 "bison_parser.cpp" /* yacc.c:1646  */
+  case 88: /* opt_decimal_specification: '(' INTVAL ')'  */
+#line 742 "bison_parser.y"
+                 { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-1].ival), 0}; }
+#line 4115 "bison_parser.cpp"
     break;
 
-  case 89:
-#line 740 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{0, 0}; }
-#line 3930 "bison_parser.cpp" /* yacc.c:1646  */
+  case 89: /* opt_decimal_specification: %empty  */
+#line 743 "bison_parser.y"
+              { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{0, 0}; }
+#line 4121 "bison_parser.cpp"
     break;
 
-  case 90:
-#line 742 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraints_t) = (yyvsp[0].column_constraints_t); }
-#line 3936 "bison_parser.cpp" /* yacc.c:1646  */
+  case 90: /* opt_column_constraints: column_constraints  */
+#line 745 "bison_parser.y"
+                                            { (yyval.column_constraints_t) = (yyvsp[0].column_constraints_t); }
+#line 4127 "bison_parser.cpp"
     break;
 
-  case 91:
-#line 743 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraints_t) = new ColumnConstraints(); }
-#line 3942 "bison_parser.cpp" /* yacc.c:1646  */
+  case 91: /* opt_column_constraints: %empty  */
+#line 746 "bison_parser.y"
+              { (yyval.column_constraints_t) = new ColumnConstraints(); }
+#line 4133 "bison_parser.cpp"
     break;
 
-  case 92:
-#line 745 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 92: /* column_constraints: column_constraint  */
+#line 748 "bison_parser.y"
+                                       {
   (yyval.column_constraints_t) = new ColumnConstraints();
   (yyval.column_constraints_t)->constraints->insert((yyvsp[0].column_constraint_t));
 }
-#line 3951 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4142 "bison_parser.cpp"
     break;
 
-  case 93:
-#line 749 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 93: /* column_constraints: column_constraints column_constraint  */
+#line 752 "bison_parser.y"
+                                       {
   (yyvsp[-1].column_constraints_t)->constraints->insert((yyvsp[0].column_constraint_t));
   (yyval.column_constraints_t) = (yyvsp[-1].column_constraints_t);
 }
-#line 3960 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4151 "bison_parser.cpp"
     break;
 
-  case 94:
-#line 753 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 94: /* column_constraints: references_spec  */
+#line 756 "bison_parser.y"
+                  {
   (yyval.column_constraints_t) = new ColumnConstraints();
   (yyval.column_constraints_t)->constraints->insert(ConstraintType::ForeignKey);
   (yyval.column_constraints_t)->references->emplace_back((yyvsp[0].references_spec_t));
 }
-#line 3970 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4161 "bison_parser.cpp"
     break;
 
-  case 95:
-#line 758 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 95: /* column_constraints: column_constraints references_spec  */
+#line 761 "bison_parser.y"
+                                     {
   // Multiple foreign keys for the same column could be possible, so we do not raise an error in that case.
   // Think of foreign keys referenced on multiple levels (returned item references sold item references items).
   (yyvsp[-1].column_constraints_t)->constraints->insert(ConstraintType::ForeignKey);
   (yyvsp[-1].column_constraints_t)->references->emplace_back((yyvsp[0].references_spec_t));
   (yyval.column_constraints_t) = (yyvsp[-1].column_constraints_t);
 }
-#line 3982 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4173 "bison_parser.cpp"
     break;
 
-  case 96:
-#line 766 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraint_t) = ConstraintType::PrimaryKey; }
-#line 3988 "bison_parser.cpp" /* yacc.c:1646  */
+  case 96: /* column_constraint: PRIMARY KEY  */
+#line 769 "bison_parser.y"
+                                { (yyval.column_constraint_t) = ConstraintType::PrimaryKey; }
+#line 4179 "bison_parser.cpp"
     break;
 
-  case 97:
-#line 767 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraint_t) = ConstraintType::Unique; }
-#line 3994 "bison_parser.cpp" /* yacc.c:1646  */
+  case 97: /* column_constraint: UNIQUE  */
+#line 770 "bison_parser.y"
+         { (yyval.column_constraint_t) = ConstraintType::Unique; }
+#line 4185 "bison_parser.cpp"
     break;
 
-  case 98:
-#line 768 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraint_t) = ConstraintType::Null; }
-#line 4000 "bison_parser.cpp" /* yacc.c:1646  */
+  case 98: /* column_constraint: NULL  */
+#line 771 "bison_parser.y"
+       { (yyval.column_constraint_t) = ConstraintType::Null; }
+#line 4191 "bison_parser.cpp"
     break;
 
-  case 99:
-#line 769 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraint_t) = ConstraintType::NotNull; }
-#line 4006 "bison_parser.cpp" /* yacc.c:1646  */
+  case 99: /* column_constraint: NOT NULL  */
+#line 772 "bison_parser.y"
+           { (yyval.column_constraint_t) = ConstraintType::NotNull; }
+#line 4197 "bison_parser.cpp"
     break;
 
-  case 100:
-#line 771 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::PrimaryKey, (yyvsp[-1].str_vec)); }
-#line 4012 "bison_parser.cpp" /* yacc.c:1646  */
+  case 100: /* table_constraint: PRIMARY KEY '(' ident_commalist ')'  */
+#line 774 "bison_parser.y"
+                                                       { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::PrimaryKey, (yyvsp[-1].str_vec)); }
+#line 4203 "bison_parser.cpp"
     break;
 
-  case 101:
-#line 772 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::Unique, (yyvsp[-1].str_vec)); }
-#line 4018 "bison_parser.cpp" /* yacc.c:1646  */
+  case 101: /* table_constraint: UNIQUE '(' ident_commalist ')'  */
+#line 775 "bison_parser.y"
+                                 { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::Unique, (yyvsp[-1].str_vec)); }
+#line 4209 "bison_parser.cpp"
     break;
 
-  case 102:
-#line 773 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table_constraint_t) = new ForeignKeyConstraint((yyvsp[-2].str_vec), (yyvsp[0].references_spec_t)); }
-#line 4024 "bison_parser.cpp" /* yacc.c:1646  */
+  case 102: /* table_constraint: FOREIGN KEY '(' ident_commalist ')' references_spec  */
+#line 776 "bison_parser.y"
+                                                      { (yyval.table_constraint_t) = new ForeignKeyConstraint((yyvsp[-2].str_vec), (yyvsp[0].references_spec_t)); }
+#line 4215 "bison_parser.cpp"
     break;
 
-  case 103:
-#line 775 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.references_spec_t) = new ReferencesSpecification((yyvsp[-1].table_name).schema, (yyvsp[-1].table_name).name, (yyvsp[0].str_vec)); }
-#line 4030 "bison_parser.cpp" /* yacc.c:1646  */
+  case 103: /* references_spec: REFERENCES table_name opt_column_list  */
+#line 778 "bison_parser.y"
+                                                        { (yyval.references_spec_t) = new ReferencesSpecification((yyvsp[-1].table_name).schema, (yyvsp[-1].table_name).name, (yyvsp[0].str_vec)); }
+#line 4221 "bison_parser.cpp"
     break;
 
-  case 104:
-#line 783 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 104: /* drop_statement: DROP TABLE opt_exists table_name  */
+#line 786 "bison_parser.y"
+                                                  {
   (yyval.drop_stmt) = new DropStatement(kDropTable);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.drop_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 4041 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4232 "bison_parser.cpp"
     break;
 
-  case 105:
-#line 789 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 105: /* drop_statement: DROP VIEW opt_exists table_name  */
+#line 792 "bison_parser.y"
+                                  {
   (yyval.drop_stmt) = new DropStatement(kDropView);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.drop_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 4052 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4243 "bison_parser.cpp"
     break;
 
-  case 106:
-#line 795 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 106: /* drop_statement: DEALLOCATE PREPARE IDENTIFIER  */
+#line 798 "bison_parser.y"
+                                {
   (yyval.drop_stmt) = new DropStatement(kDropPreparedStatement);
   (yyval.drop_stmt)->ifExists = false;
   (yyval.drop_stmt)->name = (yyvsp[0].sval);
 }
-#line 4062 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4253 "bison_parser.cpp"
     break;
 
-  case 107:
-#line 801 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 107: /* drop_statement: DROP INDEX opt_exists IDENTIFIER  */
+#line 804 "bison_parser.y"
+                                   {
   (yyval.drop_stmt) = new DropStatement(kDropIndex);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->indexName = (yyvsp[0].sval);
 }
-#line 4072 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4263 "bison_parser.cpp"
     break;
 
-  case 108:
-#line 807 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = true; }
-#line 4078 "bison_parser.cpp" /* yacc.c:1646  */
+  case 108: /* opt_exists: IF EXISTS  */
+#line 810 "bison_parser.y"
+                       { (yyval.bval) = true; }
+#line 4269 "bison_parser.cpp"
     break;
 
-  case 109:
-#line 808 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = false; }
-#line 4084 "bison_parser.cpp" /* yacc.c:1646  */
+  case 109: /* opt_exists: %empty  */
+#line 811 "bison_parser.y"
+              { (yyval.bval) = false; }
+#line 4275 "bison_parser.cpp"
     break;
 
-  case 110:
-#line 815 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 110: /* alter_statement: ALTER TABLE opt_exists table_name alter_action  */
+#line 818 "bison_parser.y"
+                                                                 {
   (yyval.alter_stmt) = new AlterStatement((yyvsp[-1].table_name).name, (yyvsp[0].alter_action_t));
   (yyval.alter_stmt)->ifTableExists = (yyvsp[-2].bval);
   (yyval.alter_stmt)->schema = (yyvsp[-1].table_name).schema;
 }
-#line 4094 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4285 "bison_parser.cpp"
     break;
 
-  case 111:
-#line 821 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alter_action_t) = (yyvsp[0].drop_action_t); }
-#line 4100 "bison_parser.cpp" /* yacc.c:1646  */
+  case 111: /* alter_action: drop_action  */
+#line 824 "bison_parser.y"
+                           { (yyval.alter_action_t) = (yyvsp[0].drop_action_t); }
+#line 4291 "bison_parser.cpp"
     break;
 
-  case 112:
-#line 823 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 112: /* drop_action: DROP COLUMN opt_exists IDENTIFIER  */
+#line 826 "bison_parser.y"
+                                                {
   (yyval.drop_action_t) = new DropColumnAction((yyvsp[0].sval));
   (yyval.drop_action_t)->ifExists = (yyvsp[-1].bval);
 }
-#line 4109 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4300 "bison_parser.cpp"
     break;
 
-  case 113:
-#line 833 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 113: /* delete_statement: DELETE FROM table_name opt_where  */
+#line 836 "bison_parser.y"
+                                                    {
   (yyval.delete_stmt) = new DeleteStatement();
   (yyval.delete_stmt)->schema = (yyvsp[-1].table_name).schema;
   (yyval.delete_stmt)->tableName = (yyvsp[-1].table_name).name;
   (yyval.delete_stmt)->expr = (yyvsp[0].expr);
 }
-#line 4120 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4311 "bison_parser.cpp"
     break;
 
-  case 114:
-#line 840 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 114: /* truncate_statement: TRUNCATE table_name  */
+#line 843 "bison_parser.y"
+                                         {
   (yyval.delete_stmt) = new DeleteStatement();
   (yyval.delete_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.delete_stmt)->tableName = (yyvsp[0].table_name).name;
 }
-#line 4130 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4321 "bison_parser.cpp"
     break;
 
-  case 115:
-#line 851 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 115: /* insert_statement: INSERT INTO table_name opt_column_list VALUES '(' extended_literal_list ')'  */
+#line 854 "bison_parser.y"
+                                                                                               {
   (yyval.insert_stmt) = new InsertStatement(kInsertValues);
   (yyval.insert_stmt)->schema = (yyvsp[-5].table_name).schema;
   (yyval.insert_stmt)->tableName = (yyvsp[-5].table_name).name;
   (yyval.insert_stmt)->columns = (yyvsp[-4].str_vec);
   (yyval.insert_stmt)->values = (yyvsp[-1].expr_vec);
 }
-#line 4142 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4333 "bison_parser.cpp"
     break;
 
-  case 116:
-#line 858 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 116: /* insert_statement: INSERT INTO table_name opt_column_list select_no_paren  */
+#line 861 "bison_parser.y"
+                                                         {
   (yyval.insert_stmt) = new InsertStatement(kInsertSelect);
   (yyval.insert_stmt)->schema = (yyvsp[-2].table_name).schema;
   (yyval.insert_stmt)->tableName = (yyvsp[-2].table_name).name;
   (yyval.insert_stmt)->columns = (yyvsp[-1].str_vec);
   (yyval.insert_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 4154 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4345 "bison_parser.cpp"
     break;
 
-  case 117:
-#line 866 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.str_vec) = (yyvsp[-1].str_vec); }
-#line 4160 "bison_parser.cpp" /* yacc.c:1646  */
+  case 117: /* opt_column_list: '(' ident_commalist ')'  */
+#line 869 "bison_parser.y"
+                                          { (yyval.str_vec) = (yyvsp[-1].str_vec); }
+#line 4351 "bison_parser.cpp"
     break;
 
-  case 118:
-#line 867 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.str_vec) = nullptr; }
-#line 4166 "bison_parser.cpp" /* yacc.c:1646  */
+  case 118: /* opt_column_list: %empty  */
+#line 870 "bison_parser.y"
+              { (yyval.str_vec) = nullptr; }
+#line 4357 "bison_parser.cpp"
     break;
 
-  case 119:
-#line 874 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 119: /* update_statement: UPDATE table_ref_name_no_alias SET update_clause_commalist opt_where  */
+#line 877 "bison_parser.y"
+                                                                                        {
   (yyval.update_stmt) = new UpdateStatement();
   (yyval.update_stmt)->table = (yyvsp[-3].table);
   (yyval.update_stmt)->updates = (yyvsp[-1].update_vec);
   (yyval.update_stmt)->where = (yyvsp[0].expr);
 }
-#line 4177 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4368 "bison_parser.cpp"
     break;
 
-  case 120:
-#line 881 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 120: /* update_clause_commalist: update_clause  */
+#line 884 "bison_parser.y"
+                                        {
   (yyval.update_vec) = new std::vector<UpdateClause*>();
   (yyval.update_vec)->push_back((yyvsp[0].update_t));
 }
-#line 4186 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4377 "bison_parser.cpp"
     break;
 
-  case 121:
-#line 885 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 121: /* update_clause_commalist: update_clause_commalist ',' update_clause  */
+#line 888 "bison_parser.y"
+                                            {
   (yyvsp[-2].update_vec)->push_back((yyvsp[0].update_t));
   (yyval.update_vec) = (yyvsp[-2].update_vec);
 }
-#line 4195 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4386 "bison_parser.cpp"
     break;
 
-  case 122:
-#line 890 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 122: /* update_clause: IDENTIFIER '=' expr  */
+#line 893 "bison_parser.y"
+                                    {
   (yyval.update_t) = new UpdateClause();
   (yyval.update_t)->column = (yyvsp[-2].sval);
   (yyval.update_t)->value = (yyvsp[0].expr);
 }
-#line 4205 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4396 "bison_parser.cpp"
     break;
 
-  case 123:
-#line 900 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 123: /* select_statement: opt_with_clause select_with_paren  */
+#line 903 "bison_parser.y"
+                                                     {
   (yyval.select_stmt) = (yyvsp[0].select_stmt);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-1].with_description_vec);
 }
-#line 4214 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4405 "bison_parser.cpp"
     break;
 
-  case 124:
-#line 904 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 124: /* select_statement: opt_with_clause select_no_paren  */
+#line 907 "bison_parser.y"
+                                  {
   (yyval.select_stmt) = (yyvsp[0].select_stmt);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-1].with_description_vec);
 }
-#line 4223 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4414 "bison_parser.cpp"
     break;
 
-  case 125:
-#line 908 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 125: /* select_statement: opt_with_clause select_with_paren set_operator select_within_set_operation opt_order opt_limit  */
+#line 911 "bison_parser.y"
+                                                                                                 {
   (yyval.select_stmt) = (yyvsp[-4].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
     (yyval.select_stmt)->setOperations = new std::vector<SetOperation*>();
@@ -4235,18 +4426,18 @@ yyreduce:
   (yyval.select_stmt)->setOperations->back()->resultLimit = (yyvsp[0].limit);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-5].with_description_vec);
 }
-#line 4239 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4430 "bison_parser.cpp"
     break;
 
-  case 128:
-#line 922 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.select_stmt) = (yyvsp[0].select_stmt); }
-#line 4245 "bison_parser.cpp" /* yacc.c:1646  */
+  case 128: /* select_within_set_operation_no_parentheses: select_clause  */
+#line 925 "bison_parser.y"
+                                                           { (yyval.select_stmt) = (yyvsp[0].select_stmt); }
+#line 4436 "bison_parser.cpp"
     break;
 
-  case 129:
-#line 923 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 129: /* select_within_set_operation_no_parentheses: select_clause set_operator select_within_set_operation  */
+#line 926 "bison_parser.y"
+                                                         {
   (yyval.select_stmt) = (yyvsp[-2].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
     (yyval.select_stmt)->setOperations = new std::vector<SetOperation*>();
@@ -4254,24 +4445,24 @@ yyreduce:
   (yyval.select_stmt)->setOperations->push_back((yyvsp[-1].set_operator_t));
   (yyval.select_stmt)->setOperations->back()->nestedSelectStatement = (yyvsp[0].select_stmt);
 }
-#line 4258 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4449 "bison_parser.cpp"
     break;
 
-  case 130:
-#line 932 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 4264 "bison_parser.cpp" /* yacc.c:1646  */
+  case 130: /* select_with_paren: '(' select_no_paren ')'  */
+#line 935 "bison_parser.y"
+                                            { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
+#line 4455 "bison_parser.cpp"
     break;
 
-  case 131:
-#line 933 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 4270 "bison_parser.cpp" /* yacc.c:1646  */
+  case 131: /* select_with_paren: '(' select_with_paren ')'  */
+#line 936 "bison_parser.y"
+                            { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
+#line 4461 "bison_parser.cpp"
     break;
 
-  case 132:
-#line 935 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 132: /* select_no_paren: select_clause opt_order opt_limit opt_locking_clause  */
+#line 938 "bison_parser.y"
+                                                                       {
   (yyval.select_stmt) = (yyvsp[-3].select_stmt);
   (yyval.select_stmt)->order = (yyvsp[-2].order_vec);
 
@@ -4285,12 +4476,12 @@ yyreduce:
     (yyval.select_stmt)->lockings = (yyvsp[0].locking_clause_vec);
   }
 }
-#line 4289 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4480 "bison_parser.cpp"
     break;
 
-  case 133:
-#line 949 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 133: /* select_no_paren: select_clause set_operator select_within_set_operation opt_order opt_limit opt_locking_clause  */
+#line 952 "bison_parser.y"
+                                                                                                {
   (yyval.select_stmt) = (yyvsp[-5].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
     (yyval.select_stmt)->setOperations = new std::vector<SetOperation*>();
@@ -4301,60 +4492,60 @@ yyreduce:
   (yyval.select_stmt)->setOperations->back()->resultLimit = (yyvsp[-1].limit);
   (yyval.select_stmt)->lockings = (yyvsp[0].locking_clause_vec);
 }
-#line 4305 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4496 "bison_parser.cpp"
     break;
 
-  case 134:
-#line 961 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 134: /* set_operator: set_type opt_all  */
+#line 964 "bison_parser.y"
+                                {
   (yyval.set_operator_t) = (yyvsp[-1].set_operator_t);
   (yyval.set_operator_t)->isAll = (yyvsp[0].bval);
 }
-#line 4314 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4505 "bison_parser.cpp"
     break;
 
-  case 135:
-#line 966 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 135: /* set_type: UNION  */
+#line 969 "bison_parser.y"
+                 {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetUnion;
 }
-#line 4323 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4514 "bison_parser.cpp"
     break;
 
-  case 136:
-#line 970 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 136: /* set_type: INTERSECT  */
+#line 973 "bison_parser.y"
+            {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetIntersect;
 }
-#line 4332 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4523 "bison_parser.cpp"
     break;
 
-  case 137:
-#line 974 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 137: /* set_type: EXCEPT  */
+#line 977 "bison_parser.y"
+         {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetExcept;
 }
-#line 4341 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4532 "bison_parser.cpp"
     break;
 
-  case 138:
-#line 979 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = true; }
-#line 4347 "bison_parser.cpp" /* yacc.c:1646  */
+  case 138: /* opt_all: ALL  */
+#line 982 "bison_parser.y"
+              { (yyval.bval) = true; }
+#line 4538 "bison_parser.cpp"
     break;
 
-  case 139:
-#line 980 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = false; }
-#line 4353 "bison_parser.cpp" /* yacc.c:1646  */
+  case 139: /* opt_all: %empty  */
+#line 983 "bison_parser.y"
+              { (yyval.bval) = false; }
+#line 4544 "bison_parser.cpp"
     break;
 
-  case 140:
-#line 982 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 140: /* select_clause: SELECT opt_top opt_distinct select_list opt_from_clause opt_where opt_group  */
+#line 985 "bison_parser.y"
+                                                                                            {
   (yyval.select_stmt) = new SelectStatement();
   (yyval.select_stmt)->limit = (yyvsp[-5].limit);
   (yyval.select_stmt)->selectDistinct = (yyvsp[-4].bval);
@@ -4363,142 +4554,142 @@ yyreduce:
   (yyval.select_stmt)->whereClause = (yyvsp[-1].expr);
   (yyval.select_stmt)->groupBy = (yyvsp[0].group_t);
 }
-#line 4367 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4558 "bison_parser.cpp"
     break;
 
-  case 141:
-#line 992 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = true; }
-#line 4373 "bison_parser.cpp" /* yacc.c:1646  */
+  case 141: /* opt_distinct: DISTINCT  */
+#line 995 "bison_parser.y"
+                        { (yyval.bval) = true; }
+#line 4564 "bison_parser.cpp"
     break;
 
-  case 142:
-#line 993 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = false; }
-#line 4379 "bison_parser.cpp" /* yacc.c:1646  */
+  case 142: /* opt_distinct: %empty  */
+#line 996 "bison_parser.y"
+              { (yyval.bval) = false; }
+#line 4570 "bison_parser.cpp"
     break;
 
-  case 144:
-#line 997 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table) = (yyvsp[0].table); }
-#line 4385 "bison_parser.cpp" /* yacc.c:1646  */
+  case 144: /* opt_from_clause: from_clause  */
+#line 1000 "bison_parser.y"
+                              { (yyval.table) = (yyvsp[0].table); }
+#line 4576 "bison_parser.cpp"
     break;
 
-  case 145:
-#line 998 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table) = nullptr; }
-#line 4391 "bison_parser.cpp" /* yacc.c:1646  */
+  case 145: /* opt_from_clause: %empty  */
+#line 1001 "bison_parser.y"
+              { (yyval.table) = nullptr; }
+#line 4582 "bison_parser.cpp"
     break;
 
-  case 146:
-#line 1000 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table) = (yyvsp[0].table); }
-#line 4397 "bison_parser.cpp" /* yacc.c:1646  */
+  case 146: /* from_clause: FROM table_ref  */
+#line 1003 "bison_parser.y"
+                             { (yyval.table) = (yyvsp[0].table); }
+#line 4588 "bison_parser.cpp"
     break;
 
-  case 147:
-#line 1002 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = (yyvsp[0].expr); }
-#line 4403 "bison_parser.cpp" /* yacc.c:1646  */
+  case 147: /* opt_where: WHERE expr  */
+#line 1005 "bison_parser.y"
+                       { (yyval.expr) = (yyvsp[0].expr); }
+#line 4594 "bison_parser.cpp"
     break;
 
-  case 148:
-#line 1003 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = nullptr; }
-#line 4409 "bison_parser.cpp" /* yacc.c:1646  */
+  case 148: /* opt_where: %empty  */
+#line 1006 "bison_parser.y"
+              { (yyval.expr) = nullptr; }
+#line 4600 "bison_parser.cpp"
     break;
 
-  case 149:
-#line 1005 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 149: /* opt_group: GROUP BY expr_list opt_having  */
+#line 1008 "bison_parser.y"
+                                          {
   (yyval.group_t) = new GroupByDescription();
   (yyval.group_t)->columns = (yyvsp[-1].expr_vec);
   (yyval.group_t)->having = (yyvsp[0].expr);
 }
-#line 4419 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4610 "bison_parser.cpp"
     break;
 
-  case 150:
-#line 1010 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.group_t) = nullptr; }
-#line 4425 "bison_parser.cpp" /* yacc.c:1646  */
+  case 150: /* opt_group: %empty  */
+#line 1013 "bison_parser.y"
+              { (yyval.group_t) = nullptr; }
+#line 4616 "bison_parser.cpp"
     break;
 
-  case 151:
-#line 1012 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = (yyvsp[0].expr); }
-#line 4431 "bison_parser.cpp" /* yacc.c:1646  */
+  case 151: /* opt_having: HAVING expr  */
+#line 1015 "bison_parser.y"
+                         { (yyval.expr) = (yyvsp[0].expr); }
+#line 4622 "bison_parser.cpp"
     break;
 
-  case 152:
-#line 1013 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = nullptr; }
-#line 4437 "bison_parser.cpp" /* yacc.c:1646  */
+  case 152: /* opt_having: %empty  */
+#line 1016 "bison_parser.y"
+              { (yyval.expr) = nullptr; }
+#line 4628 "bison_parser.cpp"
     break;
 
-  case 153:
-#line 1015 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order_vec) = (yyvsp[0].order_vec); }
-#line 4443 "bison_parser.cpp" /* yacc.c:1646  */
+  case 153: /* opt_order: ORDER BY order_list  */
+#line 1018 "bison_parser.y"
+                                { (yyval.order_vec) = (yyvsp[0].order_vec); }
+#line 4634 "bison_parser.cpp"
     break;
 
-  case 154:
-#line 1016 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order_vec) = nullptr; }
-#line 4449 "bison_parser.cpp" /* yacc.c:1646  */
+  case 154: /* opt_order: %empty  */
+#line 1019 "bison_parser.y"
+              { (yyval.order_vec) = nullptr; }
+#line 4640 "bison_parser.cpp"
     break;
 
-  case 155:
-#line 1018 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 155: /* order_list: order_desc  */
+#line 1021 "bison_parser.y"
+                        {
   (yyval.order_vec) = new std::vector<OrderDescription*>();
   (yyval.order_vec)->push_back((yyvsp[0].order));
 }
-#line 4458 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4649 "bison_parser.cpp"
     break;
 
-  case 156:
-#line 1022 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 156: /* order_list: order_list ',' order_desc  */
+#line 1025 "bison_parser.y"
+                            {
   (yyvsp[-2].order_vec)->push_back((yyvsp[0].order));
   (yyval.order_vec) = (yyvsp[-2].order_vec);
 }
-#line 4467 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4658 "bison_parser.cpp"
     break;
 
-  case 157:
-#line 1027 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order) = new OrderDescription((yyvsp[-1].order_type), (yyvsp[-2].expr), (yyvsp[0].null_ordering_t)); }
-#line 4473 "bison_parser.cpp" /* yacc.c:1646  */
+  case 157: /* order_desc: expr opt_order_type opt_null_ordering  */
+#line 1030 "bison_parser.y"
+                                                   { (yyval.order) = new OrderDescription((yyvsp[-1].order_type), (yyvsp[-2].expr), (yyvsp[0].null_ordering_t)); }
+#line 4664 "bison_parser.cpp"
     break;
 
-  case 158:
-#line 1029 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order_type) = kOrderAsc; }
-#line 4479 "bison_parser.cpp" /* yacc.c:1646  */
+  case 158: /* opt_order_type: ASC  */
+#line 1032 "bison_parser.y"
+                     { (yyval.order_type) = kOrderAsc; }
+#line 4670 "bison_parser.cpp"
     break;
 
-  case 159:
-#line 1030 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order_type) = kOrderDesc; }
-#line 4485 "bison_parser.cpp" /* yacc.c:1646  */
+  case 159: /* opt_order_type: DESC  */
+#line 1033 "bison_parser.y"
+       { (yyval.order_type) = kOrderDesc; }
+#line 4676 "bison_parser.cpp"
     break;
 
-  case 160:
-#line 1031 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order_type) = kOrderAsc; }
-#line 4491 "bison_parser.cpp" /* yacc.c:1646  */
+  case 160: /* opt_order_type: %empty  */
+#line 1034 "bison_parser.y"
+              { (yyval.order_type) = kOrderAsc; }
+#line 4682 "bison_parser.cpp"
     break;
 
-  case 161:
-#line 1033 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.null_ordering_t) = NullOrdering::Undefined; }
-#line 4497 "bison_parser.cpp" /* yacc.c:1646  */
+  case 161: /* opt_null_ordering: %empty  */
+#line 1036 "bison_parser.y"
+                                { (yyval.null_ordering_t) = NullOrdering::Undefined; }
+#line 4688 "bison_parser.cpp"
     break;
 
-  case 162:
-#line 1034 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 162: /* opt_null_ordering: IDENTIFIER IDENTIFIER  */
+#line 1037 "bison_parser.y"
+                        {
   auto null_ordering = NullOrdering::Undefined;
   if (strcasecmp((yyvsp[-1].sval), "nulls") == 0) {
     if (strcasecmp((yyvsp[0].sval), "first") == 0) {
@@ -4517,116 +4708,116 @@ yyreduce:
 
   (yyval.null_ordering_t) = null_ordering;
 }
-#line 4521 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4712 "bison_parser.cpp"
     break;
 
-  case 163:
-#line 1056 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
-#line 4527 "bison_parser.cpp" /* yacc.c:1646  */
+  case 163: /* opt_top: TOP int_literal  */
+#line 1059 "bison_parser.y"
+                          { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
+#line 4718 "bison_parser.cpp"
     break;
 
-  case 164:
-#line 1057 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = nullptr; }
-#line 4533 "bison_parser.cpp" /* yacc.c:1646  */
+  case 164: /* opt_top: %empty  */
+#line 1060 "bison_parser.y"
+              { (yyval.limit) = nullptr; }
+#line 4724 "bison_parser.cpp"
     break;
 
-  case 165:
-#line 1059 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
-#line 4539 "bison_parser.cpp" /* yacc.c:1646  */
+  case 165: /* opt_limit: LIMIT expr  */
+#line 1062 "bison_parser.y"
+                       { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
+#line 4730 "bison_parser.cpp"
     break;
 
-  case 166:
-#line 1060 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
-#line 4545 "bison_parser.cpp" /* yacc.c:1646  */
+  case 166: /* opt_limit: OFFSET expr  */
+#line 1063 "bison_parser.y"
+              { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
+#line 4736 "bison_parser.cpp"
     break;
 
-  case 167:
-#line 1061 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription((yyvsp[-2].expr), (yyvsp[0].expr)); }
-#line 4551 "bison_parser.cpp" /* yacc.c:1646  */
+  case 167: /* opt_limit: LIMIT expr OFFSET expr  */
+#line 1064 "bison_parser.y"
+                         { (yyval.limit) = new LimitDescription((yyvsp[-2].expr), (yyvsp[0].expr)); }
+#line 4742 "bison_parser.cpp"
     break;
 
-  case 168:
-#line 1062 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription(nullptr, nullptr); }
-#line 4557 "bison_parser.cpp" /* yacc.c:1646  */
+  case 168: /* opt_limit: LIMIT ALL  */
+#line 1065 "bison_parser.y"
+            { (yyval.limit) = new LimitDescription(nullptr, nullptr); }
+#line 4748 "bison_parser.cpp"
     break;
 
-  case 169:
-#line 1063 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
-#line 4563 "bison_parser.cpp" /* yacc.c:1646  */
+  case 169: /* opt_limit: LIMIT ALL OFFSET expr  */
+#line 1066 "bison_parser.y"
+                        { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
+#line 4754 "bison_parser.cpp"
     break;
 
-  case 170:
-#line 1064 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = nullptr; }
-#line 4569 "bison_parser.cpp" /* yacc.c:1646  */
+  case 170: /* opt_limit: %empty  */
+#line 1067 "bison_parser.y"
+              { (yyval.limit) = nullptr; }
+#line 4760 "bison_parser.cpp"
     break;
 
-  case 171:
-#line 1069 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 171: /* expr_list: expr_alias  */
+#line 1072 "bison_parser.y"
+                       {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 4578 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4769 "bison_parser.cpp"
     break;
 
-  case 172:
-#line 1073 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 172: /* expr_list: expr_list ',' expr_alias  */
+#line 1076 "bison_parser.y"
+                           {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 4587 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4778 "bison_parser.cpp"
     break;
 
-  case 173:
-#line 1079 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
-#line 4593 "bison_parser.cpp" /* yacc.c:1646  */
+  case 173: /* opt_extended_literal_list: extended_literal_list  */
+#line 1082 "bison_parser.y"
+                                                  { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
+#line 4784 "bison_parser.cpp"
     break;
 
-  case 174:
-#line 1080 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = nullptr; }
-#line 4599 "bison_parser.cpp" /* yacc.c:1646  */
+  case 174: /* opt_extended_literal_list: %empty  */
+#line 1083 "bison_parser.y"
+              { (yyval.expr_vec) = nullptr; }
+#line 4790 "bison_parser.cpp"
     break;
 
-  case 175:
-#line 1082 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 175: /* extended_literal_list: casted_extended_literal  */
+#line 1085 "bison_parser.y"
+                                                {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 4608 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4799 "bison_parser.cpp"
     break;
 
-  case 176:
-#line 1086 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 176: /* extended_literal_list: extended_literal_list ',' casted_extended_literal  */
+#line 1089 "bison_parser.y"
+                                                    {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 4617 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4808 "bison_parser.cpp"
     break;
 
-  case 178:
-#line 1091 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 178: /* casted_extended_literal: CAST '(' extended_literal AS column_type ')'  */
+#line 1094 "bison_parser.y"
+                                                                                          {
   (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t));
 }
-#line 4625 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4816 "bison_parser.cpp"
     break;
 
-  case 179:
-#line 1095 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 179: /* extended_literal: literal  */
+#line 1098 "bison_parser.y"
+                           {
   if ((yyvsp[0].expr)->type == ExprType::kExprParameter) {
     delete (yyvsp[0].expr);
     yyerror(&yyloc, result, scanner, "Parameter ? is not a valid literal.");
@@ -4634,24 +4825,24 @@ yyreduce:
   }
   (yyval.expr) = (yyvsp[0].expr);
 }
-#line 4638 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4829 "bison_parser.cpp"
     break;
 
-  case 180:
-#line 1103 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4644 "bison_parser.cpp" /* yacc.c:1646  */
+  case 180: /* extended_literal: '-' num_literal  */
+#line 1106 "bison_parser.y"
+                  { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
+#line 4835 "bison_parser.cpp"
     break;
 
-  case 181:
-#line 1104 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4650 "bison_parser.cpp" /* yacc.c:1646  */
+  case 181: /* extended_literal: '-' interval_literal  */
+#line 1107 "bison_parser.y"
+                       { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
+#line 4841 "bison_parser.cpp"
     break;
 
-  case 182:
-#line 1106 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 182: /* expr_alias: expr opt_alias  */
+#line 1109 "bison_parser.y"
+                            {
   (yyval.expr) = (yyvsp[-1].expr);
   if ((yyvsp[0].alias_t)) {
     (yyval.expr)->alias = (yyvsp[0].alias_t)->name;
@@ -4659,520 +4850,524 @@ yyreduce:
     delete (yyvsp[0].alias_t);
   }
 }
-#line 4663 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4854 "bison_parser.cpp"
     break;
 
-  case 188:
-#line 1117 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = (yyvsp[-1].expr); }
-#line 4669 "bison_parser.cpp" /* yacc.c:1646  */
+  case 188: /* operand: '(' expr ')'  */
+#line 1120 "bison_parser.y"
+                       { (yyval.expr) = (yyvsp[-1].expr); }
+#line 4860 "bison_parser.cpp"
     break;
 
-  case 198:
-#line 1119 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 198: /* operand: '(' select_no_paren ')'  */
+#line 1122 "bison_parser.y"
+                                         {
   (yyval.expr) = Expr::makeSelect((yyvsp[-1].select_stmt));
 }
-#line 4677 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4868 "bison_parser.cpp"
     break;
 
-  case 201:
-#line 1125 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4683 "bison_parser.cpp" /* yacc.c:1646  */
+  case 201: /* unary_expr: '-' operand  */
+#line 1128 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
+#line 4874 "bison_parser.cpp"
     break;
 
-  case 202:
-#line 1126 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpNot, (yyvsp[0].expr)); }
-#line 4689 "bison_parser.cpp" /* yacc.c:1646  */
+  case 202: /* unary_expr: NOT operand  */
+#line 1129 "bison_parser.y"
+              { (yyval.expr) = Expr::makeOpUnary(kOpNot, (yyvsp[0].expr)); }
+#line 4880 "bison_parser.cpp"
     break;
 
-  case 203:
-#line 1127 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-1].expr)); }
-#line 4695 "bison_parser.cpp" /* yacc.c:1646  */
+  case 203: /* unary_expr: operand ISNULL  */
+#line 1130 "bison_parser.y"
+                 { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-1].expr)); }
+#line 4886 "bison_parser.cpp"
     break;
 
-  case 204:
-#line 1128 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-2].expr)); }
-#line 4701 "bison_parser.cpp" /* yacc.c:1646  */
+  case 204: /* unary_expr: operand IS NULL  */
+#line 1131 "bison_parser.y"
+                  { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-2].expr)); }
+#line 4892 "bison_parser.cpp"
     break;
 
-  case 205:
-#line 1129 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeOpUnary(kOpIsNull, (yyvsp[-3].expr))); }
-#line 4707 "bison_parser.cpp" /* yacc.c:1646  */
+  case 205: /* unary_expr: operand IS NOT NULL  */
+#line 1132 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeOpUnary(kOpIsNull, (yyvsp[-3].expr))); }
+#line 4898 "bison_parser.cpp"
     break;
 
-  case 207:
-#line 1131 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpMinus, (yyvsp[0].expr)); }
-#line 4713 "bison_parser.cpp" /* yacc.c:1646  */
+  case 207: /* binary_expr: operand '-' operand  */
+#line 1134 "bison_parser.y"
+                                              { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpMinus, (yyvsp[0].expr)); }
+#line 4904 "bison_parser.cpp"
     break;
 
-  case 208:
-#line 1132 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPlus, (yyvsp[0].expr)); }
-#line 4719 "bison_parser.cpp" /* yacc.c:1646  */
+  case 208: /* binary_expr: operand '+' operand  */
+#line 1135 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPlus, (yyvsp[0].expr)); }
+#line 4910 "bison_parser.cpp"
     break;
 
-  case 209:
-#line 1133 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpSlash, (yyvsp[0].expr)); }
-#line 4725 "bison_parser.cpp" /* yacc.c:1646  */
+  case 209: /* binary_expr: operand '/' operand  */
+#line 1136 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpSlash, (yyvsp[0].expr)); }
+#line 4916 "bison_parser.cpp"
     break;
 
-  case 210:
-#line 1134 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAsterisk, (yyvsp[0].expr)); }
-#line 4731 "bison_parser.cpp" /* yacc.c:1646  */
+  case 210: /* binary_expr: operand '*' operand  */
+#line 1137 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAsterisk, (yyvsp[0].expr)); }
+#line 4922 "bison_parser.cpp"
     break;
 
-  case 211:
-#line 1135 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPercentage, (yyvsp[0].expr)); }
-#line 4737 "bison_parser.cpp" /* yacc.c:1646  */
+  case 211: /* binary_expr: operand '%' operand  */
+#line 1138 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPercentage, (yyvsp[0].expr)); }
+#line 4928 "bison_parser.cpp"
     break;
 
-  case 212:
-#line 1136 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpCaret, (yyvsp[0].expr)); }
-#line 4743 "bison_parser.cpp" /* yacc.c:1646  */
+  case 212: /* binary_expr: operand '^' operand  */
+#line 1139 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpCaret, (yyvsp[0].expr)); }
+#line 4934 "bison_parser.cpp"
     break;
 
-  case 213:
-#line 1137 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLike, (yyvsp[0].expr)); }
-#line 4749 "bison_parser.cpp" /* yacc.c:1646  */
+  case 213: /* binary_expr: operand LIKE operand  */
+#line 1140 "bison_parser.y"
+                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLike, (yyvsp[0].expr)); }
+#line 4940 "bison_parser.cpp"
     break;
 
-  case 214:
-#line 1138 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-3].expr), kOpNotLike, (yyvsp[0].expr)); }
-#line 4755 "bison_parser.cpp" /* yacc.c:1646  */
+  case 214: /* binary_expr: operand NOT LIKE operand  */
+#line 1141 "bison_parser.y"
+                           { (yyval.expr) = Expr::makeOpBinary((yyvsp[-3].expr), kOpNotLike, (yyvsp[0].expr)); }
+#line 4946 "bison_parser.cpp"
     break;
 
-  case 215:
-#line 1139 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpILike, (yyvsp[0].expr)); }
-#line 4761 "bison_parser.cpp" /* yacc.c:1646  */
+  case 215: /* binary_expr: operand ILIKE operand  */
+#line 1142 "bison_parser.y"
+                        { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpILike, (yyvsp[0].expr)); }
+#line 4952 "bison_parser.cpp"
     break;
 
-  case 216:
-#line 1140 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpConcat, (yyvsp[0].expr)); }
-#line 4767 "bison_parser.cpp" /* yacc.c:1646  */
+  case 216: /* binary_expr: operand CONCAT operand  */
+#line 1143 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpConcat, (yyvsp[0].expr)); }
+#line 4958 "bison_parser.cpp"
     break;
 
-  case 217:
-#line 1142 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAnd, (yyvsp[0].expr)); }
-#line 4773 "bison_parser.cpp" /* yacc.c:1646  */
+  case 217: /* logic_expr: expr AND expr  */
+#line 1145 "bison_parser.y"
+                           { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAnd, (yyvsp[0].expr)); }
+#line 4964 "bison_parser.cpp"
     break;
 
-  case 218:
-#line 1143 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpOr, (yyvsp[0].expr)); }
-#line 4779 "bison_parser.cpp" /* yacc.c:1646  */
+  case 218: /* logic_expr: expr OR expr  */
+#line 1146 "bison_parser.y"
+               { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpOr, (yyvsp[0].expr)); }
+#line 4970 "bison_parser.cpp"
     break;
 
-  case 219:
-#line 1145 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].expr_vec)); }
-#line 4785 "bison_parser.cpp" /* yacc.c:1646  */
+  case 219: /* in_expr: operand IN '(' expr_list ')'  */
+#line 1148 "bison_parser.y"
+                                       { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].expr_vec)); }
+#line 4976 "bison_parser.cpp"
     break;
 
-  case 220:
-#line 1146 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].expr_vec))); }
-#line 4791 "bison_parser.cpp" /* yacc.c:1646  */
+  case 220: /* in_expr: operand NOT IN '(' expr_list ')'  */
+#line 1149 "bison_parser.y"
+                                   { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].expr_vec))); }
+#line 4982 "bison_parser.cpp"
     break;
 
-  case 221:
-#line 1147 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].select_stmt)); }
-#line 4797 "bison_parser.cpp" /* yacc.c:1646  */
+  case 221: /* in_expr: operand IN '(' select_no_paren ')'  */
+#line 1150 "bison_parser.y"
+                                     { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].select_stmt)); }
+#line 4988 "bison_parser.cpp"
     break;
 
-  case 222:
-#line 1148 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].select_stmt))); }
-#line 4803 "bison_parser.cpp" /* yacc.c:1646  */
+  case 222: /* in_expr: operand NOT IN '(' select_no_paren ')'  */
+#line 1151 "bison_parser.y"
+                                         { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].select_stmt))); }
+#line 4994 "bison_parser.cpp"
     break;
 
-  case 223:
-#line 1152 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCase((yyvsp[-2].expr), (yyvsp[-1].expr), nullptr); }
-#line 4809 "bison_parser.cpp" /* yacc.c:1646  */
+  case 223: /* case_expr: CASE expr case_list END  */
+#line 1155 "bison_parser.y"
+                                    { (yyval.expr) = Expr::makeCase((yyvsp[-2].expr), (yyvsp[-1].expr), nullptr); }
+#line 5000 "bison_parser.cpp"
     break;
 
-  case 224:
-#line 1153 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCase((yyvsp[-4].expr), (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 4815 "bison_parser.cpp" /* yacc.c:1646  */
+  case 224: /* case_expr: CASE expr case_list ELSE expr END  */
+#line 1156 "bison_parser.y"
+                                    { (yyval.expr) = Expr::makeCase((yyvsp[-4].expr), (yyvsp[-3].expr), (yyvsp[-1].expr)); }
+#line 5006 "bison_parser.cpp"
     break;
 
-  case 225:
-#line 1154 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-1].expr), nullptr); }
-#line 4821 "bison_parser.cpp" /* yacc.c:1646  */
+  case 225: /* case_expr: CASE case_list END  */
+#line 1157 "bison_parser.y"
+                     { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-1].expr), nullptr); }
+#line 5012 "bison_parser.cpp"
     break;
 
-  case 226:
-#line 1155 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 4827 "bison_parser.cpp" /* yacc.c:1646  */
+  case 226: /* case_expr: CASE case_list ELSE expr END  */
+#line 1158 "bison_parser.y"
+                               { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-3].expr), (yyvsp[-1].expr)); }
+#line 5018 "bison_parser.cpp"
     break;
 
-  case 227:
-#line 1157 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCaseList(Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
-#line 4833 "bison_parser.cpp" /* yacc.c:1646  */
+  case 227: /* case_list: WHEN expr THEN expr  */
+#line 1160 "bison_parser.y"
+                                { (yyval.expr) = Expr::makeCaseList(Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
+#line 5024 "bison_parser.cpp"
     break;
 
-  case 228:
-#line 1158 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::caseListAppend((yyvsp[-4].expr), Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
-#line 4839 "bison_parser.cpp" /* yacc.c:1646  */
+  case 228: /* case_list: case_list WHEN expr THEN expr  */
+#line 1161 "bison_parser.y"
+                                { (yyval.expr) = Expr::caseListAppend((yyvsp[-4].expr), Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
+#line 5030 "bison_parser.cpp"
     break;
 
-  case 229:
-#line 1160 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeExists((yyvsp[-1].select_stmt)); }
-#line 4845 "bison_parser.cpp" /* yacc.c:1646  */
+  case 229: /* exists_expr: EXISTS '(' select_no_paren ')'  */
+#line 1163 "bison_parser.y"
+                                             { (yyval.expr) = Expr::makeExists((yyvsp[-1].select_stmt)); }
+#line 5036 "bison_parser.cpp"
     break;
 
-  case 230:
-#line 1161 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeExists((yyvsp[-1].select_stmt))); }
-#line 4851 "bison_parser.cpp" /* yacc.c:1646  */
+  case 230: /* exists_expr: NOT EXISTS '(' select_no_paren ')'  */
+#line 1164 "bison_parser.y"
+                                     { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeExists((yyvsp[-1].select_stmt))); }
+#line 5042 "bison_parser.cpp"
     break;
 
-  case 231:
-#line 1163 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
-#line 4857 "bison_parser.cpp" /* yacc.c:1646  */
+  case 231: /* comp_expr: operand '=' operand  */
+#line 1166 "bison_parser.y"
+                                { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
+#line 5048 "bison_parser.cpp"
     break;
 
-  case 232:
-#line 1164 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
-#line 4863 "bison_parser.cpp" /* yacc.c:1646  */
+  case 232: /* comp_expr: operand EQUALS operand  */
+#line 1167 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
+#line 5054 "bison_parser.cpp"
     break;
 
-  case 233:
-#line 1165 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpNotEquals, (yyvsp[0].expr)); }
-#line 4869 "bison_parser.cpp" /* yacc.c:1646  */
+  case 233: /* comp_expr: operand NOTEQUALS operand  */
+#line 1168 "bison_parser.y"
+                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpNotEquals, (yyvsp[0].expr)); }
+#line 5060 "bison_parser.cpp"
     break;
 
-  case 234:
-#line 1166 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLess, (yyvsp[0].expr)); }
-#line 4875 "bison_parser.cpp" /* yacc.c:1646  */
+  case 234: /* comp_expr: operand '<' operand  */
+#line 1169 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLess, (yyvsp[0].expr)); }
+#line 5066 "bison_parser.cpp"
     break;
 
-  case 235:
-#line 1167 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreater, (yyvsp[0].expr)); }
-#line 4881 "bison_parser.cpp" /* yacc.c:1646  */
+  case 235: /* comp_expr: operand '>' operand  */
+#line 1170 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreater, (yyvsp[0].expr)); }
+#line 5072 "bison_parser.cpp"
     break;
 
-  case 236:
-#line 1168 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLessEq, (yyvsp[0].expr)); }
-#line 4887 "bison_parser.cpp" /* yacc.c:1646  */
+  case 236: /* comp_expr: operand LESSEQ operand  */
+#line 1171 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLessEq, (yyvsp[0].expr)); }
+#line 5078 "bison_parser.cpp"
     break;
 
-  case 237:
-#line 1169 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreaterEq, (yyvsp[0].expr)); }
-#line 4893 "bison_parser.cpp" /* yacc.c:1646  */
+  case 237: /* comp_expr: operand GREATEREQ operand  */
+#line 1172 "bison_parser.y"
+                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreaterEq, (yyvsp[0].expr)); }
+#line 5084 "bison_parser.cpp"
     break;
 
-  case 238:
-#line 1173 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
-#line 4899 "bison_parser.cpp" /* yacc.c:1646  */
+  case 238: /* function_expr: IDENTIFIER '(' ')' opt_window  */
+#line 1176 "bison_parser.y"
+                                              { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
+#line 5090 "bison_parser.cpp"
     break;
 
-  case 239:
-#line 1174 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
-#line 4905 "bison_parser.cpp" /* yacc.c:1646  */
+  case 239: /* function_expr: IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
+#line 1177 "bison_parser.y"
+                                                       { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
+#line 5096 "bison_parser.cpp"
     break;
 
-  case 240:
-#line 1175 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), (yyvsp[-5].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
-#line 4911 "bison_parser.cpp" /* yacc.c:1646  */
+  case 240: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' ')' opt_window  */
+#line 1178 "bison_parser.y"
+                                               {
+  (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), (yyvsp[-5].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description));
+}
+#line 5104 "bison_parser.cpp"
     break;
 
-  case 241:
-#line 1176 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-7].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
-#line 4917 "bison_parser.cpp" /* yacc.c:1646  */
+  case 241: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
+#line 1181 "bison_parser.y"
+                                                                      {
+  (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-7].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description));
+}
+#line 5112 "bison_parser.cpp"
     break;
 
-  case 242:
-#line 1180 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.window_description) = new WindowDescription((yyvsp[-3].expr_vec), (yyvsp[-2].order_vec), (yyvsp[-1].frame_description)); }
-#line 4923 "bison_parser.cpp" /* yacc.c:1646  */
+  case 242: /* opt_window: OVER '(' opt_partition opt_order opt_frame_clause ')'  */
+#line 1187 "bison_parser.y"
+                                                                   { (yyval.window_description) = new WindowDescription((yyvsp[-3].expr_vec), (yyvsp[-2].order_vec), (yyvsp[-1].frame_description)); }
+#line 5118 "bison_parser.cpp"
     break;
 
-  case 243:
-#line 1181 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.window_description) = nullptr; }
-#line 4929 "bison_parser.cpp" /* yacc.c:1646  */
+  case 243: /* opt_window: %empty  */
+#line 1188 "bison_parser.y"
+              { (yyval.window_description) = nullptr; }
+#line 5124 "bison_parser.cpp"
     break;
 
-  case 244:
-#line 1183 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
-#line 4935 "bison_parser.cpp" /* yacc.c:1646  */
+  case 244: /* opt_partition: PARTITION BY expr_list  */
+#line 1190 "bison_parser.y"
+                                       { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
+#line 5130 "bison_parser.cpp"
     break;
 
-  case 245:
-#line 1184 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = nullptr; }
-#line 4941 "bison_parser.cpp" /* yacc.c:1646  */
+  case 245: /* opt_partition: %empty  */
+#line 1191 "bison_parser.y"
+              { (yyval.expr_vec) = nullptr; }
+#line 5136 "bison_parser.cpp"
     break;
 
-  case 246:
-#line 1189 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_description) = new FrameDescription{(yyvsp[-1].frame_type), (yyvsp[0].frame_bound), new FrameBound{0, kCurrentRow, false}}; }
-#line 4947 "bison_parser.cpp" /* yacc.c:1646  */
+  case 246: /* opt_frame_clause: frame_type frame_bound  */
+#line 1196 "bison_parser.y"
+                                          { (yyval.frame_description) = new FrameDescription{(yyvsp[-1].frame_type), (yyvsp[0].frame_bound), new FrameBound{0, kCurrentRow, false}}; }
+#line 5142 "bison_parser.cpp"
     break;
 
-  case 247:
-#line 1190 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_description) = new FrameDescription{(yyvsp[-4].frame_type), (yyvsp[-2].frame_bound), (yyvsp[0].frame_bound)}; }
-#line 4953 "bison_parser.cpp" /* yacc.c:1646  */
+  case 247: /* opt_frame_clause: frame_type BETWEEN frame_bound AND frame_bound  */
+#line 1197 "bison_parser.y"
+                                                 { (yyval.frame_description) = new FrameDescription{(yyvsp[-4].frame_type), (yyvsp[-2].frame_bound), (yyvsp[0].frame_bound)}; }
+#line 5148 "bison_parser.cpp"
     break;
 
-  case 248:
-#line 1191 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 248: /* opt_frame_clause: %empty  */
+#line 1198 "bison_parser.y"
+              {
   (yyval.frame_description) = new FrameDescription{kRange, new FrameBound{0, kPreceding, true}, new FrameBound{0, kCurrentRow, false}};
 }
-#line 4961 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5156 "bison_parser.cpp"
     break;
 
-  case 249:
-#line 1195 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_type) = kRange; }
-#line 4967 "bison_parser.cpp" /* yacc.c:1646  */
+  case 249: /* frame_type: RANGE  */
+#line 1202 "bison_parser.y"
+                   { (yyval.frame_type) = kRange; }
+#line 5162 "bison_parser.cpp"
     break;
 
-  case 250:
-#line 1196 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_type) = kRows; }
-#line 4973 "bison_parser.cpp" /* yacc.c:1646  */
+  case 250: /* frame_type: ROWS  */
+#line 1203 "bison_parser.y"
+       { (yyval.frame_type) = kRows; }
+#line 5168 "bison_parser.cpp"
     break;
 
-  case 251:
-#line 1197 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_type) = kGroups; }
-#line 4979 "bison_parser.cpp" /* yacc.c:1646  */
+  case 251: /* frame_type: GROUPS  */
+#line 1204 "bison_parser.y"
+         { (yyval.frame_type) = kGroups; }
+#line 5174 "bison_parser.cpp"
     break;
 
-  case 252:
-#line 1199 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_bound) = new FrameBound{0, kPreceding, true}; }
-#line 4985 "bison_parser.cpp" /* yacc.c:1646  */
+  case 252: /* frame_bound: UNBOUNDED PRECEDING  */
+#line 1206 "bison_parser.y"
+                                  { (yyval.frame_bound) = new FrameBound{0, kPreceding, true}; }
+#line 5180 "bison_parser.cpp"
     break;
 
-  case 253:
-#line 1200 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kPreceding, false}; }
-#line 4991 "bison_parser.cpp" /* yacc.c:1646  */
+  case 253: /* frame_bound: INTVAL PRECEDING  */
+#line 1207 "bison_parser.y"
+                   { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kPreceding, false}; }
+#line 5186 "bison_parser.cpp"
     break;
 
-  case 254:
-#line 1201 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_bound) = new FrameBound{0, kFollowing, true}; }
-#line 4997 "bison_parser.cpp" /* yacc.c:1646  */
+  case 254: /* frame_bound: UNBOUNDED FOLLOWING  */
+#line 1208 "bison_parser.y"
+                      { (yyval.frame_bound) = new FrameBound{0, kFollowing, true}; }
+#line 5192 "bison_parser.cpp"
     break;
 
-  case 255:
-#line 1202 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kFollowing, false}; }
-#line 5003 "bison_parser.cpp" /* yacc.c:1646  */
+  case 255: /* frame_bound: INTVAL FOLLOWING  */
+#line 1209 "bison_parser.y"
+                   { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kFollowing, false}; }
+#line 5198 "bison_parser.cpp"
     break;
 
-  case 256:
-#line 1203 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_bound) = new FrameBound{0, kCurrentRow, false}; }
-#line 5009 "bison_parser.cpp" /* yacc.c:1646  */
+  case 256: /* frame_bound: CURRENT_ROW  */
+#line 1210 "bison_parser.y"
+              { (yyval.frame_bound) = new FrameBound{0, kCurrentRow, false}; }
+#line 5204 "bison_parser.cpp"
     break;
 
-  case 257:
-#line 1205 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeExtract((yyvsp[-3].datetime_field), (yyvsp[-1].expr)); }
-#line 5015 "bison_parser.cpp" /* yacc.c:1646  */
+  case 257: /* extract_expr: EXTRACT '(' datetime_field FROM expr ')'  */
+#line 1212 "bison_parser.y"
+                                                        { (yyval.expr) = Expr::makeExtract((yyvsp[-3].datetime_field), (yyvsp[-1].expr)); }
+#line 5210 "bison_parser.cpp"
     break;
 
-  case 258:
-#line 1207 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t)); }
-#line 5021 "bison_parser.cpp" /* yacc.c:1646  */
+  case 258: /* cast_expr: CAST '(' expr AS column_type ')'  */
+#line 1214 "bison_parser.y"
+                                             { (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t)); }
+#line 5216 "bison_parser.cpp"
     break;
 
-  case 259:
-#line 1209 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeSecond; }
-#line 5027 "bison_parser.cpp" /* yacc.c:1646  */
+  case 259: /* datetime_field: SECOND  */
+#line 1216 "bison_parser.y"
+                        { (yyval.datetime_field) = kDatetimeSecond; }
+#line 5222 "bison_parser.cpp"
     break;
 
-  case 260:
-#line 1210 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeMinute; }
-#line 5033 "bison_parser.cpp" /* yacc.c:1646  */
+  case 260: /* datetime_field: MINUTE  */
+#line 1217 "bison_parser.y"
+         { (yyval.datetime_field) = kDatetimeMinute; }
+#line 5228 "bison_parser.cpp"
     break;
 
-  case 261:
-#line 1211 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeHour; }
-#line 5039 "bison_parser.cpp" /* yacc.c:1646  */
+  case 261: /* datetime_field: HOUR  */
+#line 1218 "bison_parser.y"
+       { (yyval.datetime_field) = kDatetimeHour; }
+#line 5234 "bison_parser.cpp"
     break;
 
-  case 262:
-#line 1212 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeDay; }
-#line 5045 "bison_parser.cpp" /* yacc.c:1646  */
+  case 262: /* datetime_field: DAY  */
+#line 1219 "bison_parser.y"
+      { (yyval.datetime_field) = kDatetimeDay; }
+#line 5240 "bison_parser.cpp"
     break;
 
-  case 263:
-#line 1213 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeMonth; }
-#line 5051 "bison_parser.cpp" /* yacc.c:1646  */
+  case 263: /* datetime_field: MONTH  */
+#line 1220 "bison_parser.y"
+        { (yyval.datetime_field) = kDatetimeMonth; }
+#line 5246 "bison_parser.cpp"
     break;
 
-  case 264:
-#line 1214 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeYear; }
-#line 5057 "bison_parser.cpp" /* yacc.c:1646  */
+  case 264: /* datetime_field: YEAR  */
+#line 1221 "bison_parser.y"
+       { (yyval.datetime_field) = kDatetimeYear; }
+#line 5252 "bison_parser.cpp"
     break;
 
-  case 265:
-#line 1216 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeSecond; }
-#line 5063 "bison_parser.cpp" /* yacc.c:1646  */
+  case 265: /* datetime_field_plural: SECONDS  */
+#line 1223 "bison_parser.y"
+                                { (yyval.datetime_field) = kDatetimeSecond; }
+#line 5258 "bison_parser.cpp"
     break;
 
-  case 266:
-#line 1217 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeMinute; }
-#line 5069 "bison_parser.cpp" /* yacc.c:1646  */
+  case 266: /* datetime_field_plural: MINUTES  */
+#line 1224 "bison_parser.y"
+          { (yyval.datetime_field) = kDatetimeMinute; }
+#line 5264 "bison_parser.cpp"
     break;
 
-  case 267:
-#line 1218 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeHour; }
-#line 5075 "bison_parser.cpp" /* yacc.c:1646  */
+  case 267: /* datetime_field_plural: HOURS  */
+#line 1225 "bison_parser.y"
+        { (yyval.datetime_field) = kDatetimeHour; }
+#line 5270 "bison_parser.cpp"
     break;
 
-  case 268:
-#line 1219 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeDay; }
-#line 5081 "bison_parser.cpp" /* yacc.c:1646  */
+  case 268: /* datetime_field_plural: DAYS  */
+#line 1226 "bison_parser.y"
+       { (yyval.datetime_field) = kDatetimeDay; }
+#line 5276 "bison_parser.cpp"
     break;
 
-  case 269:
-#line 1220 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeMonth; }
-#line 5087 "bison_parser.cpp" /* yacc.c:1646  */
+  case 269: /* datetime_field_plural: MONTHS  */
+#line 1227 "bison_parser.y"
+         { (yyval.datetime_field) = kDatetimeMonth; }
+#line 5282 "bison_parser.cpp"
     break;
 
-  case 270:
-#line 1221 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeYear; }
-#line 5093 "bison_parser.cpp" /* yacc.c:1646  */
+  case 270: /* datetime_field_plural: YEARS  */
+#line 1228 "bison_parser.y"
+        { (yyval.datetime_field) = kDatetimeYear; }
+#line 5288 "bison_parser.cpp"
     break;
 
-  case 273:
-#line 1225 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeArray((yyvsp[-1].expr_vec)); }
-#line 5099 "bison_parser.cpp" /* yacc.c:1646  */
+  case 273: /* array_expr: ARRAY '[' expr_list ']'  */
+#line 1232 "bison_parser.y"
+                                     { (yyval.expr) = Expr::makeArray((yyvsp[-1].expr_vec)); }
+#line 5294 "bison_parser.cpp"
     break;
 
-  case 274:
-#line 1227 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeArrayIndex((yyvsp[-3].expr), (yyvsp[-1].expr)->ival); }
-#line 5105 "bison_parser.cpp" /* yacc.c:1646  */
+  case 274: /* array_index: operand '[' int_literal ']'  */
+#line 1234 "bison_parser.y"
+                                          { (yyval.expr) = Expr::makeArrayIndex((yyvsp[-3].expr), (yyvsp[-1].expr)->ival); }
+#line 5300 "bison_parser.cpp"
     break;
 
-  case 275:
-#line 1229 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeBetween((yyvsp[-4].expr), (yyvsp[-2].expr), (yyvsp[0].expr)); }
-#line 5111 "bison_parser.cpp" /* yacc.c:1646  */
+  case 275: /* between_expr: operand BETWEEN operand AND operand  */
+#line 1236 "bison_parser.y"
+                                                   { (yyval.expr) = Expr::makeBetween((yyvsp[-4].expr), (yyvsp[-2].expr), (yyvsp[0].expr)); }
+#line 5306 "bison_parser.cpp"
     break;
 
-  case 276:
-#line 1231 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeColumnRef((yyvsp[0].sval)); }
-#line 5117 "bison_parser.cpp" /* yacc.c:1646  */
+  case 276: /* column_name: IDENTIFIER  */
+#line 1238 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeColumnRef((yyvsp[0].sval)); }
+#line 5312 "bison_parser.cpp"
     break;
 
-  case 277:
-#line 1232 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeColumnRef((yyvsp[-2].sval), (yyvsp[0].sval)); }
-#line 5123 "bison_parser.cpp" /* yacc.c:1646  */
+  case 277: /* column_name: IDENTIFIER '.' IDENTIFIER  */
+#line 1239 "bison_parser.y"
+                            { (yyval.expr) = Expr::makeColumnRef((yyvsp[-2].sval), (yyvsp[0].sval)); }
+#line 5318 "bison_parser.cpp"
     break;
 
-  case 278:
-#line 1233 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeStar(); }
-#line 5129 "bison_parser.cpp" /* yacc.c:1646  */
+  case 278: /* column_name: '*'  */
+#line 1240 "bison_parser.y"
+      { (yyval.expr) = Expr::makeStar(); }
+#line 5324 "bison_parser.cpp"
     break;
 
-  case 279:
-#line 1234 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeStar((yyvsp[-2].sval)); }
-#line 5135 "bison_parser.cpp" /* yacc.c:1646  */
+  case 279: /* column_name: IDENTIFIER '.' '*'  */
+#line 1241 "bison_parser.y"
+                     { (yyval.expr) = Expr::makeStar((yyvsp[-2].sval)); }
+#line 5330 "bison_parser.cpp"
     break;
 
-  case 287:
-#line 1238 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeLiteral((yyvsp[0].sval)); }
-#line 5141 "bison_parser.cpp" /* yacc.c:1646  */
+  case 287: /* string_literal: STRING  */
+#line 1245 "bison_parser.y"
+                        { (yyval.expr) = Expr::makeLiteral((yyvsp[0].sval)); }
+#line 5336 "bison_parser.cpp"
     break;
 
-  case 288:
-#line 1240 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeLiteral(true); }
-#line 5147 "bison_parser.cpp" /* yacc.c:1646  */
+  case 288: /* bool_literal: TRUE  */
+#line 1247 "bison_parser.y"
+                    { (yyval.expr) = Expr::makeLiteral(true); }
+#line 5342 "bison_parser.cpp"
     break;
 
-  case 289:
-#line 1241 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeLiteral(false); }
-#line 5153 "bison_parser.cpp" /* yacc.c:1646  */
+  case 289: /* bool_literal: FALSE  */
+#line 1248 "bison_parser.y"
+        { (yyval.expr) = Expr::makeLiteral(false); }
+#line 5348 "bison_parser.cpp"
     break;
 
-  case 290:
-#line 1243 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeLiteral((yyvsp[0].fval)); }
-#line 5159 "bison_parser.cpp" /* yacc.c:1646  */
+  case 290: /* num_literal: FLOATVAL  */
+#line 1250 "bison_parser.y"
+                       { (yyval.expr) = Expr::makeLiteral((yyvsp[0].fval)); }
+#line 5354 "bison_parser.cpp"
     break;
 
-  case 292:
-#line 1246 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeLiteral((yyvsp[0].ival)); }
-#line 5165 "bison_parser.cpp" /* yacc.c:1646  */
+  case 292: /* int_literal: INTVAL  */
+#line 1253 "bison_parser.y"
+                     { (yyval.expr) = Expr::makeLiteral((yyvsp[0].ival)); }
+#line 5360 "bison_parser.cpp"
     break;
 
-  case 293:
-#line 1248 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeNullLiteral(); }
-#line 5171 "bison_parser.cpp" /* yacc.c:1646  */
+  case 293: /* null_literal: NULL  */
+#line 1255 "bison_parser.y"
+                    { (yyval.expr) = Expr::makeNullLiteral(); }
+#line 5366 "bison_parser.cpp"
     break;
 
-  case 294:
-#line 1250 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 294: /* date_literal: DATE STRING  */
+#line 1257 "bison_parser.y"
+                           {
   int day{0}, month{0}, year{0}, chars_parsed{0};
   // If the whole string is parsed, chars_parsed points to the terminating null byte after the last character
   if (sscanf((yyvsp[0].sval), "%4d-%2d-%2d%n", &day, &month, &year, &chars_parsed) != 3 || (yyvsp[0].sval)[chars_parsed] != 0) {
@@ -5182,18 +5377,18 @@ yyreduce:
   }
   (yyval.expr) = Expr::makeDateLiteral((yyvsp[0].sval));
 }
-#line 5186 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5381 "bison_parser.cpp"
     break;
 
-  case 295:
-#line 1261 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeIntervalLiteral((yyvsp[-1].ival), (yyvsp[0].datetime_field)); }
-#line 5192 "bison_parser.cpp" /* yacc.c:1646  */
+  case 295: /* interval_literal: INTVAL duration_field  */
+#line 1268 "bison_parser.y"
+                                         { (yyval.expr) = Expr::makeIntervalLiteral((yyvsp[-1].ival), (yyvsp[0].datetime_field)); }
+#line 5387 "bison_parser.cpp"
     break;
 
-  case 296:
-#line 1262 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 296: /* interval_literal: INTERVAL STRING datetime_field  */
+#line 1269 "bison_parser.y"
+                                 {
   int duration{0}, chars_parsed{0};
   // If the whole string is parsed, chars_parsed points to the terminating null byte after the last character
   if (sscanf((yyvsp[-1].sval), "%d%n", &duration, &chars_parsed) != 1 || (yyvsp[-1].sval)[chars_parsed] != 0) {
@@ -5204,12 +5399,12 @@ yyreduce:
   free((yyvsp[-1].sval));
   (yyval.expr) = Expr::makeIntervalLiteral(duration, (yyvsp[0].datetime_field));
 }
-#line 5208 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5403 "bison_parser.cpp"
     break;
 
-  case 297:
-#line 1273 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 297: /* interval_literal: INTERVAL STRING  */
+#line 1280 "bison_parser.y"
+                  {
   int duration{0}, chars_parsed{0};
   // 'seconds' and 'minutes' are the longest accepted interval qualifiers (7 chars) + null byte
   char unit_string[8];
@@ -5240,290 +5435,312 @@ yyreduce:
   }
   (yyval.expr) = Expr::makeIntervalLiteral(duration, unit);
 }
-#line 5244 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5439 "bison_parser.cpp"
     break;
 
-  case 298:
-#line 1305 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 298: /* param_expr: '?'  */
+#line 1312 "bison_parser.y"
+                 {
   (yyval.expr) = Expr::makeParameter(yylloc.total_column);
   (yyval.expr)->ival2 = yyloc.param_list.size();
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5254 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5449 "bison_parser.cpp"
     break;
 
-  case 300:
-#line 1314 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 299: /* param_expr: DOLLAR_PARAM  */
+#line 1317 "bison_parser.y"
+               {
+  if ((yyvsp[0].ival) < 1) {
+    yyerror(&yyloc, result, scanner, "$0 is not a valid positional parameter.");
+    YYERROR;
+  }
+  (yyval.expr) = Expr::makeDollarParameter((yyvsp[0].ival));
+  yyloc.param_list.push_back((yyval.expr));
+}
+#line 5462 "bison_parser.cpp"
+    break;
+
+  case 300: /* param_expr: NAMED_PARAM  */
+#line 1325 "bison_parser.y"
+              {
+  (yyval.expr) = Expr::makeNamedParameter((yyvsp[0].sval));
+  yyloc.param_list.push_back((yyval.expr));
+}
+#line 5471 "bison_parser.cpp"
+    break;
+
+  case 302: /* table_ref: table_ref_commalist ',' table_ref_atomic  */
+#line 1333 "bison_parser.y"
+                                                                        {
   (yyvsp[-2].table_vec)->push_back((yyvsp[0].table));
   auto tbl = new TableRef(kTableCrossProduct);
   tbl->list = (yyvsp[-2].table_vec);
   (yyval.table) = tbl;
 }
-#line 5265 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5482 "bison_parser.cpp"
     break;
 
-  case 304:
-#line 1323 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 306: /* nonjoin_table_ref_atomic: '(' select_statement ')' opt_table_alias  */
+#line 1342 "bison_parser.y"
+                                                                                     {
   auto tbl = new TableRef(kTableSelect);
   tbl->select = (yyvsp[-2].select_stmt);
   tbl->alias = (yyvsp[0].alias_t);
   (yyval.table) = tbl;
 }
-#line 5276 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5493 "bison_parser.cpp"
     break;
 
-  case 305:
-#line 1330 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 307: /* table_ref_commalist: table_ref_atomic  */
+#line 1349 "bison_parser.y"
+                                       {
   (yyval.table_vec) = new std::vector<TableRef*>();
   (yyval.table_vec)->push_back((yyvsp[0].table));
 }
-#line 5285 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5502 "bison_parser.cpp"
     break;
 
-  case 306:
-#line 1334 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 308: /* table_ref_commalist: table_ref_commalist ',' table_ref_atomic  */
+#line 1353 "bison_parser.y"
+                                           {
   (yyvsp[-2].table_vec)->push_back((yyvsp[0].table));
   (yyval.table_vec) = (yyvsp[-2].table_vec);
 }
-#line 5294 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5511 "bison_parser.cpp"
     break;
 
-  case 307:
-#line 1339 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 309: /* table_ref_name: table_name opt_table_alias  */
+#line 1358 "bison_parser.y"
+                                            {
   auto tbl = new TableRef(kTableName);
   tbl->schema = (yyvsp[-1].table_name).schema;
   tbl->name = (yyvsp[-1].table_name).name;
   tbl->alias = (yyvsp[0].alias_t);
   (yyval.table) = tbl;
 }
-#line 5306 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5523 "bison_parser.cpp"
     break;
 
-  case 308:
-#line 1347 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 310: /* table_ref_name_no_alias: table_name  */
+#line 1366 "bison_parser.y"
+                                     {
   (yyval.table) = new TableRef(kTableName);
   (yyval.table)->schema = (yyvsp[0].table_name).schema;
   (yyval.table)->name = (yyvsp[0].table_name).name;
 }
-#line 5316 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5533 "bison_parser.cpp"
     break;
 
-  case 309:
-#line 1353 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 311: /* table_name: IDENTIFIER  */
+#line 1372 "bison_parser.y"
+                        {
   (yyval.table_name).schema = nullptr;
   (yyval.table_name).name = (yyvsp[0].sval);
 }
-#line 5325 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5542 "bison_parser.cpp"
     break;
 
-  case 310:
-#line 1357 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 312: /* table_name: IDENTIFIER '.' IDENTIFIER  */
+#line 1376 "bison_parser.y"
+                            {
   (yyval.table_name).schema = (yyvsp[-2].sval);
   (yyval.table_name).name = (yyvsp[0].sval);
 }
-#line 5334 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5551 "bison_parser.cpp"
     break;
 
-  case 311:
-#line 1362 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.sval) = (yyvsp[0].sval); }
-#line 5340 "bison_parser.cpp" /* yacc.c:1646  */
+  case 313: /* opt_index_name: IDENTIFIER  */
+#line 1381 "bison_parser.y"
+                            { (yyval.sval) = (yyvsp[0].sval); }
+#line 5557 "bison_parser.cpp"
     break;
 
-  case 312:
-#line 1363 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.sval) = nullptr; }
-#line 5346 "bison_parser.cpp" /* yacc.c:1646  */
+  case 314: /* opt_index_name: %empty  */
+#line 1382 "bison_parser.y"
+              { (yyval.sval) = nullptr; }
+#line 5563 "bison_parser.cpp"
     break;
 
-  case 314:
-#line 1365 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alias_t) = new Alias((yyvsp[-3].sval), (yyvsp[-1].str_vec)); }
-#line 5352 "bison_parser.cpp" /* yacc.c:1646  */
+  case 316: /* table_alias: AS IDENTIFIER '(' ident_commalist ')'  */
+#line 1384 "bison_parser.y"
+                                                            { (yyval.alias_t) = new Alias((yyvsp[-3].sval), (yyvsp[-1].str_vec)); }
+#line 5569 "bison_parser.cpp"
     break;
 
-  case 316:
-#line 1367 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alias_t) = nullptr; }
-#line 5358 "bison_parser.cpp" /* yacc.c:1646  */
+  case 318: /* opt_table_alias: %empty  */
+#line 1386 "bison_parser.y"
+                                            { (yyval.alias_t) = nullptr; }
+#line 5575 "bison_parser.cpp"
     break;
 
-  case 317:
-#line 1369 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
-#line 5364 "bison_parser.cpp" /* yacc.c:1646  */
+  case 319: /* alias: AS IDENTIFIER  */
+#line 1388 "bison_parser.y"
+                      { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
+#line 5581 "bison_parser.cpp"
     break;
 
-  case 318:
-#line 1370 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
-#line 5370 "bison_parser.cpp" /* yacc.c:1646  */
+  case 320: /* alias: IDENTIFIER  */
+#line 1389 "bison_parser.y"
+             { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
+#line 5587 "bison_parser.cpp"
     break;
 
-  case 320:
-#line 1372 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alias_t) = nullptr; }
-#line 5376 "bison_parser.cpp" /* yacc.c:1646  */
+  case 322: /* opt_alias: %empty  */
+#line 1391 "bison_parser.y"
+                                { (yyval.alias_t) = nullptr; }
+#line 5593 "bison_parser.cpp"
     break;
 
-  case 321:
-#line 1378 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.locking_clause_vec) = (yyvsp[0].locking_clause_vec); }
-#line 5382 "bison_parser.cpp" /* yacc.c:1646  */
+  case 323: /* opt_locking_clause: opt_locking_clause_list  */
+#line 1397 "bison_parser.y"
+                                             { (yyval.locking_clause_vec) = (yyvsp[0].locking_clause_vec); }
+#line 5599 "bison_parser.cpp"
     break;
 
-  case 322:
-#line 1379 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.locking_clause_vec) = nullptr; }
-#line 5388 "bison_parser.cpp" /* yacc.c:1646  */
+  case 324: /* opt_locking_clause: %empty  */
+#line 1398 "bison_parser.y"
+              { (yyval.locking_clause_vec) = nullptr; }
+#line 5605 "bison_parser.cpp"
     break;
 
-  case 323:
-#line 1381 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 325: /* opt_locking_clause_list: locking_clause  */
+#line 1400 "bison_parser.y"
+                                         {
   (yyval.locking_clause_vec) = new std::vector<LockingClause*>();
   (yyval.locking_clause_vec)->push_back((yyvsp[0].locking_t));
 }
-#line 5397 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5614 "bison_parser.cpp"
     break;
 
-  case 324:
-#line 1385 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 326: /* opt_locking_clause_list: opt_locking_clause_list locking_clause  */
+#line 1404 "bison_parser.y"
+                                         {
   (yyvsp[-1].locking_clause_vec)->push_back((yyvsp[0].locking_t));
   (yyval.locking_clause_vec) = (yyvsp[-1].locking_clause_vec);
 }
-#line 5406 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5623 "bison_parser.cpp"
     break;
 
-  case 325:
-#line 1390 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 327: /* locking_clause: FOR row_lock_mode opt_row_lock_policy  */
+#line 1409 "bison_parser.y"
+                                                       {
   (yyval.locking_t) = new LockingClause();
   (yyval.locking_t)->rowLockMode = (yyvsp[-1].lock_mode_t);
   (yyval.locking_t)->rowLockWaitPolicy = (yyvsp[0].lock_wait_policy_t);
   (yyval.locking_t)->tables = nullptr;
 }
-#line 5417 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5634 "bison_parser.cpp"
     break;
 
-  case 326:
-#line 1396 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 328: /* locking_clause: FOR row_lock_mode OF ident_commalist opt_row_lock_policy  */
+#line 1415 "bison_parser.y"
+                                                           {
   (yyval.locking_t) = new LockingClause();
   (yyval.locking_t)->rowLockMode = (yyvsp[-3].lock_mode_t);
   (yyval.locking_t)->tables = (yyvsp[-1].str_vec);
   (yyval.locking_t)->rowLockWaitPolicy = (yyvsp[0].lock_wait_policy_t);
 }
-#line 5428 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5645 "bison_parser.cpp"
     break;
 
-  case 327:
-#line 1403 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_mode_t) = RowLockMode::ForUpdate; }
-#line 5434 "bison_parser.cpp" /* yacc.c:1646  */
+  case 329: /* row_lock_mode: UPDATE  */
+#line 1422 "bison_parser.y"
+                       { (yyval.lock_mode_t) = RowLockMode::ForUpdate; }
+#line 5651 "bison_parser.cpp"
     break;
 
-  case 328:
-#line 1404 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_mode_t) = RowLockMode::ForNoKeyUpdate; }
-#line 5440 "bison_parser.cpp" /* yacc.c:1646  */
+  case 330: /* row_lock_mode: NO KEY UPDATE  */
+#line 1423 "bison_parser.y"
+                { (yyval.lock_mode_t) = RowLockMode::ForNoKeyUpdate; }
+#line 5657 "bison_parser.cpp"
     break;
 
-  case 329:
-#line 1405 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_mode_t) = RowLockMode::ForShare; }
-#line 5446 "bison_parser.cpp" /* yacc.c:1646  */
+  case 331: /* row_lock_mode: SHARE  */
+#line 1424 "bison_parser.y"
+        { (yyval.lock_mode_t) = RowLockMode::ForShare; }
+#line 5663 "bison_parser.cpp"
     break;
 
-  case 330:
-#line 1406 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_mode_t) = RowLockMode::ForKeyShare; }
-#line 5452 "bison_parser.cpp" /* yacc.c:1646  */
+  case 332: /* row_lock_mode: KEY SHARE  */
+#line 1425 "bison_parser.y"
+            { (yyval.lock_mode_t) = RowLockMode::ForKeyShare; }
+#line 5669 "bison_parser.cpp"
     break;
 
-  case 331:
-#line 1408 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::SkipLocked; }
-#line 5458 "bison_parser.cpp" /* yacc.c:1646  */
+  case 333: /* opt_row_lock_policy: SKIP LOCKED  */
+#line 1427 "bison_parser.y"
+                                  { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::SkipLocked; }
+#line 5675 "bison_parser.cpp"
     break;
 
-  case 332:
-#line 1409 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::NoWait; }
-#line 5464 "bison_parser.cpp" /* yacc.c:1646  */
+  case 334: /* opt_row_lock_policy: NOWAIT  */
+#line 1428 "bison_parser.y"
+         { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::NoWait; }
+#line 5681 "bison_parser.cpp"
     break;
 
-  case 333:
-#line 1410 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::None; }
-#line 5470 "bison_parser.cpp" /* yacc.c:1646  */
+  case 335: /* opt_row_lock_policy: %empty  */
+#line 1429 "bison_parser.y"
+              { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::None; }
+#line 5687 "bison_parser.cpp"
     break;
 
-  case 335:
-#line 1416 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.with_description_vec) = nullptr; }
-#line 5476 "bison_parser.cpp" /* yacc.c:1646  */
+  case 337: /* opt_with_clause: %empty  */
+#line 1435 "bison_parser.y"
+                                            { (yyval.with_description_vec) = nullptr; }
+#line 5693 "bison_parser.cpp"
     break;
 
-  case 336:
-#line 1418 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.with_description_vec) = (yyvsp[0].with_description_vec); }
-#line 5482 "bison_parser.cpp" /* yacc.c:1646  */
+  case 338: /* with_clause: WITH with_description_list  */
+#line 1437 "bison_parser.y"
+                                         { (yyval.with_description_vec) = (yyvsp[0].with_description_vec); }
+#line 5699 "bison_parser.cpp"
     break;
 
-  case 337:
-#line 1420 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 339: /* with_description_list: with_description  */
+#line 1439 "bison_parser.y"
+                                         {
   (yyval.with_description_vec) = new std::vector<WithDescription*>();
   (yyval.with_description_vec)->push_back((yyvsp[0].with_description_t));
 }
-#line 5491 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5708 "bison_parser.cpp"
     break;
 
-  case 338:
-#line 1424 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 340: /* with_description_list: with_description_list ',' with_description  */
+#line 1443 "bison_parser.y"
+                                             {
   (yyvsp[-2].with_description_vec)->push_back((yyvsp[0].with_description_t));
   (yyval.with_description_vec) = (yyvsp[-2].with_description_vec);
 }
-#line 5500 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5717 "bison_parser.cpp"
     break;
 
-  case 339:
-#line 1429 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 341: /* with_description: IDENTIFIER AS select_with_paren  */
+#line 1448 "bison_parser.y"
+                                                   {
   (yyval.with_description_t) = new WithDescription();
   (yyval.with_description_t)->alias = (yyvsp[-2].sval);
   (yyval.with_description_t)->select = (yyvsp[0].select_stmt);
 }
-#line 5510 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5727 "bison_parser.cpp"
     break;
 
-  case 340:
-#line 1439 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 342: /* join_clause: table_ref_atomic NATURAL JOIN nonjoin_table_ref_atomic  */
+#line 1458 "bison_parser.y"
+                                                                     {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
   (yyval.table)->join->type = kJoinNatural;
   (yyval.table)->join->left = (yyvsp[-3].table);
   (yyval.table)->join->right = (yyvsp[0].table);
 }
-#line 5522 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5739 "bison_parser.cpp"
     break;
 
-  case 341:
-#line 1446 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 343: /* join_clause: table_ref_atomic opt_join_type JOIN table_ref_atomic ON join_condition  */
+#line 1465 "bison_parser.y"
+                                                                         {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
   (yyval.table)->join->type = (JoinType)(yyvsp[-4].join_type);
@@ -5531,12 +5748,12 @@ yyreduce:
   (yyval.table)->join->right = (yyvsp[-2].table);
   (yyval.table)->join->condition = (yyvsp[0].expr);
 }
-#line 5535 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5752 "bison_parser.cpp"
     break;
 
-  case 342:
-#line 1454 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 344: /* join_clause: table_ref_atomic opt_join_type JOIN table_ref_atomic USING '(' ident_commalist ')'  */
+#line 1473 "bison_parser.y"
+                                                                                     {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
   (yyval.table)->join->type = (yyvsp[-6].join_type);
@@ -5544,89 +5761,90 @@ yyreduce:
   (yyval.table)->join->right = (yyvsp[-4].table);
   (yyval.table)->join->namedColumns = (yyvsp[-1].str_vec);
 }
-#line 5548 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5765 "bison_parser.cpp"
     break;
 
-  case 343:
-#line 1463 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinInner; }
-#line 5554 "bison_parser.cpp" /* yacc.c:1646  */
+  case 345: /* opt_join_type: INNER  */
+#line 1482 "bison_parser.y"
+                      { (yyval.join_type) = kJoinInner; }
+#line 5771 "bison_parser.cpp"
     break;
 
-  case 344:
-#line 1464 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinLeft; }
-#line 5560 "bison_parser.cpp" /* yacc.c:1646  */
+  case 346: /* opt_join_type: LEFT OUTER  */
+#line 1483 "bison_parser.y"
+             { (yyval.join_type) = kJoinLeft; }
+#line 5777 "bison_parser.cpp"
     break;
 
-  case 345:
-#line 1465 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinLeft; }
-#line 5566 "bison_parser.cpp" /* yacc.c:1646  */
+  case 347: /* opt_join_type: LEFT  */
+#line 1484 "bison_parser.y"
+       { (yyval.join_type) = kJoinLeft; }
+#line 5783 "bison_parser.cpp"
     break;
 
-  case 346:
-#line 1466 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinRight; }
-#line 5572 "bison_parser.cpp" /* yacc.c:1646  */
+  case 348: /* opt_join_type: RIGHT OUTER  */
+#line 1485 "bison_parser.y"
+              { (yyval.join_type) = kJoinRight; }
+#line 5789 "bison_parser.cpp"
     break;
 
-  case 347:
-#line 1467 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinRight; }
-#line 5578 "bison_parser.cpp" /* yacc.c:1646  */
+  case 349: /* opt_join_type: RIGHT  */
+#line 1486 "bison_parser.y"
+        { (yyval.join_type) = kJoinRight; }
+#line 5795 "bison_parser.cpp"
     break;
 
-  case 348:
-#line 1468 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinFull; }
-#line 5584 "bison_parser.cpp" /* yacc.c:1646  */
+  case 350: /* opt_join_type: FULL OUTER  */
+#line 1487 "bison_parser.y"
+             { (yyval.join_type) = kJoinFull; }
+#line 5801 "bison_parser.cpp"
     break;
 
-  case 349:
-#line 1469 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinFull; }
-#line 5590 "bison_parser.cpp" /* yacc.c:1646  */
+  case 351: /* opt_join_type: OUTER  */
+#line 1488 "bison_parser.y"
+        { (yyval.join_type) = kJoinFull; }
+#line 5807 "bison_parser.cpp"
     break;
 
-  case 350:
-#line 1470 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinFull; }
-#line 5596 "bison_parser.cpp" /* yacc.c:1646  */
+  case 352: /* opt_join_type: FULL  */
+#line 1489 "bison_parser.y"
+       { (yyval.join_type) = kJoinFull; }
+#line 5813 "bison_parser.cpp"
     break;
 
-  case 351:
-#line 1471 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinCross; }
-#line 5602 "bison_parser.cpp" /* yacc.c:1646  */
+  case 353: /* opt_join_type: CROSS  */
+#line 1490 "bison_parser.y"
+        { (yyval.join_type) = kJoinCross; }
+#line 5819 "bison_parser.cpp"
     break;
 
-  case 352:
-#line 1472 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinInner; }
-#line 5608 "bison_parser.cpp" /* yacc.c:1646  */
+  case 354: /* opt_join_type: %empty  */
+#line 1491 "bison_parser.y"
+                       { (yyval.join_type) = kJoinInner; }
+#line 5825 "bison_parser.cpp"
     break;
 
-  case 356:
-#line 1483 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 358: /* ident_commalist: IDENTIFIER  */
+#line 1502 "bison_parser.y"
+                             {
   (yyval.str_vec) = new std::vector<char*>();
   (yyval.str_vec)->push_back((yyvsp[0].sval));
 }
-#line 5617 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5834 "bison_parser.cpp"
     break;
 
-  case 357:
-#line 1487 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 359: /* ident_commalist: ident_commalist ',' IDENTIFIER  */
+#line 1506 "bison_parser.y"
+                                 {
   (yyvsp[-2].str_vec)->push_back((yyvsp[0].sval));
   (yyval.str_vec) = (yyvsp[-2].str_vec);
 }
-#line 5626 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5843 "bison_parser.cpp"
     break;
 
 
-#line 5630 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5847 "bison_parser.cpp"
+
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -5640,11 +5858,10 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
   *++yylsp = yyloc;
@@ -5652,14 +5869,13 @@ yyreduce:
   /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
@@ -5670,66 +5886,61 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == SQL_HSQL_EMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
-      yyerror (&yylloc, result, scanner, YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
       {
+        yypcontext_t yyctx
+          = {yyssp, yytoken, &yylloc};
         char const *yymsgp = YY_("syntax error");
         int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
+        yysyntax_error_status = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
         if (yysyntax_error_status == 0)
           yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
+        else if (yysyntax_error_status == -1)
           {
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
-            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
-            if (!yymsg)
+            yymsg = YY_CAST (char *,
+                             YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
+            if (yymsg)
               {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
+                yysyntax_error_status
+                  = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
+                yymsgp = yymsg;
               }
             else
               {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
+                yymsg = yymsgbuf;
+                yymsg_alloc = sizeof yymsgbuf;
+                yysyntax_error_status = YYENOMEM;
               }
           }
         yyerror (&yylloc, result, scanner, yymsgp);
-        if (yysyntax_error_status == 2)
-          goto yyexhaustedlab;
+        if (yysyntax_error_status == YYENOMEM)
+          YYNOMEM;
       }
-# undef YYSYNTAX_ERROR
-#endif
     }
 
   yyerror_range[1] = yylloc;
-
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
          error, discard it.  */
 
-      if (yychar <= YYEOF)
+      if (yychar <= SQL_YYEOF)
         {
           /* Return failure if at end of input.  */
-          if (yychar == YYEOF)
+          if (yychar == SQL_YYEOF)
             YYABORT;
         }
       else
         {
           yydestruct ("Error: discarding",
                       yytoken, &yylval, &yylloc, result, scanner);
-          yychar = YYEMPTY;
+          yychar = SQL_HSQL_EMPTY;
         }
     }
 
@@ -5742,14 +5953,12 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
+  ++yynerrs;
 
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
-
-  yyerror_range[1] = yylsp[1-yylen];
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
@@ -5765,13 +5974,14 @@ yyerrorlab:
 yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
               yyn = yytable[yyn];
               if (0 < yyn)
@@ -5785,7 +5995,7 @@ yyerrlab1:
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, yylsp, result, scanner);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp, result, scanner);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -5796,13 +6006,11 @@ yyerrlab1:
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
   yyerror_range[2] = yylloc;
-  /* Using YYLLOC is tempting, but would change the location of
-     the lookahead.  YYLOC is available though.  */
-  YYLLOC_DEFAULT (yyloc, yyerror_range, 2);
-  *++yylsp = yyloc;
+  ++yylsp;
+  YYLLOC_DEFAULT (*yylsp, yyerror_range, 2);
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -5813,27 +6021,31 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
-#if !defined yyoverflow || YYERROR_VERBOSE
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (&yylloc, result, scanner, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
-yyreturn:
-  if (yychar != YYEMPTY)
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
+  if (yychar != SQL_HSQL_EMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at
          user semantic actions for why this is necessary.  */
@@ -5848,20 +6060,19 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp, yylsp, result, scanner);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp, result, scanner);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
-#endif
   return yyresult;
 }
-#line 1493 "bison_parser.y" /* yacc.c:1906  */
+
+#line 1512 "bison_parser.y"
 
 
 /*********************************

--- a/src/parser/bison_parser.cpp
+++ b/src/parser/bison_parser.cpp
@@ -894,24 +894,24 @@ static const yytype_int16 yyrline[] =
     1013,  1015,  1016,  1018,  1019,  1021,  1025,  1030,  1032,  1033,
     1034,  1036,  1037,  1059,  1060,  1062,  1063,  1064,  1065,  1066,
     1067,  1072,  1076,  1082,  1083,  1085,  1089,  1094,  1094,  1098,
-    1106,  1107,  1109,  1118,  1118,  1118,  1118,  1118,  1120,  1121,
-    1121,  1121,  1121,  1121,  1121,  1121,  1121,  1122,  1122,  1126,
-    1126,  1128,  1129,  1130,  1131,  1132,  1134,  1134,  1135,  1136,
-    1137,  1138,  1139,  1140,  1141,  1142,  1143,  1145,  1146,  1148,
-    1149,  1150,  1151,  1155,  1156,  1157,  1158,  1160,  1161,  1163,
-    1164,  1166,  1167,  1168,  1169,  1170,  1171,  1172,  1176,  1177,
-    1178,  1181,  1187,  1188,  1190,  1191,  1196,  1197,  1198,  1202,
-    1203,  1204,  1206,  1207,  1208,  1209,  1210,  1212,  1214,  1216,
-    1217,  1218,  1219,  1220,  1221,  1223,  1224,  1225,  1226,  1227,
-    1228,  1230,  1230,  1232,  1234,  1236,  1238,  1239,  1240,  1241,
-    1243,  1243,  1243,  1243,  1243,  1243,  1243,  1245,  1247,  1248,
-    1250,  1251,  1253,  1255,  1257,  1268,  1269,  1280,  1312,  1317,
-    1325,  1333,  1333,  1340,  1340,  1342,  1342,  1349,  1353,  1358,
-    1366,  1372,  1376,  1381,  1382,  1384,  1384,  1386,  1386,  1388,
-    1389,  1391,  1391,  1397,  1398,  1400,  1404,  1409,  1415,  1422,
-    1423,  1424,  1425,  1427,  1428,  1429,  1435,  1435,  1437,  1439,
-    1443,  1448,  1458,  1465,  1473,  1482,  1483,  1484,  1485,  1486,
-    1487,  1488,  1489,  1490,  1491,  1493,  1499,  1499,  1502,  1506
+    1099,  1100,  1102,  1111,  1111,  1111,  1111,  1111,  1113,  1114,
+    1114,  1114,  1114,  1114,  1114,  1114,  1114,  1115,  1115,  1119,
+    1119,  1121,  1122,  1123,  1124,  1125,  1127,  1127,  1128,  1129,
+    1130,  1131,  1132,  1133,  1134,  1135,  1136,  1138,  1139,  1141,
+    1142,  1143,  1144,  1148,  1149,  1150,  1151,  1153,  1154,  1156,
+    1157,  1159,  1160,  1161,  1162,  1163,  1164,  1165,  1169,  1170,
+    1171,  1174,  1180,  1181,  1183,  1184,  1189,  1190,  1191,  1195,
+    1196,  1197,  1199,  1200,  1201,  1202,  1203,  1205,  1207,  1209,
+    1210,  1211,  1212,  1213,  1214,  1216,  1217,  1218,  1219,  1220,
+    1221,  1223,  1223,  1225,  1227,  1229,  1231,  1232,  1233,  1234,
+    1236,  1236,  1236,  1236,  1236,  1236,  1236,  1238,  1240,  1241,
+    1243,  1244,  1246,  1248,  1250,  1261,  1262,  1273,  1305,  1310,
+    1322,  1331,  1331,  1338,  1338,  1340,  1340,  1347,  1351,  1356,
+    1364,  1370,  1374,  1379,  1380,  1382,  1382,  1384,  1384,  1386,
+    1387,  1389,  1389,  1395,  1396,  1398,  1402,  1407,  1413,  1420,
+    1421,  1422,  1423,  1425,  1426,  1427,  1433,  1433,  1435,  1437,
+    1441,  1446,  1456,  1463,  1471,  1480,  1481,  1482,  1483,  1484,
+    1485,  1486,  1487,  1488,  1489,  1491,  1497,  1497,  1500,  1504
 };
 #endif
 
@@ -4817,31 +4817,24 @@ yyreduce:
 
   case 179: /* extended_literal: literal  */
 #line 1098 "bison_parser.y"
-                           {
-  if ((yyvsp[0].expr)->type == ExprType::kExprParameter) {
-    delete (yyvsp[0].expr);
-    yyerror(&yyloc, result, scanner, "Parameter ? is not a valid literal.");
-    YYERROR;
-  }
-  (yyval.expr) = (yyvsp[0].expr);
-}
-#line 4829 "bison_parser.cpp"
+                           { (yyval.expr) = (yyvsp[0].expr); }
+#line 4822 "bison_parser.cpp"
     break;
 
   case 180: /* extended_literal: '-' num_literal  */
-#line 1106 "bison_parser.y"
+#line 1099 "bison_parser.y"
                   { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4835 "bison_parser.cpp"
+#line 4828 "bison_parser.cpp"
     break;
 
   case 181: /* extended_literal: '-' interval_literal  */
-#line 1107 "bison_parser.y"
+#line 1100 "bison_parser.y"
                        { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4841 "bison_parser.cpp"
+#line 4834 "bison_parser.cpp"
     break;
 
   case 182: /* expr_alias: expr opt_alias  */
-#line 1109 "bison_parser.y"
+#line 1102 "bison_parser.y"
                             {
   (yyval.expr) = (yyvsp[-1].expr);
   if ((yyvsp[0].alias_t)) {
@@ -4850,523 +4843,523 @@ yyreduce:
     delete (yyvsp[0].alias_t);
   }
 }
-#line 4854 "bison_parser.cpp"
+#line 4847 "bison_parser.cpp"
     break;
 
   case 188: /* operand: '(' expr ')'  */
-#line 1120 "bison_parser.y"
+#line 1113 "bison_parser.y"
                        { (yyval.expr) = (yyvsp[-1].expr); }
-#line 4860 "bison_parser.cpp"
+#line 4853 "bison_parser.cpp"
     break;
 
   case 198: /* operand: '(' select_no_paren ')'  */
-#line 1122 "bison_parser.y"
+#line 1115 "bison_parser.y"
                                          {
   (yyval.expr) = Expr::makeSelect((yyvsp[-1].select_stmt));
 }
-#line 4868 "bison_parser.cpp"
+#line 4861 "bison_parser.cpp"
     break;
 
   case 201: /* unary_expr: '-' operand  */
-#line 1128 "bison_parser.y"
+#line 1121 "bison_parser.y"
                          { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4874 "bison_parser.cpp"
+#line 4867 "bison_parser.cpp"
     break;
 
   case 202: /* unary_expr: NOT operand  */
-#line 1129 "bison_parser.y"
+#line 1122 "bison_parser.y"
               { (yyval.expr) = Expr::makeOpUnary(kOpNot, (yyvsp[0].expr)); }
-#line 4880 "bison_parser.cpp"
+#line 4873 "bison_parser.cpp"
     break;
 
   case 203: /* unary_expr: operand ISNULL  */
-#line 1130 "bison_parser.y"
+#line 1123 "bison_parser.y"
                  { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-1].expr)); }
-#line 4886 "bison_parser.cpp"
+#line 4879 "bison_parser.cpp"
     break;
 
   case 204: /* unary_expr: operand IS NULL  */
-#line 1131 "bison_parser.y"
+#line 1124 "bison_parser.y"
                   { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-2].expr)); }
-#line 4892 "bison_parser.cpp"
+#line 4885 "bison_parser.cpp"
     break;
 
   case 205: /* unary_expr: operand IS NOT NULL  */
-#line 1132 "bison_parser.y"
+#line 1125 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeOpUnary(kOpIsNull, (yyvsp[-3].expr))); }
-#line 4898 "bison_parser.cpp"
+#line 4891 "bison_parser.cpp"
     break;
 
   case 207: /* binary_expr: operand '-' operand  */
-#line 1134 "bison_parser.y"
+#line 1127 "bison_parser.y"
                                               { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpMinus, (yyvsp[0].expr)); }
-#line 4904 "bison_parser.cpp"
+#line 4897 "bison_parser.cpp"
     break;
 
   case 208: /* binary_expr: operand '+' operand  */
-#line 1135 "bison_parser.y"
+#line 1128 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPlus, (yyvsp[0].expr)); }
-#line 4910 "bison_parser.cpp"
+#line 4903 "bison_parser.cpp"
     break;
 
   case 209: /* binary_expr: operand '/' operand  */
-#line 1136 "bison_parser.y"
+#line 1129 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpSlash, (yyvsp[0].expr)); }
-#line 4916 "bison_parser.cpp"
+#line 4909 "bison_parser.cpp"
     break;
 
   case 210: /* binary_expr: operand '*' operand  */
-#line 1137 "bison_parser.y"
+#line 1130 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAsterisk, (yyvsp[0].expr)); }
-#line 4922 "bison_parser.cpp"
+#line 4915 "bison_parser.cpp"
     break;
 
   case 211: /* binary_expr: operand '%' operand  */
-#line 1138 "bison_parser.y"
+#line 1131 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPercentage, (yyvsp[0].expr)); }
-#line 4928 "bison_parser.cpp"
+#line 4921 "bison_parser.cpp"
     break;
 
   case 212: /* binary_expr: operand '^' operand  */
-#line 1139 "bison_parser.y"
+#line 1132 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpCaret, (yyvsp[0].expr)); }
-#line 4934 "bison_parser.cpp"
+#line 4927 "bison_parser.cpp"
     break;
 
   case 213: /* binary_expr: operand LIKE operand  */
-#line 1140 "bison_parser.y"
+#line 1133 "bison_parser.y"
                        { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLike, (yyvsp[0].expr)); }
-#line 4940 "bison_parser.cpp"
+#line 4933 "bison_parser.cpp"
     break;
 
   case 214: /* binary_expr: operand NOT LIKE operand  */
-#line 1141 "bison_parser.y"
+#line 1134 "bison_parser.y"
                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-3].expr), kOpNotLike, (yyvsp[0].expr)); }
-#line 4946 "bison_parser.cpp"
+#line 4939 "bison_parser.cpp"
     break;
 
   case 215: /* binary_expr: operand ILIKE operand  */
-#line 1142 "bison_parser.y"
+#line 1135 "bison_parser.y"
                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpILike, (yyvsp[0].expr)); }
-#line 4952 "bison_parser.cpp"
+#line 4945 "bison_parser.cpp"
     break;
 
   case 216: /* binary_expr: operand CONCAT operand  */
-#line 1143 "bison_parser.y"
+#line 1136 "bison_parser.y"
                          { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpConcat, (yyvsp[0].expr)); }
-#line 4958 "bison_parser.cpp"
+#line 4951 "bison_parser.cpp"
     break;
 
   case 217: /* logic_expr: expr AND expr  */
-#line 1145 "bison_parser.y"
+#line 1138 "bison_parser.y"
                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAnd, (yyvsp[0].expr)); }
-#line 4964 "bison_parser.cpp"
+#line 4957 "bison_parser.cpp"
     break;
 
   case 218: /* logic_expr: expr OR expr  */
-#line 1146 "bison_parser.y"
+#line 1139 "bison_parser.y"
                { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpOr, (yyvsp[0].expr)); }
-#line 4970 "bison_parser.cpp"
+#line 4963 "bison_parser.cpp"
     break;
 
   case 219: /* in_expr: operand IN '(' expr_list ')'  */
-#line 1148 "bison_parser.y"
+#line 1141 "bison_parser.y"
                                        { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].expr_vec)); }
-#line 4976 "bison_parser.cpp"
+#line 4969 "bison_parser.cpp"
     break;
 
   case 220: /* in_expr: operand NOT IN '(' expr_list ')'  */
-#line 1149 "bison_parser.y"
+#line 1142 "bison_parser.y"
                                    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].expr_vec))); }
-#line 4982 "bison_parser.cpp"
+#line 4975 "bison_parser.cpp"
     break;
 
   case 221: /* in_expr: operand IN '(' select_no_paren ')'  */
-#line 1150 "bison_parser.y"
+#line 1143 "bison_parser.y"
                                      { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].select_stmt)); }
-#line 4988 "bison_parser.cpp"
+#line 4981 "bison_parser.cpp"
     break;
 
   case 222: /* in_expr: operand NOT IN '(' select_no_paren ')'  */
-#line 1151 "bison_parser.y"
+#line 1144 "bison_parser.y"
                                          { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].select_stmt))); }
-#line 4994 "bison_parser.cpp"
+#line 4987 "bison_parser.cpp"
     break;
 
   case 223: /* case_expr: CASE expr case_list END  */
-#line 1155 "bison_parser.y"
+#line 1148 "bison_parser.y"
                                     { (yyval.expr) = Expr::makeCase((yyvsp[-2].expr), (yyvsp[-1].expr), nullptr); }
-#line 5000 "bison_parser.cpp"
+#line 4993 "bison_parser.cpp"
     break;
 
   case 224: /* case_expr: CASE expr case_list ELSE expr END  */
-#line 1156 "bison_parser.y"
+#line 1149 "bison_parser.y"
                                     { (yyval.expr) = Expr::makeCase((yyvsp[-4].expr), (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 5006 "bison_parser.cpp"
+#line 4999 "bison_parser.cpp"
     break;
 
   case 225: /* case_expr: CASE case_list END  */
-#line 1157 "bison_parser.y"
+#line 1150 "bison_parser.y"
                      { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-1].expr), nullptr); }
-#line 5012 "bison_parser.cpp"
+#line 5005 "bison_parser.cpp"
     break;
 
   case 226: /* case_expr: CASE case_list ELSE expr END  */
-#line 1158 "bison_parser.y"
+#line 1151 "bison_parser.y"
                                { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 5018 "bison_parser.cpp"
+#line 5011 "bison_parser.cpp"
     break;
 
   case 227: /* case_list: WHEN expr THEN expr  */
-#line 1160 "bison_parser.y"
+#line 1153 "bison_parser.y"
                                 { (yyval.expr) = Expr::makeCaseList(Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
-#line 5024 "bison_parser.cpp"
+#line 5017 "bison_parser.cpp"
     break;
 
   case 228: /* case_list: case_list WHEN expr THEN expr  */
-#line 1161 "bison_parser.y"
+#line 1154 "bison_parser.y"
                                 { (yyval.expr) = Expr::caseListAppend((yyvsp[-4].expr), Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
-#line 5030 "bison_parser.cpp"
+#line 5023 "bison_parser.cpp"
     break;
 
   case 229: /* exists_expr: EXISTS '(' select_no_paren ')'  */
-#line 1163 "bison_parser.y"
+#line 1156 "bison_parser.y"
                                              { (yyval.expr) = Expr::makeExists((yyvsp[-1].select_stmt)); }
-#line 5036 "bison_parser.cpp"
+#line 5029 "bison_parser.cpp"
     break;
 
   case 230: /* exists_expr: NOT EXISTS '(' select_no_paren ')'  */
-#line 1164 "bison_parser.y"
+#line 1157 "bison_parser.y"
                                      { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeExists((yyvsp[-1].select_stmt))); }
-#line 5042 "bison_parser.cpp"
+#line 5035 "bison_parser.cpp"
     break;
 
   case 231: /* comp_expr: operand '=' operand  */
-#line 1166 "bison_parser.y"
+#line 1159 "bison_parser.y"
                                 { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
-#line 5048 "bison_parser.cpp"
+#line 5041 "bison_parser.cpp"
     break;
 
   case 232: /* comp_expr: operand EQUALS operand  */
-#line 1167 "bison_parser.y"
+#line 1160 "bison_parser.y"
                          { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
-#line 5054 "bison_parser.cpp"
+#line 5047 "bison_parser.cpp"
     break;
 
   case 233: /* comp_expr: operand NOTEQUALS operand  */
-#line 1168 "bison_parser.y"
+#line 1161 "bison_parser.y"
                             { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpNotEquals, (yyvsp[0].expr)); }
-#line 5060 "bison_parser.cpp"
+#line 5053 "bison_parser.cpp"
     break;
 
   case 234: /* comp_expr: operand '<' operand  */
-#line 1169 "bison_parser.y"
+#line 1162 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLess, (yyvsp[0].expr)); }
-#line 5066 "bison_parser.cpp"
+#line 5059 "bison_parser.cpp"
     break;
 
   case 235: /* comp_expr: operand '>' operand  */
-#line 1170 "bison_parser.y"
+#line 1163 "bison_parser.y"
                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreater, (yyvsp[0].expr)); }
-#line 5072 "bison_parser.cpp"
+#line 5065 "bison_parser.cpp"
     break;
 
   case 236: /* comp_expr: operand LESSEQ operand  */
-#line 1171 "bison_parser.y"
+#line 1164 "bison_parser.y"
                          { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLessEq, (yyvsp[0].expr)); }
-#line 5078 "bison_parser.cpp"
+#line 5071 "bison_parser.cpp"
     break;
 
   case 237: /* comp_expr: operand GREATEREQ operand  */
-#line 1172 "bison_parser.y"
+#line 1165 "bison_parser.y"
                             { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreaterEq, (yyvsp[0].expr)); }
-#line 5084 "bison_parser.cpp"
+#line 5077 "bison_parser.cpp"
     break;
 
   case 238: /* function_expr: IDENTIFIER '(' ')' opt_window  */
-#line 1176 "bison_parser.y"
+#line 1169 "bison_parser.y"
                                               { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
-#line 5090 "bison_parser.cpp"
+#line 5083 "bison_parser.cpp"
     break;
 
   case 239: /* function_expr: IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
-#line 1177 "bison_parser.y"
+#line 1170 "bison_parser.y"
                                                        { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
-#line 5096 "bison_parser.cpp"
+#line 5089 "bison_parser.cpp"
     break;
 
   case 240: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' ')' opt_window  */
-#line 1178 "bison_parser.y"
+#line 1171 "bison_parser.y"
                                                {
   (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), (yyvsp[-5].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description));
 }
-#line 5104 "bison_parser.cpp"
+#line 5097 "bison_parser.cpp"
     break;
 
   case 241: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
-#line 1181 "bison_parser.y"
+#line 1174 "bison_parser.y"
                                                                       {
   (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-7].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description));
 }
-#line 5112 "bison_parser.cpp"
+#line 5105 "bison_parser.cpp"
     break;
 
   case 242: /* opt_window: OVER '(' opt_partition opt_order opt_frame_clause ')'  */
-#line 1187 "bison_parser.y"
+#line 1180 "bison_parser.y"
                                                                    { (yyval.window_description) = new WindowDescription((yyvsp[-3].expr_vec), (yyvsp[-2].order_vec), (yyvsp[-1].frame_description)); }
-#line 5118 "bison_parser.cpp"
+#line 5111 "bison_parser.cpp"
     break;
 
   case 243: /* opt_window: %empty  */
-#line 1188 "bison_parser.y"
+#line 1181 "bison_parser.y"
               { (yyval.window_description) = nullptr; }
-#line 5124 "bison_parser.cpp"
+#line 5117 "bison_parser.cpp"
     break;
 
   case 244: /* opt_partition: PARTITION BY expr_list  */
-#line 1190 "bison_parser.y"
+#line 1183 "bison_parser.y"
                                        { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
-#line 5130 "bison_parser.cpp"
+#line 5123 "bison_parser.cpp"
     break;
 
   case 245: /* opt_partition: %empty  */
-#line 1191 "bison_parser.y"
+#line 1184 "bison_parser.y"
               { (yyval.expr_vec) = nullptr; }
-#line 5136 "bison_parser.cpp"
+#line 5129 "bison_parser.cpp"
     break;
 
   case 246: /* opt_frame_clause: frame_type frame_bound  */
-#line 1196 "bison_parser.y"
+#line 1189 "bison_parser.y"
                                           { (yyval.frame_description) = new FrameDescription{(yyvsp[-1].frame_type), (yyvsp[0].frame_bound), new FrameBound{0, kCurrentRow, false}}; }
-#line 5142 "bison_parser.cpp"
+#line 5135 "bison_parser.cpp"
     break;
 
   case 247: /* opt_frame_clause: frame_type BETWEEN frame_bound AND frame_bound  */
-#line 1197 "bison_parser.y"
+#line 1190 "bison_parser.y"
                                                  { (yyval.frame_description) = new FrameDescription{(yyvsp[-4].frame_type), (yyvsp[-2].frame_bound), (yyvsp[0].frame_bound)}; }
-#line 5148 "bison_parser.cpp"
+#line 5141 "bison_parser.cpp"
     break;
 
   case 248: /* opt_frame_clause: %empty  */
-#line 1198 "bison_parser.y"
+#line 1191 "bison_parser.y"
               {
   (yyval.frame_description) = new FrameDescription{kRange, new FrameBound{0, kPreceding, true}, new FrameBound{0, kCurrentRow, false}};
 }
-#line 5156 "bison_parser.cpp"
+#line 5149 "bison_parser.cpp"
     break;
 
   case 249: /* frame_type: RANGE  */
-#line 1202 "bison_parser.y"
+#line 1195 "bison_parser.y"
                    { (yyval.frame_type) = kRange; }
-#line 5162 "bison_parser.cpp"
+#line 5155 "bison_parser.cpp"
     break;
 
   case 250: /* frame_type: ROWS  */
-#line 1203 "bison_parser.y"
+#line 1196 "bison_parser.y"
        { (yyval.frame_type) = kRows; }
-#line 5168 "bison_parser.cpp"
+#line 5161 "bison_parser.cpp"
     break;
 
   case 251: /* frame_type: GROUPS  */
-#line 1204 "bison_parser.y"
+#line 1197 "bison_parser.y"
          { (yyval.frame_type) = kGroups; }
-#line 5174 "bison_parser.cpp"
+#line 5167 "bison_parser.cpp"
     break;
 
   case 252: /* frame_bound: UNBOUNDED PRECEDING  */
-#line 1206 "bison_parser.y"
+#line 1199 "bison_parser.y"
                                   { (yyval.frame_bound) = new FrameBound{0, kPreceding, true}; }
-#line 5180 "bison_parser.cpp"
+#line 5173 "bison_parser.cpp"
     break;
 
   case 253: /* frame_bound: INTVAL PRECEDING  */
-#line 1207 "bison_parser.y"
+#line 1200 "bison_parser.y"
                    { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kPreceding, false}; }
-#line 5186 "bison_parser.cpp"
+#line 5179 "bison_parser.cpp"
     break;
 
   case 254: /* frame_bound: UNBOUNDED FOLLOWING  */
-#line 1208 "bison_parser.y"
+#line 1201 "bison_parser.y"
                       { (yyval.frame_bound) = new FrameBound{0, kFollowing, true}; }
-#line 5192 "bison_parser.cpp"
+#line 5185 "bison_parser.cpp"
     break;
 
   case 255: /* frame_bound: INTVAL FOLLOWING  */
-#line 1209 "bison_parser.y"
+#line 1202 "bison_parser.y"
                    { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kFollowing, false}; }
-#line 5198 "bison_parser.cpp"
+#line 5191 "bison_parser.cpp"
     break;
 
   case 256: /* frame_bound: CURRENT_ROW  */
-#line 1210 "bison_parser.y"
+#line 1203 "bison_parser.y"
               { (yyval.frame_bound) = new FrameBound{0, kCurrentRow, false}; }
-#line 5204 "bison_parser.cpp"
+#line 5197 "bison_parser.cpp"
     break;
 
   case 257: /* extract_expr: EXTRACT '(' datetime_field FROM expr ')'  */
-#line 1212 "bison_parser.y"
+#line 1205 "bison_parser.y"
                                                         { (yyval.expr) = Expr::makeExtract((yyvsp[-3].datetime_field), (yyvsp[-1].expr)); }
-#line 5210 "bison_parser.cpp"
+#line 5203 "bison_parser.cpp"
     break;
 
   case 258: /* cast_expr: CAST '(' expr AS column_type ')'  */
-#line 1214 "bison_parser.y"
+#line 1207 "bison_parser.y"
                                              { (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t)); }
-#line 5216 "bison_parser.cpp"
+#line 5209 "bison_parser.cpp"
     break;
 
   case 259: /* datetime_field: SECOND  */
-#line 1216 "bison_parser.y"
+#line 1209 "bison_parser.y"
                         { (yyval.datetime_field) = kDatetimeSecond; }
-#line 5222 "bison_parser.cpp"
+#line 5215 "bison_parser.cpp"
     break;
 
   case 260: /* datetime_field: MINUTE  */
-#line 1217 "bison_parser.y"
+#line 1210 "bison_parser.y"
          { (yyval.datetime_field) = kDatetimeMinute; }
-#line 5228 "bison_parser.cpp"
+#line 5221 "bison_parser.cpp"
     break;
 
   case 261: /* datetime_field: HOUR  */
-#line 1218 "bison_parser.y"
+#line 1211 "bison_parser.y"
        { (yyval.datetime_field) = kDatetimeHour; }
-#line 5234 "bison_parser.cpp"
+#line 5227 "bison_parser.cpp"
     break;
 
   case 262: /* datetime_field: DAY  */
-#line 1219 "bison_parser.y"
+#line 1212 "bison_parser.y"
       { (yyval.datetime_field) = kDatetimeDay; }
-#line 5240 "bison_parser.cpp"
+#line 5233 "bison_parser.cpp"
     break;
 
   case 263: /* datetime_field: MONTH  */
-#line 1220 "bison_parser.y"
+#line 1213 "bison_parser.y"
         { (yyval.datetime_field) = kDatetimeMonth; }
-#line 5246 "bison_parser.cpp"
+#line 5239 "bison_parser.cpp"
     break;
 
   case 264: /* datetime_field: YEAR  */
-#line 1221 "bison_parser.y"
+#line 1214 "bison_parser.y"
        { (yyval.datetime_field) = kDatetimeYear; }
-#line 5252 "bison_parser.cpp"
+#line 5245 "bison_parser.cpp"
     break;
 
   case 265: /* datetime_field_plural: SECONDS  */
-#line 1223 "bison_parser.y"
+#line 1216 "bison_parser.y"
                                 { (yyval.datetime_field) = kDatetimeSecond; }
-#line 5258 "bison_parser.cpp"
+#line 5251 "bison_parser.cpp"
     break;
 
   case 266: /* datetime_field_plural: MINUTES  */
-#line 1224 "bison_parser.y"
+#line 1217 "bison_parser.y"
           { (yyval.datetime_field) = kDatetimeMinute; }
-#line 5264 "bison_parser.cpp"
+#line 5257 "bison_parser.cpp"
     break;
 
   case 267: /* datetime_field_plural: HOURS  */
-#line 1225 "bison_parser.y"
+#line 1218 "bison_parser.y"
         { (yyval.datetime_field) = kDatetimeHour; }
-#line 5270 "bison_parser.cpp"
+#line 5263 "bison_parser.cpp"
     break;
 
   case 268: /* datetime_field_plural: DAYS  */
-#line 1226 "bison_parser.y"
+#line 1219 "bison_parser.y"
        { (yyval.datetime_field) = kDatetimeDay; }
-#line 5276 "bison_parser.cpp"
+#line 5269 "bison_parser.cpp"
     break;
 
   case 269: /* datetime_field_plural: MONTHS  */
-#line 1227 "bison_parser.y"
+#line 1220 "bison_parser.y"
          { (yyval.datetime_field) = kDatetimeMonth; }
-#line 5282 "bison_parser.cpp"
+#line 5275 "bison_parser.cpp"
     break;
 
   case 270: /* datetime_field_plural: YEARS  */
-#line 1228 "bison_parser.y"
+#line 1221 "bison_parser.y"
         { (yyval.datetime_field) = kDatetimeYear; }
-#line 5288 "bison_parser.cpp"
+#line 5281 "bison_parser.cpp"
     break;
 
   case 273: /* array_expr: ARRAY '[' expr_list ']'  */
-#line 1232 "bison_parser.y"
+#line 1225 "bison_parser.y"
                                      { (yyval.expr) = Expr::makeArray((yyvsp[-1].expr_vec)); }
-#line 5294 "bison_parser.cpp"
+#line 5287 "bison_parser.cpp"
     break;
 
   case 274: /* array_index: operand '[' int_literal ']'  */
-#line 1234 "bison_parser.y"
+#line 1227 "bison_parser.y"
                                           { (yyval.expr) = Expr::makeArrayIndex((yyvsp[-3].expr), (yyvsp[-1].expr)->ival); }
-#line 5300 "bison_parser.cpp"
+#line 5293 "bison_parser.cpp"
     break;
 
   case 275: /* between_expr: operand BETWEEN operand AND operand  */
-#line 1236 "bison_parser.y"
+#line 1229 "bison_parser.y"
                                                    { (yyval.expr) = Expr::makeBetween((yyvsp[-4].expr), (yyvsp[-2].expr), (yyvsp[0].expr)); }
-#line 5306 "bison_parser.cpp"
+#line 5299 "bison_parser.cpp"
     break;
 
   case 276: /* column_name: IDENTIFIER  */
-#line 1238 "bison_parser.y"
+#line 1231 "bison_parser.y"
                          { (yyval.expr) = Expr::makeColumnRef((yyvsp[0].sval)); }
-#line 5312 "bison_parser.cpp"
+#line 5305 "bison_parser.cpp"
     break;
 
   case 277: /* column_name: IDENTIFIER '.' IDENTIFIER  */
-#line 1239 "bison_parser.y"
+#line 1232 "bison_parser.y"
                             { (yyval.expr) = Expr::makeColumnRef((yyvsp[-2].sval), (yyvsp[0].sval)); }
-#line 5318 "bison_parser.cpp"
+#line 5311 "bison_parser.cpp"
     break;
 
   case 278: /* column_name: '*'  */
-#line 1240 "bison_parser.y"
+#line 1233 "bison_parser.y"
       { (yyval.expr) = Expr::makeStar(); }
-#line 5324 "bison_parser.cpp"
+#line 5317 "bison_parser.cpp"
     break;
 
   case 279: /* column_name: IDENTIFIER '.' '*'  */
-#line 1241 "bison_parser.y"
+#line 1234 "bison_parser.y"
                      { (yyval.expr) = Expr::makeStar((yyvsp[-2].sval)); }
-#line 5330 "bison_parser.cpp"
+#line 5323 "bison_parser.cpp"
     break;
 
   case 287: /* string_literal: STRING  */
-#line 1245 "bison_parser.y"
+#line 1238 "bison_parser.y"
                         { (yyval.expr) = Expr::makeLiteral((yyvsp[0].sval)); }
-#line 5336 "bison_parser.cpp"
+#line 5329 "bison_parser.cpp"
     break;
 
   case 288: /* bool_literal: TRUE  */
-#line 1247 "bison_parser.y"
+#line 1240 "bison_parser.y"
                     { (yyval.expr) = Expr::makeLiteral(true); }
-#line 5342 "bison_parser.cpp"
+#line 5335 "bison_parser.cpp"
     break;
 
   case 289: /* bool_literal: FALSE  */
-#line 1248 "bison_parser.y"
+#line 1241 "bison_parser.y"
         { (yyval.expr) = Expr::makeLiteral(false); }
-#line 5348 "bison_parser.cpp"
+#line 5341 "bison_parser.cpp"
     break;
 
   case 290: /* num_literal: FLOATVAL  */
-#line 1250 "bison_parser.y"
+#line 1243 "bison_parser.y"
                        { (yyval.expr) = Expr::makeLiteral((yyvsp[0].fval)); }
-#line 5354 "bison_parser.cpp"
+#line 5347 "bison_parser.cpp"
     break;
 
   case 292: /* int_literal: INTVAL  */
-#line 1253 "bison_parser.y"
+#line 1246 "bison_parser.y"
                      { (yyval.expr) = Expr::makeLiteral((yyvsp[0].ival)); }
-#line 5360 "bison_parser.cpp"
+#line 5353 "bison_parser.cpp"
     break;
 
   case 293: /* null_literal: NULL  */
-#line 1255 "bison_parser.y"
+#line 1248 "bison_parser.y"
                     { (yyval.expr) = Expr::makeNullLiteral(); }
-#line 5366 "bison_parser.cpp"
+#line 5359 "bison_parser.cpp"
     break;
 
   case 294: /* date_literal: DATE STRING  */
-#line 1257 "bison_parser.y"
+#line 1250 "bison_parser.y"
                            {
   int day{0}, month{0}, year{0}, chars_parsed{0};
   // If the whole string is parsed, chars_parsed points to the terminating null byte after the last character
@@ -5377,17 +5370,17 @@ yyreduce:
   }
   (yyval.expr) = Expr::makeDateLiteral((yyvsp[0].sval));
 }
-#line 5381 "bison_parser.cpp"
+#line 5374 "bison_parser.cpp"
     break;
 
   case 295: /* interval_literal: INTVAL duration_field  */
-#line 1268 "bison_parser.y"
+#line 1261 "bison_parser.y"
                                          { (yyval.expr) = Expr::makeIntervalLiteral((yyvsp[-1].ival), (yyvsp[0].datetime_field)); }
-#line 5387 "bison_parser.cpp"
+#line 5380 "bison_parser.cpp"
     break;
 
   case 296: /* interval_literal: INTERVAL STRING datetime_field  */
-#line 1269 "bison_parser.y"
+#line 1262 "bison_parser.y"
                                  {
   int duration{0}, chars_parsed{0};
   // If the whole string is parsed, chars_parsed points to the terminating null byte after the last character
@@ -5399,11 +5392,11 @@ yyreduce:
   free((yyvsp[-1].sval));
   (yyval.expr) = Expr::makeIntervalLiteral(duration, (yyvsp[0].datetime_field));
 }
-#line 5403 "bison_parser.cpp"
+#line 5396 "bison_parser.cpp"
     break;
 
   case 297: /* interval_literal: INTERVAL STRING  */
-#line 1280 "bison_parser.y"
+#line 1273 "bison_parser.y"
                   {
   int duration{0}, chars_parsed{0};
   // 'seconds' and 'minutes' are the longest accepted interval qualifiers (7 chars) + null byte
@@ -5435,83 +5428,88 @@ yyreduce:
   }
   (yyval.expr) = Expr::makeIntervalLiteral(duration, unit);
 }
-#line 5439 "bison_parser.cpp"
+#line 5432 "bison_parser.cpp"
     break;
 
   case 298: /* param_expr: '?'  */
-#line 1312 "bison_parser.y"
+#line 1305 "bison_parser.y"
                  {
   (yyval.expr) = Expr::makeParameter(yylloc.total_column);
-  (yyval.expr)->ival2 = yyloc.param_list.size();
+  (yyval.expr)->ival2 = yylloc.total_column - 1;  // source column (0-based) of the '?' token
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5449 "bison_parser.cpp"
+#line 5442 "bison_parser.cpp"
     break;
 
   case 299: /* param_expr: DOLLAR_PARAM  */
-#line 1317 "bison_parser.y"
+#line 1310 "bison_parser.y"
                {
   if ((yyvsp[0].ival) < 1) {
     yyerror(&yyloc, result, scanner, "$0 is not a valid positional parameter.");
     YYERROR;
   }
   (yyval.expr) = Expr::makeDollarParameter((yyvsp[0].ival));
+  // length of $N token: 1 for '$' + digit count of N
+  int64_t dollarLen = 1;
+  for (int64_t v = (yyvsp[0].ival); v > 0; v /= 10) ++dollarLen;
+  (yyval.expr)->ival2 = yylloc.total_column - dollarLen;
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5462 "bison_parser.cpp"
+#line 5459 "bison_parser.cpp"
     break;
 
   case 300: /* param_expr: NAMED_PARAM  */
-#line 1325 "bison_parser.y"
+#line 1322 "bison_parser.y"
               {
   (yyval.expr) = Expr::makeNamedParameter((yyvsp[0].sval));
+  (yyval.expr)->ival2 = yylloc.total_column - 1 - (int64_t)strlen((yyvsp[0].sval));
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5471 "bison_parser.cpp"
+#line 5469 "bison_parser.cpp"
     break;
 
   case 302: /* table_ref: table_ref_commalist ',' table_ref_atomic  */
-#line 1333 "bison_parser.y"
+#line 1331 "bison_parser.y"
                                                                         {
   (yyvsp[-2].table_vec)->push_back((yyvsp[0].table));
   auto tbl = new TableRef(kTableCrossProduct);
   tbl->list = (yyvsp[-2].table_vec);
   (yyval.table) = tbl;
 }
-#line 5482 "bison_parser.cpp"
+#line 5480 "bison_parser.cpp"
     break;
 
   case 306: /* nonjoin_table_ref_atomic: '(' select_statement ')' opt_table_alias  */
-#line 1342 "bison_parser.y"
+#line 1340 "bison_parser.y"
                                                                                      {
   auto tbl = new TableRef(kTableSelect);
   tbl->select = (yyvsp[-2].select_stmt);
   tbl->alias = (yyvsp[0].alias_t);
   (yyval.table) = tbl;
 }
-#line 5493 "bison_parser.cpp"
+#line 5491 "bison_parser.cpp"
     break;
 
   case 307: /* table_ref_commalist: table_ref_atomic  */
-#line 1349 "bison_parser.y"
+#line 1347 "bison_parser.y"
                                        {
   (yyval.table_vec) = new std::vector<TableRef*>();
   (yyval.table_vec)->push_back((yyvsp[0].table));
 }
-#line 5502 "bison_parser.cpp"
+#line 5500 "bison_parser.cpp"
     break;
 
   case 308: /* table_ref_commalist: table_ref_commalist ',' table_ref_atomic  */
-#line 1353 "bison_parser.y"
+#line 1351 "bison_parser.y"
                                            {
   (yyvsp[-2].table_vec)->push_back((yyvsp[0].table));
   (yyval.table_vec) = (yyvsp[-2].table_vec);
 }
-#line 5511 "bison_parser.cpp"
+#line 5509 "bison_parser.cpp"
     break;
 
   case 309: /* table_ref_name: table_name opt_table_alias  */
-#line 1358 "bison_parser.y"
+#line 1356 "bison_parser.y"
                                             {
   auto tbl = new TableRef(kTableName);
   tbl->schema = (yyvsp[-1].table_name).schema;
@@ -5519,215 +5517,215 @@ yyreduce:
   tbl->alias = (yyvsp[0].alias_t);
   (yyval.table) = tbl;
 }
-#line 5523 "bison_parser.cpp"
+#line 5521 "bison_parser.cpp"
     break;
 
   case 310: /* table_ref_name_no_alias: table_name  */
-#line 1366 "bison_parser.y"
+#line 1364 "bison_parser.y"
                                      {
   (yyval.table) = new TableRef(kTableName);
   (yyval.table)->schema = (yyvsp[0].table_name).schema;
   (yyval.table)->name = (yyvsp[0].table_name).name;
 }
-#line 5533 "bison_parser.cpp"
+#line 5531 "bison_parser.cpp"
     break;
 
   case 311: /* table_name: IDENTIFIER  */
-#line 1372 "bison_parser.y"
+#line 1370 "bison_parser.y"
                         {
   (yyval.table_name).schema = nullptr;
   (yyval.table_name).name = (yyvsp[0].sval);
 }
-#line 5542 "bison_parser.cpp"
+#line 5540 "bison_parser.cpp"
     break;
 
   case 312: /* table_name: IDENTIFIER '.' IDENTIFIER  */
-#line 1376 "bison_parser.y"
+#line 1374 "bison_parser.y"
                             {
   (yyval.table_name).schema = (yyvsp[-2].sval);
   (yyval.table_name).name = (yyvsp[0].sval);
 }
-#line 5551 "bison_parser.cpp"
+#line 5549 "bison_parser.cpp"
     break;
 
   case 313: /* opt_index_name: IDENTIFIER  */
-#line 1381 "bison_parser.y"
+#line 1379 "bison_parser.y"
                             { (yyval.sval) = (yyvsp[0].sval); }
-#line 5557 "bison_parser.cpp"
+#line 5555 "bison_parser.cpp"
     break;
 
   case 314: /* opt_index_name: %empty  */
-#line 1382 "bison_parser.y"
+#line 1380 "bison_parser.y"
               { (yyval.sval) = nullptr; }
-#line 5563 "bison_parser.cpp"
+#line 5561 "bison_parser.cpp"
     break;
 
   case 316: /* table_alias: AS IDENTIFIER '(' ident_commalist ')'  */
-#line 1384 "bison_parser.y"
+#line 1382 "bison_parser.y"
                                                             { (yyval.alias_t) = new Alias((yyvsp[-3].sval), (yyvsp[-1].str_vec)); }
-#line 5569 "bison_parser.cpp"
+#line 5567 "bison_parser.cpp"
     break;
 
   case 318: /* opt_table_alias: %empty  */
-#line 1386 "bison_parser.y"
+#line 1384 "bison_parser.y"
                                             { (yyval.alias_t) = nullptr; }
-#line 5575 "bison_parser.cpp"
+#line 5573 "bison_parser.cpp"
     break;
 
   case 319: /* alias: AS IDENTIFIER  */
-#line 1388 "bison_parser.y"
+#line 1386 "bison_parser.y"
                       { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
-#line 5581 "bison_parser.cpp"
+#line 5579 "bison_parser.cpp"
     break;
 
   case 320: /* alias: IDENTIFIER  */
-#line 1389 "bison_parser.y"
+#line 1387 "bison_parser.y"
              { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
-#line 5587 "bison_parser.cpp"
+#line 5585 "bison_parser.cpp"
     break;
 
   case 322: /* opt_alias: %empty  */
-#line 1391 "bison_parser.y"
+#line 1389 "bison_parser.y"
                                 { (yyval.alias_t) = nullptr; }
-#line 5593 "bison_parser.cpp"
+#line 5591 "bison_parser.cpp"
     break;
 
   case 323: /* opt_locking_clause: opt_locking_clause_list  */
-#line 1397 "bison_parser.y"
+#line 1395 "bison_parser.y"
                                              { (yyval.locking_clause_vec) = (yyvsp[0].locking_clause_vec); }
-#line 5599 "bison_parser.cpp"
+#line 5597 "bison_parser.cpp"
     break;
 
   case 324: /* opt_locking_clause: %empty  */
-#line 1398 "bison_parser.y"
+#line 1396 "bison_parser.y"
               { (yyval.locking_clause_vec) = nullptr; }
-#line 5605 "bison_parser.cpp"
+#line 5603 "bison_parser.cpp"
     break;
 
   case 325: /* opt_locking_clause_list: locking_clause  */
-#line 1400 "bison_parser.y"
+#line 1398 "bison_parser.y"
                                          {
   (yyval.locking_clause_vec) = new std::vector<LockingClause*>();
   (yyval.locking_clause_vec)->push_back((yyvsp[0].locking_t));
 }
-#line 5614 "bison_parser.cpp"
+#line 5612 "bison_parser.cpp"
     break;
 
   case 326: /* opt_locking_clause_list: opt_locking_clause_list locking_clause  */
-#line 1404 "bison_parser.y"
+#line 1402 "bison_parser.y"
                                          {
   (yyvsp[-1].locking_clause_vec)->push_back((yyvsp[0].locking_t));
   (yyval.locking_clause_vec) = (yyvsp[-1].locking_clause_vec);
 }
-#line 5623 "bison_parser.cpp"
+#line 5621 "bison_parser.cpp"
     break;
 
   case 327: /* locking_clause: FOR row_lock_mode opt_row_lock_policy  */
-#line 1409 "bison_parser.y"
+#line 1407 "bison_parser.y"
                                                        {
   (yyval.locking_t) = new LockingClause();
   (yyval.locking_t)->rowLockMode = (yyvsp[-1].lock_mode_t);
   (yyval.locking_t)->rowLockWaitPolicy = (yyvsp[0].lock_wait_policy_t);
   (yyval.locking_t)->tables = nullptr;
 }
-#line 5634 "bison_parser.cpp"
+#line 5632 "bison_parser.cpp"
     break;
 
   case 328: /* locking_clause: FOR row_lock_mode OF ident_commalist opt_row_lock_policy  */
-#line 1415 "bison_parser.y"
+#line 1413 "bison_parser.y"
                                                            {
   (yyval.locking_t) = new LockingClause();
   (yyval.locking_t)->rowLockMode = (yyvsp[-3].lock_mode_t);
   (yyval.locking_t)->tables = (yyvsp[-1].str_vec);
   (yyval.locking_t)->rowLockWaitPolicy = (yyvsp[0].lock_wait_policy_t);
 }
-#line 5645 "bison_parser.cpp"
+#line 5643 "bison_parser.cpp"
     break;
 
   case 329: /* row_lock_mode: UPDATE  */
-#line 1422 "bison_parser.y"
+#line 1420 "bison_parser.y"
                        { (yyval.lock_mode_t) = RowLockMode::ForUpdate; }
-#line 5651 "bison_parser.cpp"
+#line 5649 "bison_parser.cpp"
     break;
 
   case 330: /* row_lock_mode: NO KEY UPDATE  */
-#line 1423 "bison_parser.y"
+#line 1421 "bison_parser.y"
                 { (yyval.lock_mode_t) = RowLockMode::ForNoKeyUpdate; }
-#line 5657 "bison_parser.cpp"
+#line 5655 "bison_parser.cpp"
     break;
 
   case 331: /* row_lock_mode: SHARE  */
-#line 1424 "bison_parser.y"
+#line 1422 "bison_parser.y"
         { (yyval.lock_mode_t) = RowLockMode::ForShare; }
-#line 5663 "bison_parser.cpp"
+#line 5661 "bison_parser.cpp"
     break;
 
   case 332: /* row_lock_mode: KEY SHARE  */
-#line 1425 "bison_parser.y"
+#line 1423 "bison_parser.y"
             { (yyval.lock_mode_t) = RowLockMode::ForKeyShare; }
-#line 5669 "bison_parser.cpp"
+#line 5667 "bison_parser.cpp"
     break;
 
   case 333: /* opt_row_lock_policy: SKIP LOCKED  */
-#line 1427 "bison_parser.y"
+#line 1425 "bison_parser.y"
                                   { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::SkipLocked; }
-#line 5675 "bison_parser.cpp"
+#line 5673 "bison_parser.cpp"
     break;
 
   case 334: /* opt_row_lock_policy: NOWAIT  */
-#line 1428 "bison_parser.y"
+#line 1426 "bison_parser.y"
          { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::NoWait; }
-#line 5681 "bison_parser.cpp"
+#line 5679 "bison_parser.cpp"
     break;
 
   case 335: /* opt_row_lock_policy: %empty  */
-#line 1429 "bison_parser.y"
+#line 1427 "bison_parser.y"
               { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::None; }
-#line 5687 "bison_parser.cpp"
+#line 5685 "bison_parser.cpp"
     break;
 
   case 337: /* opt_with_clause: %empty  */
-#line 1435 "bison_parser.y"
+#line 1433 "bison_parser.y"
                                             { (yyval.with_description_vec) = nullptr; }
-#line 5693 "bison_parser.cpp"
+#line 5691 "bison_parser.cpp"
     break;
 
   case 338: /* with_clause: WITH with_description_list  */
-#line 1437 "bison_parser.y"
+#line 1435 "bison_parser.y"
                                          { (yyval.with_description_vec) = (yyvsp[0].with_description_vec); }
-#line 5699 "bison_parser.cpp"
+#line 5697 "bison_parser.cpp"
     break;
 
   case 339: /* with_description_list: with_description  */
-#line 1439 "bison_parser.y"
+#line 1437 "bison_parser.y"
                                          {
   (yyval.with_description_vec) = new std::vector<WithDescription*>();
   (yyval.with_description_vec)->push_back((yyvsp[0].with_description_t));
 }
-#line 5708 "bison_parser.cpp"
+#line 5706 "bison_parser.cpp"
     break;
 
   case 340: /* with_description_list: with_description_list ',' with_description  */
-#line 1443 "bison_parser.y"
+#line 1441 "bison_parser.y"
                                              {
   (yyvsp[-2].with_description_vec)->push_back((yyvsp[0].with_description_t));
   (yyval.with_description_vec) = (yyvsp[-2].with_description_vec);
 }
-#line 5717 "bison_parser.cpp"
+#line 5715 "bison_parser.cpp"
     break;
 
   case 341: /* with_description: IDENTIFIER AS select_with_paren  */
-#line 1448 "bison_parser.y"
+#line 1446 "bison_parser.y"
                                                    {
   (yyval.with_description_t) = new WithDescription();
   (yyval.with_description_t)->alias = (yyvsp[-2].sval);
   (yyval.with_description_t)->select = (yyvsp[0].select_stmt);
 }
-#line 5727 "bison_parser.cpp"
+#line 5725 "bison_parser.cpp"
     break;
 
   case 342: /* join_clause: table_ref_atomic NATURAL JOIN nonjoin_table_ref_atomic  */
-#line 1458 "bison_parser.y"
+#line 1456 "bison_parser.y"
                                                                      {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
@@ -5735,11 +5733,11 @@ yyreduce:
   (yyval.table)->join->left = (yyvsp[-3].table);
   (yyval.table)->join->right = (yyvsp[0].table);
 }
-#line 5739 "bison_parser.cpp"
+#line 5737 "bison_parser.cpp"
     break;
 
   case 343: /* join_clause: table_ref_atomic opt_join_type JOIN table_ref_atomic ON join_condition  */
-#line 1465 "bison_parser.y"
+#line 1463 "bison_parser.y"
                                                                          {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
@@ -5748,11 +5746,11 @@ yyreduce:
   (yyval.table)->join->right = (yyvsp[-2].table);
   (yyval.table)->join->condition = (yyvsp[0].expr);
 }
-#line 5752 "bison_parser.cpp"
+#line 5750 "bison_parser.cpp"
     break;
 
   case 344: /* join_clause: table_ref_atomic opt_join_type JOIN table_ref_atomic USING '(' ident_commalist ')'  */
-#line 1473 "bison_parser.y"
+#line 1471 "bison_parser.y"
                                                                                      {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
@@ -5761,89 +5759,89 @@ yyreduce:
   (yyval.table)->join->right = (yyvsp[-4].table);
   (yyval.table)->join->namedColumns = (yyvsp[-1].str_vec);
 }
-#line 5765 "bison_parser.cpp"
+#line 5763 "bison_parser.cpp"
     break;
 
   case 345: /* opt_join_type: INNER  */
-#line 1482 "bison_parser.y"
+#line 1480 "bison_parser.y"
                       { (yyval.join_type) = kJoinInner; }
-#line 5771 "bison_parser.cpp"
+#line 5769 "bison_parser.cpp"
     break;
 
   case 346: /* opt_join_type: LEFT OUTER  */
-#line 1483 "bison_parser.y"
+#line 1481 "bison_parser.y"
              { (yyval.join_type) = kJoinLeft; }
-#line 5777 "bison_parser.cpp"
+#line 5775 "bison_parser.cpp"
     break;
 
   case 347: /* opt_join_type: LEFT  */
-#line 1484 "bison_parser.y"
+#line 1482 "bison_parser.y"
        { (yyval.join_type) = kJoinLeft; }
-#line 5783 "bison_parser.cpp"
+#line 5781 "bison_parser.cpp"
     break;
 
   case 348: /* opt_join_type: RIGHT OUTER  */
-#line 1485 "bison_parser.y"
+#line 1483 "bison_parser.y"
               { (yyval.join_type) = kJoinRight; }
-#line 5789 "bison_parser.cpp"
+#line 5787 "bison_parser.cpp"
     break;
 
   case 349: /* opt_join_type: RIGHT  */
-#line 1486 "bison_parser.y"
+#line 1484 "bison_parser.y"
         { (yyval.join_type) = kJoinRight; }
-#line 5795 "bison_parser.cpp"
+#line 5793 "bison_parser.cpp"
     break;
 
   case 350: /* opt_join_type: FULL OUTER  */
-#line 1487 "bison_parser.y"
+#line 1485 "bison_parser.y"
              { (yyval.join_type) = kJoinFull; }
-#line 5801 "bison_parser.cpp"
+#line 5799 "bison_parser.cpp"
     break;
 
   case 351: /* opt_join_type: OUTER  */
-#line 1488 "bison_parser.y"
+#line 1486 "bison_parser.y"
         { (yyval.join_type) = kJoinFull; }
-#line 5807 "bison_parser.cpp"
+#line 5805 "bison_parser.cpp"
     break;
 
   case 352: /* opt_join_type: FULL  */
-#line 1489 "bison_parser.y"
+#line 1487 "bison_parser.y"
        { (yyval.join_type) = kJoinFull; }
-#line 5813 "bison_parser.cpp"
+#line 5811 "bison_parser.cpp"
     break;
 
   case 353: /* opt_join_type: CROSS  */
-#line 1490 "bison_parser.y"
+#line 1488 "bison_parser.y"
         { (yyval.join_type) = kJoinCross; }
-#line 5819 "bison_parser.cpp"
+#line 5817 "bison_parser.cpp"
     break;
 
   case 354: /* opt_join_type: %empty  */
-#line 1491 "bison_parser.y"
+#line 1489 "bison_parser.y"
                        { (yyval.join_type) = kJoinInner; }
-#line 5825 "bison_parser.cpp"
+#line 5823 "bison_parser.cpp"
     break;
 
   case 358: /* ident_commalist: IDENTIFIER  */
-#line 1502 "bison_parser.y"
+#line 1500 "bison_parser.y"
                              {
   (yyval.str_vec) = new std::vector<char*>();
   (yyval.str_vec)->push_back((yyvsp[0].sval));
 }
-#line 5834 "bison_parser.cpp"
+#line 5832 "bison_parser.cpp"
     break;
 
   case 359: /* ident_commalist: ident_commalist ',' IDENTIFIER  */
-#line 1506 "bison_parser.y"
+#line 1504 "bison_parser.y"
                                  {
   (yyvsp[-2].str_vec)->push_back((yyvsp[0].sval));
   (yyval.str_vec) = (yyvsp[-2].str_vec);
 }
-#line 5843 "bison_parser.cpp"
+#line 5841 "bison_parser.cpp"
     break;
 
 
-#line 5847 "bison_parser.cpp"
+#line 5845 "bison_parser.cpp"
 
       default: break;
     }
@@ -6072,7 +6070,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 1512 "bison_parser.y"
+#line 1510 "bison_parser.y"
 
 
 /*********************************

--- a/src/parser/bison_parser.h
+++ b/src/parser/bison_parser.h
@@ -53,7 +53,7 @@
 extern int hsql_debug;
 #endif
 /* "%code requires" blocks.  */
-#line 39 "bison_parser.y"
+#line 54 "bison_parser.y"
 
 // %code requires block
 
@@ -276,7 +276,7 @@ extern int hsql_debug;
 #if ! defined HSQL_STYPE && ! defined HSQL_STYPE_IS_DECLARED
 union HSQL_STYPE
 {
-#line 102 "bison_parser.y"
+#line 117 "bison_parser.y"
 
   // clang-format on
   bool bval;

--- a/src/parser/bison_parser.h
+++ b/src/parser/bison_parser.h
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -29,6 +30,10 @@
 
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
+
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
 #ifndef YY_HSQL_BISON_PARSER_H_INCLUDED
 # define YY_HSQL_BISON_PARSER_H_INCLUDED
@@ -48,7 +53,7 @@
 extern int hsql_debug;
 #endif
 /* "%code requires" blocks.  */
-#line 39 "bison_parser.y" /* yacc.c:1909  */
+#line 39 "bison_parser.y"
 
 // %code requires block
 
@@ -71,201 +76,207 @@ extern int hsql_debug;
     }                                         \
   }
 
-#line 75 "bison_parser.h" /* yacc.c:1909  */
+#line 80 "bison_parser.h"
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef HSQL_TOKENTYPE
 # define HSQL_TOKENTYPE
   enum hsql_tokentype
   {
-    SQL_IDENTIFIER = 258,
-    SQL_STRING = 259,
-    SQL_FLOATVAL = 260,
-    SQL_INTVAL = 261,
-    SQL_DEALLOCATE = 262,
-    SQL_PARAMETERS = 263,
-    SQL_INTERSECT = 264,
-    SQL_TEMPORARY = 265,
-    SQL_TIMESTAMP = 266,
-    SQL_DISTINCT = 267,
-    SQL_NVARCHAR = 268,
-    SQL_RESTRICT = 269,
-    SQL_TRUNCATE = 270,
-    SQL_ANALYZE = 271,
-    SQL_BETWEEN = 272,
-    SQL_CASCADE = 273,
-    SQL_COLUMNS = 274,
-    SQL_CONTROL = 275,
-    SQL_DEFAULT = 276,
-    SQL_EXECUTE = 277,
-    SQL_EXPLAIN = 278,
-    SQL_ENCODING = 279,
-    SQL_INTEGER = 280,
-    SQL_NATURAL = 281,
-    SQL_PREPARE = 282,
-    SQL_SCHEMAS = 283,
-    SQL_CHARACTER_VARYING = 284,
-    SQL_REAL = 285,
-    SQL_DECIMAL = 286,
-    SQL_SMALLINT = 287,
-    SQL_BIGINT = 288,
-    SQL_SPATIAL = 289,
-    SQL_VARCHAR = 290,
-    SQL_VIRTUAL = 291,
-    SQL_DESCRIBE = 292,
-    SQL_BEFORE = 293,
-    SQL_COLUMN = 294,
-    SQL_CREATE = 295,
-    SQL_DELETE = 296,
-    SQL_DIRECT = 297,
-    SQL_DOUBLE = 298,
-    SQL_ESCAPE = 299,
-    SQL_EXCEPT = 300,
-    SQL_EXISTS = 301,
-    SQL_EXTRACT = 302,
-    SQL_CAST = 303,
-    SQL_FORMAT = 304,
-    SQL_GLOBAL = 305,
-    SQL_HAVING = 306,
-    SQL_IMPORT = 307,
-    SQL_INSERT = 308,
-    SQL_ISNULL = 309,
-    SQL_OFFSET = 310,
-    SQL_RENAME = 311,
-    SQL_SCHEMA = 312,
-    SQL_SELECT = 313,
-    SQL_SORTED = 314,
-    SQL_TABLES = 315,
-    SQL_UNLOAD = 316,
-    SQL_UPDATE = 317,
-    SQL_VALUES = 318,
-    SQL_AFTER = 319,
-    SQL_ALTER = 320,
-    SQL_CROSS = 321,
-    SQL_DELTA = 322,
-    SQL_FLOAT = 323,
-    SQL_GROUP = 324,
-    SQL_INDEX = 325,
-    SQL_INNER = 326,
-    SQL_LIMIT = 327,
-    SQL_LOCAL = 328,
-    SQL_MERGE = 329,
-    SQL_MINUS = 330,
-    SQL_ORDER = 331,
-    SQL_OVER = 332,
-    SQL_OUTER = 333,
-    SQL_RIGHT = 334,
-    SQL_TABLE = 335,
-    SQL_UNION = 336,
-    SQL_USING = 337,
-    SQL_WHERE = 338,
-    SQL_CALL = 339,
-    SQL_CASE = 340,
-    SQL_CHAR = 341,
-    SQL_COPY = 342,
-    SQL_DATE = 343,
-    SQL_DATETIME = 344,
-    SQL_DESC = 345,
-    SQL_DROP = 346,
-    SQL_ELSE = 347,
-    SQL_FILE = 348,
-    SQL_FROM = 349,
-    SQL_FULL = 350,
-    SQL_HASH = 351,
-    SQL_HINT = 352,
-    SQL_INTO = 353,
-    SQL_JOIN = 354,
-    SQL_LEFT = 355,
-    SQL_LIKE = 356,
-    SQL_LOAD = 357,
-    SQL_LONG = 358,
-    SQL_NULL = 359,
-    SQL_PARTITION = 360,
-    SQL_PLAN = 361,
-    SQL_SHOW = 362,
-    SQL_TEXT = 363,
-    SQL_THEN = 364,
-    SQL_TIME = 365,
-    SQL_VIEW = 366,
-    SQL_WHEN = 367,
-    SQL_WITH = 368,
-    SQL_ADD = 369,
-    SQL_ALL = 370,
-    SQL_AND = 371,
-    SQL_ASC = 372,
-    SQL_END = 373,
-    SQL_FOR = 374,
-    SQL_INT = 375,
-    SQL_NOT = 376,
-    SQL_OFF = 377,
-    SQL_SET = 378,
-    SQL_TOP = 379,
-    SQL_AS = 380,
-    SQL_BY = 381,
-    SQL_IF = 382,
-    SQL_IN = 383,
-    SQL_IS = 384,
-    SQL_OF = 385,
-    SQL_ON = 386,
-    SQL_OR = 387,
-    SQL_TO = 388,
-    SQL_NO = 389,
-    SQL_ARRAY = 390,
-    SQL_CONCAT = 391,
-    SQL_ILIKE = 392,
-    SQL_SECOND = 393,
-    SQL_MINUTE = 394,
-    SQL_HOUR = 395,
-    SQL_DAY = 396,
-    SQL_MONTH = 397,
-    SQL_YEAR = 398,
-    SQL_SECONDS = 399,
-    SQL_MINUTES = 400,
-    SQL_HOURS = 401,
-    SQL_DAYS = 402,
-    SQL_MONTHS = 403,
-    SQL_YEARS = 404,
-    SQL_INTERVAL = 405,
-    SQL_TRUE = 406,
-    SQL_FALSE = 407,
-    SQL_BOOLEAN = 408,
-    SQL_TRANSACTION = 409,
-    SQL_BEGIN = 410,
-    SQL_COMMIT = 411,
-    SQL_ROLLBACK = 412,
-    SQL_NOWAIT = 413,
-    SQL_SKIP = 414,
-    SQL_LOCKED = 415,
-    SQL_SHARE = 416,
-    SQL_RANGE = 417,
-    SQL_ROWS = 418,
-    SQL_GROUPS = 419,
-    SQL_UNBOUNDED = 420,
-    SQL_FOLLOWING = 421,
-    SQL_PRECEDING = 422,
-    SQL_CURRENT_ROW = 423,
-    SQL_UNIQUE = 424,
-    SQL_PRIMARY = 425,
-    SQL_FOREIGN = 426,
-    SQL_KEY = 427,
-    SQL_REFERENCES = 428,
-    SQL_EQUALS = 429,
-    SQL_NOTEQUALS = 430,
-    SQL_LESS = 431,
-    SQL_GREATER = 432,
-    SQL_LESSEQ = 433,
-    SQL_GREATEREQ = 434,
-    SQL_NOTNULL = 435,
-    SQL_UMINUS = 436
+    SQL_HSQL_EMPTY = -2,
+    SQL_YYEOF = 0,                 /* "end of file"  */
+    SQL_HSQL_error = 256,          /* error  */
+    SQL_HSQL_UNDEF = 257,          /* "invalid token"  */
+    SQL_IDENTIFIER = 258,          /* IDENTIFIER  */
+    SQL_STRING = 259,              /* STRING  */
+    SQL_FLOATVAL = 260,            /* FLOATVAL  */
+    SQL_INTVAL = 261,              /* INTVAL  */
+    SQL_DOLLAR_PARAM = 262,        /* DOLLAR_PARAM  */
+    SQL_NAMED_PARAM = 263,         /* NAMED_PARAM  */
+    SQL_DEALLOCATE = 264,          /* DEALLOCATE  */
+    SQL_PARAMETERS = 265,          /* PARAMETERS  */
+    SQL_INTERSECT = 266,           /* INTERSECT  */
+    SQL_TEMPORARY = 267,           /* TEMPORARY  */
+    SQL_TIMESTAMP = 268,           /* TIMESTAMP  */
+    SQL_DISTINCT = 269,            /* DISTINCT  */
+    SQL_NVARCHAR = 270,            /* NVARCHAR  */
+    SQL_RESTRICT = 271,            /* RESTRICT  */
+    SQL_TRUNCATE = 272,            /* TRUNCATE  */
+    SQL_ANALYZE = 273,             /* ANALYZE  */
+    SQL_BETWEEN = 274,             /* BETWEEN  */
+    SQL_CASCADE = 275,             /* CASCADE  */
+    SQL_COLUMNS = 276,             /* COLUMNS  */
+    SQL_CONTROL = 277,             /* CONTROL  */
+    SQL_DEFAULT = 278,             /* DEFAULT  */
+    SQL_EXECUTE = 279,             /* EXECUTE  */
+    SQL_EXPLAIN = 280,             /* EXPLAIN  */
+    SQL_ENCODING = 281,            /* ENCODING  */
+    SQL_INTEGER = 282,             /* INTEGER  */
+    SQL_NATURAL = 283,             /* NATURAL  */
+    SQL_PREPARE = 284,             /* PREPARE  */
+    SQL_SCHEMAS = 285,             /* SCHEMAS  */
+    SQL_CHARACTER_VARYING = 286,   /* CHARACTER_VARYING  */
+    SQL_REAL = 287,                /* REAL  */
+    SQL_DECIMAL = 288,             /* DECIMAL  */
+    SQL_SMALLINT = 289,            /* SMALLINT  */
+    SQL_BIGINT = 290,              /* BIGINT  */
+    SQL_SPATIAL = 291,             /* SPATIAL  */
+    SQL_VARCHAR = 292,             /* VARCHAR  */
+    SQL_VIRTUAL = 293,             /* VIRTUAL  */
+    SQL_DESCRIBE = 294,            /* DESCRIBE  */
+    SQL_BEFORE = 295,              /* BEFORE  */
+    SQL_COLUMN = 296,              /* COLUMN  */
+    SQL_CREATE = 297,              /* CREATE  */
+    SQL_DELETE = 298,              /* DELETE  */
+    SQL_DIRECT = 299,              /* DIRECT  */
+    SQL_DOUBLE = 300,              /* DOUBLE  */
+    SQL_ESCAPE = 301,              /* ESCAPE  */
+    SQL_EXCEPT = 302,              /* EXCEPT  */
+    SQL_EXISTS = 303,              /* EXISTS  */
+    SQL_EXTRACT = 304,             /* EXTRACT  */
+    SQL_CAST = 305,                /* CAST  */
+    SQL_FORMAT = 306,              /* FORMAT  */
+    SQL_GLOBAL = 307,              /* GLOBAL  */
+    SQL_HAVING = 308,              /* HAVING  */
+    SQL_IMPORT = 309,              /* IMPORT  */
+    SQL_INSERT = 310,              /* INSERT  */
+    SQL_ISNULL = 311,              /* ISNULL  */
+    SQL_OFFSET = 312,              /* OFFSET  */
+    SQL_RENAME = 313,              /* RENAME  */
+    SQL_SCHEMA = 314,              /* SCHEMA  */
+    SQL_SELECT = 315,              /* SELECT  */
+    SQL_SORTED = 316,              /* SORTED  */
+    SQL_TABLES = 317,              /* TABLES  */
+    SQL_UNLOAD = 318,              /* UNLOAD  */
+    SQL_UPDATE = 319,              /* UPDATE  */
+    SQL_VALUES = 320,              /* VALUES  */
+    SQL_AFTER = 321,               /* AFTER  */
+    SQL_ALTER = 322,               /* ALTER  */
+    SQL_CROSS = 323,               /* CROSS  */
+    SQL_DELTA = 324,               /* DELTA  */
+    SQL_FLOAT = 325,               /* FLOAT  */
+    SQL_GROUP = 326,               /* GROUP  */
+    SQL_INDEX = 327,               /* INDEX  */
+    SQL_INNER = 328,               /* INNER  */
+    SQL_LIMIT = 329,               /* LIMIT  */
+    SQL_LOCAL = 330,               /* LOCAL  */
+    SQL_MERGE = 331,               /* MERGE  */
+    SQL_MINUS = 332,               /* MINUS  */
+    SQL_ORDER = 333,               /* ORDER  */
+    SQL_OVER = 334,                /* OVER  */
+    SQL_OUTER = 335,               /* OUTER  */
+    SQL_RIGHT = 336,               /* RIGHT  */
+    SQL_TABLE = 337,               /* TABLE  */
+    SQL_UNION = 338,               /* UNION  */
+    SQL_USING = 339,               /* USING  */
+    SQL_WHERE = 340,               /* WHERE  */
+    SQL_CALL = 341,                /* CALL  */
+    SQL_CASE = 342,                /* CASE  */
+    SQL_CHAR = 343,                /* CHAR  */
+    SQL_COPY = 344,                /* COPY  */
+    SQL_DATE = 345,                /* DATE  */
+    SQL_DATETIME = 346,            /* DATETIME  */
+    SQL_DESC = 347,                /* DESC  */
+    SQL_DROP = 348,                /* DROP  */
+    SQL_ELSE = 349,                /* ELSE  */
+    SQL_FILE = 350,                /* FILE  */
+    SQL_FROM = 351,                /* FROM  */
+    SQL_FULL = 352,                /* FULL  */
+    SQL_HASH = 353,                /* HASH  */
+    SQL_HINT = 354,                /* HINT  */
+    SQL_INTO = 355,                /* INTO  */
+    SQL_JOIN = 356,                /* JOIN  */
+    SQL_LEFT = 357,                /* LEFT  */
+    SQL_LIKE = 358,                /* LIKE  */
+    SQL_LOAD = 359,                /* LOAD  */
+    SQL_LONG = 360,                /* LONG  */
+    SQL_NULL = 361,                /* NULL  */
+    SQL_PARTITION = 362,           /* PARTITION  */
+    SQL_PLAN = 363,                /* PLAN  */
+    SQL_SHOW = 364,                /* SHOW  */
+    SQL_TEXT = 365,                /* TEXT  */
+    SQL_THEN = 366,                /* THEN  */
+    SQL_TIME = 367,                /* TIME  */
+    SQL_VIEW = 368,                /* VIEW  */
+    SQL_WHEN = 369,                /* WHEN  */
+    SQL_WITH = 370,                /* WITH  */
+    SQL_ADD = 371,                 /* ADD  */
+    SQL_ALL = 372,                 /* ALL  */
+    SQL_AND = 373,                 /* AND  */
+    SQL_ASC = 374,                 /* ASC  */
+    SQL_END = 375,                 /* END  */
+    SQL_FOR = 376,                 /* FOR  */
+    SQL_INT = 377,                 /* INT  */
+    SQL_NOT = 378,                 /* NOT  */
+    SQL_OFF = 379,                 /* OFF  */
+    SQL_SET = 380,                 /* SET  */
+    SQL_TOP = 381,                 /* TOP  */
+    SQL_AS = 382,                  /* AS  */
+    SQL_BY = 383,                  /* BY  */
+    SQL_IF = 384,                  /* IF  */
+    SQL_IN = 385,                  /* IN  */
+    SQL_IS = 386,                  /* IS  */
+    SQL_OF = 387,                  /* OF  */
+    SQL_ON = 388,                  /* ON  */
+    SQL_OR = 389,                  /* OR  */
+    SQL_TO = 390,                  /* TO  */
+    SQL_NO = 391,                  /* NO  */
+    SQL_ARRAY = 392,               /* ARRAY  */
+    SQL_CONCAT = 393,              /* CONCAT  */
+    SQL_ILIKE = 394,               /* ILIKE  */
+    SQL_SECOND = 395,              /* SECOND  */
+    SQL_MINUTE = 396,              /* MINUTE  */
+    SQL_HOUR = 397,                /* HOUR  */
+    SQL_DAY = 398,                 /* DAY  */
+    SQL_MONTH = 399,               /* MONTH  */
+    SQL_YEAR = 400,                /* YEAR  */
+    SQL_SECONDS = 401,             /* SECONDS  */
+    SQL_MINUTES = 402,             /* MINUTES  */
+    SQL_HOURS = 403,               /* HOURS  */
+    SQL_DAYS = 404,                /* DAYS  */
+    SQL_MONTHS = 405,              /* MONTHS  */
+    SQL_YEARS = 406,               /* YEARS  */
+    SQL_INTERVAL = 407,            /* INTERVAL  */
+    SQL_TRUE = 408,                /* TRUE  */
+    SQL_FALSE = 409,               /* FALSE  */
+    SQL_BOOLEAN = 410,             /* BOOLEAN  */
+    SQL_TRANSACTION = 411,         /* TRANSACTION  */
+    SQL_BEGIN = 412,               /* BEGIN  */
+    SQL_COMMIT = 413,              /* COMMIT  */
+    SQL_ROLLBACK = 414,            /* ROLLBACK  */
+    SQL_NOWAIT = 415,              /* NOWAIT  */
+    SQL_SKIP = 416,                /* SKIP  */
+    SQL_LOCKED = 417,              /* LOCKED  */
+    SQL_SHARE = 418,               /* SHARE  */
+    SQL_RANGE = 419,               /* RANGE  */
+    SQL_ROWS = 420,                /* ROWS  */
+    SQL_GROUPS = 421,              /* GROUPS  */
+    SQL_UNBOUNDED = 422,           /* UNBOUNDED  */
+    SQL_FOLLOWING = 423,           /* FOLLOWING  */
+    SQL_PRECEDING = 424,           /* PRECEDING  */
+    SQL_CURRENT_ROW = 425,         /* CURRENT_ROW  */
+    SQL_UNIQUE = 426,              /* UNIQUE  */
+    SQL_PRIMARY = 427,             /* PRIMARY  */
+    SQL_FOREIGN = 428,             /* FOREIGN  */
+    SQL_KEY = 429,                 /* KEY  */
+    SQL_REFERENCES = 430,          /* REFERENCES  */
+    SQL_EQUALS = 431,              /* EQUALS  */
+    SQL_NOTEQUALS = 432,           /* NOTEQUALS  */
+    SQL_LESS = 433,                /* LESS  */
+    SQL_GREATER = 434,             /* GREATER  */
+    SQL_LESSEQ = 435,              /* LESSEQ  */
+    SQL_GREATEREQ = 436,           /* GREATEREQ  */
+    SQL_NOTNULL = 437,             /* NOTNULL  */
+    SQL_UMINUS = 438               /* UMINUS  */
   };
+  typedef enum hsql_tokentype hsql_token_kind_t;
 #endif
 
 /* Value type.  */
 #if ! defined HSQL_STYPE && ! defined HSQL_STYPE_IS_DECLARED
-
 union HSQL_STYPE
 {
-#line 102 "bison_parser.y" /* yacc.c:1909  */
+#line 102 "bison_parser.y"
 
   // clang-format on
   bool bval;
@@ -340,9 +351,9 @@ union HSQL_STYPE
 
   // clang-format off
 
-#line 344 "bison_parser.h" /* yacc.c:1909  */
-};
+#line 355 "bison_parser.h"
 
+};
 typedef union HSQL_STYPE HSQL_STYPE;
 # define HSQL_STYPE_IS_TRIVIAL 1
 # define HSQL_STYPE_IS_DECLARED 1
@@ -364,6 +375,8 @@ struct HSQL_LTYPE
 
 
 
+
 int hsql_parse (hsql::SQLParserResult* result, yyscan_t scanner);
+
 
 #endif /* !YY_HSQL_BISON_PARSER_H_INCLUDED  */

--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -204,6 +204,23 @@
   free($$->second);
   delete ($$);
 } <csv_option_t>
+%destructor {
+  // ColumnConstraints owns heap-allocated members (constraints, references).
+  // The happy path transfers those pointers into a ColumnDefinition and then
+  // deletes the wrapper; bison only reaches this destructor on parse error,
+  // when the inner pointers are still owned by the wrapper and must be
+  // released here to avoid leaks.
+  if ($$) {
+    delete $$->constraints;
+    if ($$->references) {
+      for (auto ptr : *($$->references)) {
+        delete ptr;
+      }
+    }
+    delete $$->references;
+  }
+  delete ($$);
+} <column_constraints_t>
 %destructor { delete ($$); } <*>
 
 

--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -1095,14 +1095,7 @@ casted_extended_literal : extended_literal | CAST '(' extended_literal AS column
   $$ = Expr::makeCast($3, $5);
 };
 
-extended_literal : literal {
-  if ($1->type == ExprType::kExprParameter) {
-    delete $1;
-    yyerror(&yyloc, result, scanner, "Parameter ? is not a valid literal.");
-    YYERROR;
-  }
-  $$ = $1;
-}
+extended_literal : literal { $$ = $1; }
 | '-' num_literal { $$ = Expr::makeOpUnary(kOpUnaryMinus, $2); };
 | '-' interval_literal { $$ = Expr::makeOpUnary(kOpUnaryMinus, $2); };
 
@@ -1311,7 +1304,7 @@ interval_literal : INTVAL duration_field { $$ = Expr::makeIntervalLiteral($1, $2
 
 param_expr : '?' {
   $$ = Expr::makeParameter(yylloc.total_column);
-  $$->ival2 = yyloc.param_list.size();
+  $$->ival2 = yylloc.total_column - 1;  // source column (0-based) of the '?' token
   yyloc.param_list.push_back($$);
 }
 | DOLLAR_PARAM {
@@ -1320,10 +1313,15 @@ param_expr : '?' {
     YYERROR;
   }
   $$ = Expr::makeDollarParameter($1);
+  // length of $N token: 1 for '$' + digit count of N
+  int64_t dollarLen = 1;
+  for (int64_t v = $1; v > 0; v /= 10) ++dollarLen;
+  $$->ival2 = yylloc.total_column - dollarLen;
   yyloc.param_list.push_back($$);
 }
 | NAMED_PARAM {
   $$ = Expr::makeNamedParameter($1);
+  $$->ival2 = yylloc.total_column - 1 - (int64_t)strlen($1);
   yyloc.param_list.push_back($$);
 };
 

--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -213,6 +213,8 @@
 %token <sval> IDENTIFIER STRING
 %token <fval> FLOATVAL
 %token <ival> INTVAL
+%token <ival> DOLLAR_PARAM
+%token <sval> NAMED_PARAM
 
 /* SQL Keywords */
 %token DEALLOCATE PARAMETERS INTERSECT TEMPORARY TIMESTAMP
@@ -350,9 +352,10 @@ input : statement_list opt_semicolon {
   for (void* param : yyloc.param_list) {
     if (param) {
       Expr* expr = (Expr*)param;
-      expr->ival = param_id;
+      if (expr->type == kExprParameter) {
+        expr->ival = param_id++;
+      }
       result->addParameter(expr);
-      ++param_id;
     }
   }
     delete $1;
@@ -1172,8 +1175,12 @@ comp_expr : operand '=' operand { $$ = Expr::makeOpBinary($1, kOpEquals, $3); }
 // reduce conflicts when splitting them.
 function_expr : IDENTIFIER '(' ')' opt_window { $$ = Expr::makeFunctionRef($1, new std::vector<Expr*>(), false, $4); }
 | IDENTIFIER '(' opt_distinct expr_list ')' opt_window { $$ = Expr::makeFunctionRef($1, $4, $3, $6); }
-| IDENTIFIER '.' IDENTIFIER '(' ')' opt_window { $$ = Expr::makeFunctionRef($3, $1, new std::vector<Expr*>(), false, $6); }
-| IDENTIFIER '.' IDENTIFIER '(' opt_distinct expr_list ')' opt_window { $$ = Expr::makeFunctionRef($3, $1, $6, $5, $8); };
+| IDENTIFIER '.' IDENTIFIER '(' ')' opt_window {
+  $$ = Expr::makeFunctionRef($3, $1, new std::vector<Expr*>(), false, $6);
+}
+| IDENTIFIER '.' IDENTIFIER '(' opt_distinct expr_list ')' opt_window {
+  $$ = Expr::makeFunctionRef($3, $1, $6, $5, $8);
+};
 
 // Window function expressions, based on https://www.postgresql.org/docs/15/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS
 // We do not support named windows, collations and exclusions (for simplicity) and filters (not part of the SQL standard).
@@ -1305,6 +1312,18 @@ interval_literal : INTVAL duration_field { $$ = Expr::makeIntervalLiteral($1, $2
 param_expr : '?' {
   $$ = Expr::makeParameter(yylloc.total_column);
   $$->ival2 = yyloc.param_list.size();
+  yyloc.param_list.push_back($$);
+}
+| DOLLAR_PARAM {
+  if ($1 < 1) {
+    yyerror(&yyloc, result, scanner, "$0 is not a valid positional parameter.");
+    YYERROR;
+  }
+  $$ = Expr::makeDollarParameter($1);
+  yyloc.param_list.push_back($$);
+}
+| NAMED_PARAM {
+  $$ = Expr::makeNamedParameter($1);
   yyloc.param_list.push_back($$);
 };
 

--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -36,6 +36,21 @@
 
 // Specify code that is included in the generated .h and .c files
 // clang-format off
+
+// Bison 3.x emits `int yynerrs = 0;` in yyparse() and only ever
+// increments it (`++yynerrs`), never reading the value. GCC's
+// -Wunused-but-set-variable (enabled by -Wall on g++ 10+) considers
+// increment-only as "set but not used" and fires on the declaration.
+// Silence it locally so downstream consumers can build with -Wall
+// without per-file -Wno-* flags. %code top injects at the very top
+// of the generated .cpp (not the .h), so the suppression scope is
+// exactly bison_parser.cpp.
+%code top {
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+}
+
 %code requires {
 // %code requires block
 

--- a/src/parser/flex_lexer.cpp
+++ b/src/parser/flex_lexer.cpp
@@ -1,6 +1,6 @@
-#line 2 "flex_lexer.cpp"
+#line 1 "flex_lexer.cpp"
 
-#line 4 "flex_lexer.cpp"
+#line 3 "flex_lexer.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -9,9 +9,243 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 1
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define hsql__create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer hsql__create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define hsql__delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer hsql__delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define hsql__scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer hsql__scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define hsql__scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string hsql__scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define hsql__scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes hsql__scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define hsql__init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer hsql__init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define hsql__flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer hsql__flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define hsql__load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state hsql__load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define hsql__switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer hsql__switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define hsql_push_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state hsql_push_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define hsql_pop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state hsql_pop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define hsql_ensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack hsql_ensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define hsql_lex_ALREADY_DEFINED
+#else
+#define yylex hsql_lex
+#endif
+
+#ifdef yyrestart
+#define hsql_restart_ALREADY_DEFINED
+#else
+#define yyrestart hsql_restart
+#endif
+
+#ifdef yylex_init
+#define hsql_lex_init_ALREADY_DEFINED
+#else
+#define yylex_init hsql_lex_init
+#endif
+
+#ifdef yylex_init_extra
+#define hsql_lex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra hsql_lex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define hsql_lex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy hsql_lex_destroy
+#endif
+
+#ifdef yyget_debug
+#define hsql_get_debug_ALREADY_DEFINED
+#else
+#define yyget_debug hsql_get_debug
+#endif
+
+#ifdef yyset_debug
+#define hsql_set_debug_ALREADY_DEFINED
+#else
+#define yyset_debug hsql_set_debug
+#endif
+
+#ifdef yyget_extra
+#define hsql_get_extra_ALREADY_DEFINED
+#else
+#define yyget_extra hsql_get_extra
+#endif
+
+#ifdef yyset_extra
+#define hsql_set_extra_ALREADY_DEFINED
+#else
+#define yyset_extra hsql_set_extra
+#endif
+
+#ifdef yyget_in
+#define hsql_get_in_ALREADY_DEFINED
+#else
+#define yyget_in hsql_get_in
+#endif
+
+#ifdef yyset_in
+#define hsql_set_in_ALREADY_DEFINED
+#else
+#define yyset_in hsql_set_in
+#endif
+
+#ifdef yyget_out
+#define hsql_get_out_ALREADY_DEFINED
+#else
+#define yyget_out hsql_get_out
+#endif
+
+#ifdef yyset_out
+#define hsql_set_out_ALREADY_DEFINED
+#else
+#define yyset_out hsql_set_out
+#endif
+
+#ifdef yyget_leng
+#define hsql_get_leng_ALREADY_DEFINED
+#else
+#define yyget_leng hsql_get_leng
+#endif
+
+#ifdef yyget_text
+#define hsql_get_text_ALREADY_DEFINED
+#else
+#define yyget_text hsql_get_text
+#endif
+
+#ifdef yyget_lineno
+#define hsql_get_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno hsql_get_lineno
+#endif
+
+#ifdef yyset_lineno
+#define hsql_set_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno hsql_set_lineno
+#endif
+
+#ifdef yyget_column
+#define hsql_get_column_ALREADY_DEFINED
+#else
+#define yyget_column hsql_get_column
+#endif
+
+#ifdef yyset_column
+#define hsql_set_column_ALREADY_DEFINED
+#else
+#define yyset_column hsql_set_column
+#endif
+
+#ifdef yywrap
+#define hsql_wrap_ALREADY_DEFINED
+#else
+#define yywrap hsql_wrap
+#endif
+
+#ifdef yyget_lval
+#define hsql_get_lval_ALREADY_DEFINED
+#else
+#define yyget_lval hsql_get_lval
+#endif
+
+#ifdef yyset_lval
+#define hsql_set_lval_ALREADY_DEFINED
+#else
+#define yyset_lval hsql_set_lval
+#endif
+
+#ifdef yyget_lloc
+#define hsql_get_lloc_ALREADY_DEFINED
+#else
+#define yyget_lloc hsql_get_lloc
+#endif
+
+#ifdef yyset_lloc
+#define hsql_set_lloc_ALREADY_DEFINED
+#else
+#define yyset_lloc hsql_set_lloc
+#endif
+
+#ifdef yyalloc
+#define hsql_alloc_ALREADY_DEFINED
+#else
+#define yyalloc hsql_alloc
+#endif
+
+#ifdef yyrealloc
+#define hsql_realloc_ALREADY_DEFINED
+#else
+#define yyrealloc hsql_realloc
+#endif
+
+#ifdef yyfree
+#define hsql_free_ALREADY_DEFINED
+#else
+#define yyfree hsql_free
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -84,9 +318,15 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
+
+/* begin standard C++ headers. */
 
 /* TODO: this is always defined, so inline it */
 #define yyconst const
@@ -100,12 +340,10 @@ typedef unsigned int flex_uint32_t;
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* An opaque pointer. */
 #ifndef YY_TYPEDEF_YY_SCANNER_T
@@ -129,20 +367,16 @@ typedef void* yyscan_t;
  * definition of BEGIN.
  */
 #define BEGIN yyg->yy_start = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START ((yyg->yy_start - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE hsql_restart(yyin ,yyscanner )
-
+#define YY_NEW_FILE yyrestart( yyin , yyscanner )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -175,7 +409,7 @@ typedef size_t yy_size_t;
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -184,7 +418,7 @@ typedef size_t yy_size_t;
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        yy_size_t yyless_macro_arg = (n); \
+        int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		*yy_cp = yyg->yy_hold_char; \
 		YY_RESTORE_YY_MORE_OFFSET \
@@ -192,7 +426,6 @@ typedef size_t yy_size_t;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, yyg->yytext_ptr , yyscanner )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -235,7 +468,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -252,7 +485,7 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via hsql_restart()), so that the user can continue scanning by
+	 * (via yyrestart()), so that the user can continue scanning by
 	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
@@ -269,73 +502,67 @@ struct yy_buffer_state
 #define YY_CURRENT_BUFFER ( yyg->yy_buffer_stack \
                           ? yyg->yy_buffer_stack[yyg->yy_buffer_stack_top] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE yyg->yy_buffer_stack[yyg->yy_buffer_stack_top]
 
-void hsql_restart (FILE *input_file ,yyscan_t yyscanner );
-void hsql__switch_to_buffer (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__create_buffer (FILE *file,int size ,yyscan_t yyscanner );
-void hsql__delete_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void hsql__flush_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void hsql_push_buffer_state (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-void hsql_pop_buffer_state (yyscan_t yyscanner );
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-static void hsql_ensure_buffer_stack (yyscan_t yyscanner );
-static void hsql__load_buffer_state (yyscan_t yyscanner );
-static void hsql__init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanner );
+static void yyensure_buffer_stack ( yyscan_t yyscanner );
+static void yy_load_buffer_state ( yyscan_t yyscanner );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER , yyscanner)
 
-#define YY_FLUSH_BUFFER hsql__flush_buffer(YY_CURRENT_BUFFER ,yyscanner)
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-YY_BUFFER_STATE hsql__scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
-void *hsql_alloc (yy_size_t ,yyscan_t yyscanner );
-void *hsql_realloc (void *,yy_size_t ,yyscan_t yyscanner );
-void hsql_free (void * ,yyscan_t yyscanner );
-
-#define yy_new_buffer hsql__create_buffer
-
+#define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        hsql_ensure_buffer_stack (yyscanner); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            hsql__create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        hsql_ensure_buffer_stack (yyscanner); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            hsql__create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
 
 #define hsql_wrap(yyscanner) (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
-
-typedef unsigned char YY_CHAR;
+typedef flex_uint8_t YY_CHAR;
 
 typedef int yy_state_type;
 
 #define yytext_ptr yytext_r
 
-static yy_state_type yy_get_previous_state (yyscan_t yyscanner );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  ,yyscan_t yyscanner);
-static int yy_get_next_buffer (yyscan_t yyscanner );
-static void yynoreturn yy_fatal_error (yyconst char* msg ,yyscan_t yyscanner );
+static yy_state_type yy_get_previous_state ( yyscan_t yyscanner );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  , yyscan_t yyscanner);
+static int yy_get_next_buffer ( yyscan_t yyscanner );
+static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
@@ -346,9 +573,8 @@ static void yynoreturn yy_fatal_error (yyconst char* msg ,yyscan_t yyscanner );
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
-
-#define YY_NUM_RULES 189
-#define YY_END_OF_BUFFER 190
+#define YY_NUM_RULES 191
+#define YY_END_OF_BUFFER 192
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -356,84 +582,29 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[1368] =
+static const flex_int16_t yy_accept[1378] =
     {   0,
-        0,    0,  186,  186,    2,    2,  190,  188,    4,    4,
-      188,  188,  177,  184,  177,  177,  181,  177,  177,  177,
-      183,  183,  183,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,  183,  177,  186,  187,    2,    2,    3,
+        0,    0,  188,  188,    2,    2,  192,  190,    4,    4,
+      190,  190,  190,  179,  186,  179,  179,  183,  179,  179,
+      179,  179,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  179,  188,  189,    2,
+        2,    3,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    4,  172,    0,    1,    0,
-      179,  178,  181,  174,  173,  171,  175,  183,  183,  183,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    4,
+      172,    0,  177,    1,    0,  181,  180,  183,  178,  174,
 
-      183,  183,  183,   12,  183,  183,  183,   19,  183,  183,
-      183,  183,  183,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,   73,  183,  183,   76,   85,  183,  183,
-      183,  183,  183,  183,  183,  183,  183,  103,  183,  183,
-      108,  111,  112,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,  149,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,  176,  186,  185,    2,    2,    2,    2,
-        1,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,  182,    0,  178,    5,
-      183,    7,  183,  183,   10,  183,   13,  183,  183,  183,
-
-      183,  183,  183,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,   34,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,  183,  183,   49,  183,  183,  183,  183,
-      183,  183,  183,  183,  183,  183,   60,  183,  183,  183,
-      183,  183,  183,  183,  183,  183,  183,  183,  183,  183,
-       80,  183,  183,   88,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,  183,  104,  183,  183,  183,  109,  183,
-      183,  183,  183,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,  183,  183,  183,  183,  135,  183,  183,
-      183,  183,  183,  183,  183,  183,  183,  183,  183,  150,
-
-      183,  183,  183,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,  183,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    0,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,   20,  183,   22,   23,   24,  183,  183,  183,
-       29,  183,  183,  183,   32,   35,  183,  183,  183,  183,
-      183,   41,  183,  183,  183,   46,   47,  183,  183,  183,
-      183,  183,  183,  183,  183,   57,  183,  183,  183,  183,
-       63,   64,  183,  183,   68,  183,   70,   71,  183,  183,
-
-      183,  183,  183,  183,   84,  183,   87,   89,   90,  183,
-       92,  183,  183,   95,  183,  183,  183,  183,  183,  106,
-      183,  183,  183,  183,  115,  183,  183,  118,  183,  183,
-      183,  183,  123,  183,  183,  183,  183,  183,  129,  183,
-      183,  183,  183,  137,  138,  183,  183,  183,  183,  183,
-      145,  146,  147,  183,  152,  183,  183,  183,  183,  183,
-      183,  183,  183,  183,  162,  183,  164,  183,  166,  167,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+      173,  171,  175,  185,  185,  185,  185,  185,  185,   12,
+      185,  185,  185,   19,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,   73,
+      185,  185,   76,   85,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  103,  185,  185,  108,  111,  112,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  149,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  176,
+      188,  187,    2,    2,    2,    2,    2,    1,    2,    2,
 
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
@@ -444,19 +615,75 @@ static yyconst flex_int16_t yy_accept[1368] =
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,  184,    0,  180,  178,    5,  185,
+
+        7,  185,  185,   10,  185,   13,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,   34,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,   49,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,   60,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,   80,
+      185,  185,   88,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  104,  185,  185,  185,  109,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  135,  185,  185,  185,
+
+      185,  185,  185,  185,  185,  185,  185,  185,  150,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    0,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,   20,  185,   22,   23,   24,  185,  185,  185,
+       29,  185,  185,  185,   32,   35,  185,  185,  185,  185,
+      185,   41,  185,  185,  185,   46,   47,  185,  185,  185,
+      185,  185,  185,  185,  185,   57,  185,  185,  185,  185,
+
+       63,   64,  185,  185,   68,  185,   70,   71,  185,  185,
+      185,  185,  185,  185,   84,  185,   87,   89,   90,  185,
+       92,  185,  185,   95,  185,  185,  185,  185,  185,  106,
+      185,  185,  185,  185,  115,  185,  185,  118,  185,  185,
+      185,  185,  123,  185,  185,  185,  185,  185,  129,  185,
+      185,  185,  185,  137,  138,  185,  185,  185,  185,  185,
+      145,  146,  147,  185,  152,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  162,  185,  164,  185,  166,  167,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+
         2,    2,    2,    2,    2,    2,    2,    2,    0,    6,
+        8,  185,   11,  185,   15,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,   31,  185,  185,  185,  185,  185,
+      185,   40,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,   56,   58,  185,  185,  185,  185,   66,
+      185,   72,   74,  185,   77,   78,  185,  185,  185,  185,
+       91,   93,  185,   96,   97,  185,  100,  185,  185,  185,
+      185,  113,  114,  185,  185,  185,  185,  185,  122,  185,
+      185,  185,  127,  185,  185,  185,  185,  136,  185,  185,
+      185,  142,  185,  185,  185,  185,  185,  155,  185,  185,
 
-        8,  183,   11,  183,   15,  183,  183,  183,  183,  183,
-      183,  183,  183,  183,   31,  183,  183,  183,  183,  183,
-      183,   40,  183,  183,  183,  183,  183,  183,  183,  183,
-      183,  183,  183,   56,   58,  183,  183,  183,  183,   66,
-      183,   72,   74,  183,   77,   78,  183,  183,  183,  183,
-       91,   93,  183,   96,   97,  183,  100,  183,  183,  183,
-      183,  113,  114,  183,  183,  183,  183,  183,  122,  183,
-      183,  183,  127,  183,  183,  183,  183,  136,  183,  183,
-      183,  142,  183,  183,  183,  183,  183,  155,  183,  183,
-      183,  159,  183,  183,  183,  165,  168,    2,    2,    2,
-
+      185,  159,  185,  185,  185,  165,  168,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
@@ -464,68 +691,68 @@ static yyconst flex_int16_t yy_accept[1368] =
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    0,  183,   14,  183,
-
-       17,  183,  183,  183,   25,   27,  183,   30,  183,  183,
-      183,  183,  183,   39,  183,   43,  183,   45,  183,   50,
-       51,  183,   53,  183,  183,  183,  183,   62,   65,   67,
-       69,   75,   79,  183,  183,  183,   86,   94,   98,  101,
-      183,  105,  183,  110,  183,  183,  183,  183,  183,  183,
-      125,  183,  183,  130,  132,  134,  183,  140,  183,  143,
-      183,  183,  183,  183,  183,  156,  157,  158,  160,  183,
-      183,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
 
+        2,    2,    2,    2,    2,    2,    0,  185,   14,  185,
+       17,  185,  185,  185,   25,   27,  185,   30,  185,  185,
+      185,  185,  185,   39,  185,   43,  185,   45,  185,   50,
+       51,  185,   53,  185,  185,  185,  185,   62,   65,   67,
+       69,   75,   79,  185,  185,  185,   86,   94,   98,  101,
+      185,  105,  185,  110,  185,  185,  185,  185,  185,  185,
+      125,  185,  185,  130,  132,  134,  185,  140,  185,  143,
+      185,  185,  185,  185,  185,  156,  157,  158,  160,  185,
+      185,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    0,    9,   16,   18,
-       21,  183,   26,   28,  183,  183,  183,   37,   38,  183,
-      183,  183,   52,   54,   55,  183,   61,   81,  183,  183,
-       99,  102,  183,  183,  183,  183,  120,  121,  183,  183,
-      183,  131,  133,  183,  141,  183,  183,  183,  183,  183,
+       21,  185,   26,   28,  185,  185,  185,   37,   38,  185,
+      185,  185,   52,   54,   55,  185,   61,   81,  185,  185,
+       99,  102,  185,  185,  185,  185,  120,  121,  185,  185,
+      185,  131,  133,  185,  141,  185,  185,  185,  185,  185,
+
       161,  163,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    0,  185,
+        0,   33,  185,   42,   44,   48,  185,  185,   83,  107,
+      185,  185,  185,  185,  126,  128,  139,  185,  185,  185,
+      153,  185,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2,    2,    2,    2,    0,  185,    0,  185,
 
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    0,  183,
-        0,   33,  183,   42,   44,   48,  183,  183,   83,  107,
-      183,  183,  183,  183,  126,  128,  139,  183,  183,  183,
-      153,  183,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    2,    2,    2,    2,    2,    0,  183,    0,  183,
-       59,   82,  183,  117,  119,  183,  144,  148,  183,  154,
-
+       59,   82,  185,  117,  119,  185,  144,  148,  185,  154,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    0,    0,    0,   36,  116,  124,
-      183,    2,    2,    2,    2,    2,    2,    2,    0,    0,
+      185,    2,    2,    2,    2,    2,    2,    2,    0,    0,
       169,  151,    2,    2,    2,    2,    0,    0,    2,    2,
         0,    0,    2,    2,    0,    0,    2,    2,    0,    0,
         2,    2,    0,    0,    2,    2,    0,  170,    2,    2,
-        0,    2,    0,    2,  180,    2,    0
+        0,    2,    0,    2,  182,    2,    0
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    2,    4,    5,    1,    1,    6,    1,    7,    6,
-        6,    6,    6,    6,    8,    9,    6,   10,   11,   12,
-       13,   14,   15,   16,   17,   18,   19,    6,    6,   20,
-       21,   22,    6,    1,   23,   24,   25,   26,   27,   28,
-       29,   30,   31,   32,   33,   34,   35,   36,   37,   38,
-       39,   40,   41,   42,   43,   44,   45,   46,   47,   48,
-        6,    1,    6,    6,   49,    1,   50,   51,   52,   53,
+        1,    2,    4,    5,    1,    6,    7,    1,    8,    7,
+        7,    7,    7,    7,    9,   10,    7,   11,   12,   13,
+       14,   15,   16,   17,   18,   19,   20,   21,    7,   22,
+       23,   24,    7,    1,   25,   26,   27,   28,   29,   30,
+       31,   32,   33,   34,   35,   36,   37,   38,   39,   40,
+       41,   42,   43,   44,   45,   46,   47,   48,   49,   50,
+        7,    1,    7,    7,   51,    1,   52,   53,   54,   55,
 
-       54,   55,   56,   57,   58,   59,   60,   61,   62,   63,
-       64,   65,   66,   67,   68,   69,   70,   71,   72,   73,
-       74,   75,    6,   76,    6,    1,    1,    1,    1,    1,
+       56,   57,   58,   59,   60,   61,   62,   63,   64,   65,
+       66,   67,   68,   69,   70,   71,   72,   73,   74,   75,
+       76,   77,    7,   78,    7,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -542,1327 +769,1348 @@ static yyconst YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[77] =
+static const YY_CHAR yy_meta[79] =
     {   0,
-        1,    1,    2,    1,    3,    1,    4,    1,    1,    5,
-        5,    5,    5,    5,    5,    5,    5,    5,    5,    1,
-        1,    1,    5,    5,    5,    5,    5,    5,    5,    5,
+        1,    1,    2,    1,    3,    1,    1,    4,    1,    1,
         5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
-        5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
-        5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
-        5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
-        5,    5,    5,    5,    5,    1
+        1,    1,    1,    1,    6,    6,    6,    6,    6,    6,
+        6,    6,    6,    6,    6,    6,    6,    6,    6,    6,
+        6,    6,    6,    6,    6,    6,    6,    6,    6,    6,
+        5,    6,    6,    6,    6,    6,    6,    6,    6,    6,
+        6,    6,    6,    6,    6,    6,    6,    6,    6,    6,
+        6,    6,    6,    6,    6,    6,    6,    1
     } ;
 
-static yyconst flex_uint16_t yy_base[1375] =
+static const flex_int16_t yy_base[1389] =
     {   0,
-        0,    0,  852,  842,   76,    0,  842, 8955,  151,  153,
-      786,    0, 8955, 8955,  149,  148,  160,  159,  778,  775,
-      156,  156,  165,  210,  202,  255,  151,  163,  265,  152,
-      171,  215,  218,  244,  295,  257,    0,  309,  349,  392,
-      163,  279,  226,  180,  676,    0,  741,    0,  237,  251,
-      696,  702,    0,    0,  243,  378,  451,  237,  682,  680,
-      470,  546,  600,  652,  700,  752,  384,  458,  795,  466,
-      532,  533,  534,  846,  895,  944,  547,  602,  990, 1042,
-      307,  650,  587,  651,  596,  301, 8955,  666, 8955,  636,
-     1107, 1117, 1128, 8955, 8955, 8955, 8955,    0,  218,  243,
+        0,    0,  947,  940,   78,    0,  911, 9132,  155,  157,
+      884,    0,  150, 9132, 9132,  162,  161,  173,    0,  171,
+      879,  838,  168,  168,  177,  222,  214,  267,  163,  175,
+      277,  164,  183,  227,  230,  256,  307,  269,    0,  321,
+      361,  404,  175,  291,  238,  192,  781,    0,  848,    0,
+      251,  265,  832,  849,  391,    0,    0,  256,  463,  474,
+      494,  249,  828,  823,  572,  650,  704,  756,  804,  856,
+      396,  494,  899,  491,  492,  493,  568,  950,  999, 1048,
+      570,  636, 1094, 1146,  319,  651,  665,  701,  728,  315,
+     9132,  767,  572, 9132,  755, 1212, 1222, 1233,    0, 9132,
 
-      300,  328,  250,  305,  379,  315,  319,    0,  376,  354,
-      694,  389,  345,  440,  710,  387,  388,  436,  439,  476,
-      463,  763,  460,  465,  480,  542,  481,  501,  521,  535,
-      591,  539,  546,    0,  584,  581,  627,  592,  607,  637,
-      657,  658,  717,  646,  658,  686,  681,  734,  705,  720,
-      717,    0,  751,  739,  757,  745,  764,  766,  755,  810,
-      769,  792,  770,  810,  811,  808,  817,  803,  822,  823,
-      842,  827,  820,  842,  871,  861,  858,  862,  866,  897,
-      872,  859,  879, 8955,    0, 8955,    0,  396,    0,  631,
-        0,  614, 1138, 1148, 1159,    0,    0,    0,    0,  942,
+     9132, 9132, 9132,    0,  230,  255,  312,  340,  262,  317,
+      391,  327,  331,    0,  388,  366,  498,  401,  357,  495,
+      757,  399,  400,  489,  486,  577,  510,  759,  562,  570,
+      572,  576,  574,  580,  581,  582,  635,  584,  619,    0,
+      633,  628,  704,  644,  653,  669,  705,  759,  811,  696,
+      701,  706,  707,  757,  716,  758,  760,    0,  763,  753,
+      773,  765,  810,  812,  801,  848,  813,  846,  816,  860,
+      858,  817,  832,  816,  865,  868,  890,  870,  866,  866,
+      887,  908,  912,  910,  909,  924,  917,  905,  925, 9132,
+        0, 9132,    0,  410,    0,  753, 1243,    0,  742, 1253,
 
-      945, 1029,  990, 1156, 1034, 1155, 1202,  934, 1030, 1168,
-     1199, 1218, 1258, 1251, 1270, 1285, 1337, 1334, 1345, 1372,
-     1272, 1422, 1391, 1471, 1399, 1443, 1397, 1481, 1483, 1492,
-     1519, 1531, 1535, 1546, 1577, 1576, 1594, 1624, 1673, 1623,
-     1629, 1648, 1673, 1721, 1773, 1677, 1719, 1765, 1774, 1814,
-     1817, 1838, 1861, 1830, 1874, 1897, 1712, 1909, 1941, 1730,
-     1916, 1993, 1946, 1972, 1990, 2042, 2015, 2033, 2059, 2081,
-     2093, 2095, 2127, 2123, 2145, 2147, 2183, 2230, 2191, 2177,
-     2222, 2239, 2265, 2274, 2287,    0, 8955,  601, 2352,    0,
-      882,    0,  903,  900,    0,  933,    0,  940,  954,  941,
+     1263, 1274, 1294,    0,    0,    0,    0,  952, 1046, 1010,
+      977, 1348, 1067, 1119, 1394, 1138, 1280, 1281, 1285, 1327,
+     1434, 1293, 1329, 1387, 1485, 1391, 1457, 1485, 1511, 1560,
+     1529, 1609, 1530, 1581, 1608, 1624, 1649, 1643, 1663, 1668,
+     1684, 1678, 1697, 1720, 1722, 1737, 1786, 1753, 1776, 1788,
+     1829, 1877, 1929, 1827, 1855, 1921, 1930, 1970, 1973, 1994,
+     2017, 1986, 2030, 2053, 1855, 2065, 2097, 1895, 2072, 2149,
+     2102, 2128, 2146, 2198, 2171, 2189, 2215, 2237, 2249, 2251,
+     2283, 2279, 2301, 2303, 1808, 2354, 2345, 2342, 2386, 2394,
+     2386, 2435, 2444,    0, 9132,  741, 1472,    0,    0,  923,
 
-      960,  988, 1001, 1156, 1038, 1038, 1050, 1044, 1137, 1162,
-     1145, 1147, 1166, 1153, 1166, 1203, 1216, 1260, 1221, 1220,
-     1207, 1226, 1215, 1229, 1247,    0, 1280, 1309, 1317, 1309,
-     1321, 1317, 1317, 1339, 1344, 1356, 1369, 1376, 1378, 1390,
-     1379, 1412, 1422, 1423, 1426, 1437, 1436, 1449, 1451, 1480,
-     1537, 1469, 1488,    0, 1490, 1516, 1530, 1537, 1593, 1538,
-     1543, 1532, 1555, 1557,    0, 1592, 1602, 1606, 1613, 1638,
-     1640, 1630, 1682, 1672, 1753, 1727, 1734, 1739, 1770, 1779,
-     1761, 1782, 1779, 1776, 1795, 1790, 1838,    0, 1827, 1824,
-     1867, 1880, 1875, 1876, 1887, 1888, 1886, 1918, 1932,    0,
+        0,  928,  924,    0,  958,    0,  951,  966,  953,  970,
+      969,  970, 1136,  965,  990,  999, 1006, 1006, 1036, 1024,
+     1027, 1060, 1048, 1056, 1064, 1073, 1143, 1081, 1084, 1095,
+     1115, 1124, 1148, 1144,    0, 1168, 1268, 1280, 1265, 1275,
+     1270, 1284, 1332, 1341, 1331, 1345, 1340, 1344, 1355, 1338,
+     1355, 1384, 1375, 1379, 1387, 1389, 1406, 1411, 1412, 1474,
+     1434, 1442,    0, 1437, 1482, 1483, 1489, 1500, 1488, 1495,
+     1486, 1492, 1512,    0, 1539, 1534, 1533, 1536, 1551, 1553,
+     1543, 1588, 1551, 1725, 1564, 1587, 1591, 1605, 1618, 1606,
+     1641, 1647, 1661, 1682, 1698, 1717,    0, 1733, 1733, 1741,
 
-     1933, 1974, 1934, 1993, 1948, 1999, 1987, 1998, 2046, 2027,
-     2032, 2064, 2045, 2074,    0,  600, 2362, 2355, 2356, 2357,
-     2358, 2281, 2392, 2400, 2401, 2412, 2440, 2448, 2453, 2455,
-     2469, 2518, 2494, 2519, 2532, 2568, 2544, 2580, 2578, 2609,
-     2621, 2623, 2637, 2662, 2680, 2677, 2712, 2721, 2730, 2756,
-     2771, 2769, 2774, 2810, 2819, 2824, 2854, 2826, 2829, 2869,
-     2880, 2880, 2902, 2921, 2934, 2943, 2968, 2979, 2992, 3015,
-     3017, 3032, 3058, 3066, 3080, 3092, 3104, 3106, 3118, 3130,
-     3145, 3149, 3173, 3174, 3193, 3218, 3270, 3196, 3232, 3267,
-     3231, 3292, 3295, 3320, 3327, 3341, 3355, 3366, 3380, 3395,
+     1748, 1755, 1768, 1783, 1805, 1811, 1835, 1852,    0, 1871,
+     1884, 1880, 1919, 1884, 1910, 1910, 1907, 1936, 1923, 1932,
+     1985, 1948, 1946,    0,  710, 2510, 2530, 2443, 2516, 2517,
+     2529, 2442, 2521, 2563, 2564, 2565, 2591, 2603, 2615, 2617,
+     2630, 2679, 2655, 2680, 2693, 2729, 2705, 2741, 2739, 2770,
+     2782, 2784, 2798, 2823, 2841, 2838, 2873, 2882, 2891, 2917,
+     2932, 2930, 2935, 2971, 2980, 2985, 3015, 2987, 2990, 3030,
+     3041, 3041, 3063, 3082, 3095, 3104, 3129, 3140, 3153, 3176,
+     3178, 3193, 3219, 3227, 3241, 3253, 3265, 3267, 3279, 3291,
+     3306, 3310, 3334, 3335, 3354, 3379, 3431, 3357, 3393, 3428,
 
-     3447, 3395, 3497, 3430, 3473, 3414, 3493, 3532, 3541, 3544,
-     3551, 3575, 3576, 3595, 3598, 3600, 3630, 3644, 3649, 3605,
-     3659, 3683, 3697, 3701, 3737, 3741, 3749, 3754, 3781, 3797,
-     3798, 3830, 3844, 3856, 3844, 3885, 3888, 3891, 3926, 3935,
-     3944, 3970,  582, 2085, 2089, 2090, 2091, 2104, 2130, 2148,
-     2147, 2171,    0, 2192,    0,    0, 2193, 2197, 2215, 2208,
-        0, 2218, 2230, 2245, 2238,    0, 2248, 2273, 2277, 2283,
-     2303, 2290, 2306, 2302, 2356,    0,    0, 2365, 2359, 2360,
-     2357, 2403, 2428, 2431, 2429,    0, 2440, 2455, 2466, 2476,
-        0,    0, 2485, 2475,    0, 2511,    0, 2510, 2526, 2517,
+     3392, 3453, 3456, 3481, 3488, 3502, 3516, 3527, 3541, 3556,
+     3608, 3556, 3658, 3591, 3634, 3575, 3654, 3693, 3702, 3705,
+     3712, 3736, 3737, 3756, 3759, 3761, 3791, 3805, 3810, 3766,
+     3820, 3844, 3858, 3862, 3898, 3902, 3910, 3915, 3942, 3958,
+     3959, 3991, 4005, 4017, 4005, 4046, 4049, 4052, 4087, 4096,
+     4105, 4131,  708, 1956, 1970, 2003, 2014, 2030, 2037, 2047,
+     2046, 2057,    0, 2087,    0,    0, 2092, 2090, 2096, 2090,
+        0, 2099, 2118, 2139, 2136,    0, 2145, 2149, 2145, 2155,
+     2204, 2188, 2205, 2200, 2199,    0,    0, 2230, 2232, 2243,
+     2242, 2245, 2270, 2271, 2273,    0, 2280, 2294, 2304, 2316,
 
-     2555, 2564, 2569, 2600,    0, 2586,    0,    0,    0, 2591,
-        0, 2601, 2626,    0, 2634, 2660, 2633, 2625, 2663,    0,
-     2681, 2686, 2675, 2678,    0, 2688, 2716,    0, 2728, 2739,
-     2740, 2738,    0, 2757, 2777, 2773, 2775, 2798,    0, 2791,
-     2795, 2834, 2868,    0,    0, 2862, 2877, 2882, 2892, 2883,
-        0,    0, 2883, 2904,    0, 2925, 2915, 2923, 2921, 2945,
-     2931, 2950, 2956, 2982,    0, 2973,    0, 2992,    0, 2982,
-      544, 3979, 3988, 4017, 4026, 4039, 4026, 4051, 4076, 4077,
-     4089, 4111, 4119, 4133, 4145, 4159, 4171, 4197, 4185, 4199,
-     4206, 4223, 4249, 4235, 4249, 4270, 4293, 4306, 4336, 4344,
+        0,    0, 2324, 2322,    0, 2334,    0, 2339, 2356, 2344,
+     2356, 2384, 2390, 2444,    0, 2402,    0,    0,    0, 2395,
+        0, 2404, 2415,    0, 2452, 2444, 2457, 2491, 2510,    0,
+     2517, 2518, 2506, 2521,    0, 2573, 2583,    0, 2589, 2594,
+     2597, 2606,    0, 2614, 2621, 2630, 2630, 2650,    0, 2652,
+     2652, 2683, 2685,    0,    0, 2684, 2735, 2734, 2743, 2737,
+        0,    0, 2740, 2749,    0, 2769, 2753, 2778, 2779, 2801,
+     2784, 2799, 2808, 2833,    0, 2824,    0, 2847,    0, 2835,
+      706, 4140, 4149, 4178, 4187, 4200, 4187, 4212, 4237, 4238,
+     4250, 4272, 4280, 4294, 4306, 4320, 4332, 4358, 4346, 4360,
 
-     4362, 4261, 4385, 4386, 4404, 4430, 4444, 4458, 4472, 4486,
-     4502, 4528, 4519, 4545, 4553, 4567, 4579, 4597, 4605, 4619,
-     4631, 4649, 4657, 4656, 4684, 4692, 4685, 4727, 4700, 4736,
-     4752, 4797, 4766, 4794, 4808, 4827, 4838, 4841, 4857, 4871,
-     4896, 4904, 4909, 4911, 4925, 4951, 4963, 4968, 4976, 4998,
-     5017, 5036, 5051, 5077, 5080, 5089, 5115, 5133, 5134, 5159,
-     5168, 5187, 5209, 5212, 5238, 5250, 5241, 5263, 4970, 5294,
-     5289, 5302, 5307, 5024, 5321, 5343, 5346, 5351, 5365, 5387,
-     5392, 5396, 5422, 5441, 5438, 5464, 5483, 5497, 5494, 5525,
-     5449, 5542, 5537, 5576, 5577, 5578, 5590, 5592,  543,    0,
+     4367, 4384, 4410, 4396, 4410, 4431, 4454, 4467, 4497, 4505,
+     4523, 4422, 4546, 4547, 4565, 4591, 4605, 4619, 4633, 4647,
+     4663, 4689, 4680, 4706, 4714, 4728, 4740, 4758, 4766, 4780,
+     4792, 4810, 4818, 4817, 4845, 4853, 4846, 4888, 4861, 4897,
+     4913, 4958, 4927, 4955, 4969, 4988, 4999, 5002, 5018, 5032,
+     5057, 5065, 5070, 5072, 5086, 5112, 5124, 5129, 5137, 5159,
+     5178, 5197, 5212, 5238, 5241, 5250, 5276, 5294, 5295, 5320,
+     5329, 5348, 5370, 5373, 5399, 5411, 5402, 5424, 5131, 5455,
+     5450, 5463, 5468, 5185, 5482, 5504, 5507, 5512, 5526, 5548,
+     5553, 5557, 5583, 5602, 5599, 5625, 5644, 5658, 5655, 5686,
 
-        0, 3009,    0, 3040,    0, 3046, 3035, 3059, 3061, 3090,
-     3085, 3094, 3110, 3142,    0, 3135, 3144, 3152, 3176, 3195,
-     3210,    0, 3208, 3211, 3239, 3254, 3253, 3264, 3267, 3271,
-     3286, 3302, 3313,    0,    0, 3300, 3323, 3316, 3337, 3342,
-     3363,    0,    0, 3364,    0,    0, 3370, 3398, 3442, 3411,
-        0,    0, 3420,    0,    0, 3434, 3438, 3458, 3443, 3460,
-     3454,    0,    0, 3472, 3458, 3489, 3478, 3485,    0, 3510,
-     3512, 3519,    0, 3530, 3550, 3567, 3575,    0, 3597, 3607,
-     3640, 3624, 3639, 3640, 3660, 3662, 3663,    0, 3694, 3704,
-     3707,    0, 3695, 3717, 3718,    0,    0,  536, 5622, 5625,
+     5610, 5703, 5698, 5737, 5738, 5739, 5751, 5753,  705,    0,
+        0, 2831,    0, 2857,    0, 2862, 2866, 2900, 2898, 2901,
+     2922, 2931, 2937, 2951,    0, 2947, 2956, 2955, 2997, 3022,
+     3030,    0, 3034, 3032, 3044, 3054, 3054, 3079, 3069, 3077,
+     3079, 3094, 3104,    0,    0, 3089, 3111, 3102, 3139, 3136,
+     3151,    0,    0, 3142,    0,    0, 3176, 3201, 3319, 3200,
+        0,    0, 3212,    0,    0, 3216, 3207, 3253, 3240, 3267,
+     3266,    0,    0, 3303, 3290, 3324, 3358, 3360,    0, 3387,
+     3390, 3405,    0, 3419, 3422, 3426, 3428,    0, 3443, 3462,
+     3471, 3458, 3466, 3471, 3496, 3509, 3508,    0, 3526, 3541,
 
-     5633, 5636, 5676, 5684, 5685, 5710, 5738, 5729, 5764, 5763,
-     5764, 5792, 5814, 5816, 5808, 5828, 5846, 5864, 5862, 5882,
-     5890, 5912, 5920, 5919, 5944, 5946, 5968, 5970, 5994, 5999,
-     6019, 6022, 6024, 6048, 6060, 6063, 6089, 6067, 6105, 6116,
-     6108, 6146, 6149, 6152, 6160, 6190, 6203, 6201, 6232, 6245,
-     6246, 6276, 6287, 6290, 6315, 6320, 6334, 6358, 6376, 6367,
-     6407, 6411, 6419, 6434, 6459, 6460, 6488, 6489, 6513, 6514,
-     6527, 6539, 6542, 6567, 6581, 6568, 6593, 6596, 6622, 6635,
-     6627, 6667, 6670, 6691, 6719, 6683, 6727, 6739, 6752, 6744,
-     6780, 6778, 6799, 6825, 6822, 6843,  526, 3718,    0, 3748,
+     3546,    0, 3545, 3583, 3584,    0,    0,  701, 5783, 5786,
+     5794, 5797, 5837, 5845, 5846, 5871, 5899, 5890, 5925, 5924,
+     5925, 5953, 5975, 5977, 5969, 5989, 6007, 6025, 6023, 6043,
+     6051, 6073, 6081, 6080, 6105, 6107, 6129, 6131, 6155, 6160,
+     6180, 6183, 6185, 6209, 6221, 6224, 6250, 6228, 6266, 6277,
+     6269, 6307, 6310, 6313, 6321, 6351, 6364, 6362, 6393, 6406,
+     6407, 6437, 6448, 6451, 6476, 6481, 6495, 6519, 6537, 6528,
+     6568, 6572, 6580, 6595, 6620, 6621, 6649, 6650, 6674, 6675,
+     6688, 6700, 6703, 6728, 6742, 6729, 6754, 6757, 6783, 6796,
+     6788, 6828, 6831, 6852, 6880, 6844, 6888, 6900, 6913, 6905,
 
-        0, 3753, 3765, 3751, 3753,    0, 3765,    0, 3790, 3801,
-     3812, 3805, 3799,    0, 3822,    0, 3822,    0, 3819,    0,
-        0, 3862,    0, 3875, 3873, 3892, 3903,    0,    0,    0,
-        0,    0,    0, 3903, 3930, 3942,    0,    0, 3932,    0,
-     3948,    0, 3968,    0, 3972, 3992, 4001, 4031, 4018, 4032,
-        0, 4044, 4049, 4061, 4077,    0, 4091,    0, 4094,    0,
-     4107, 4109, 4115, 4110, 4136,    0,    0,    0,    0, 4134,
-     4144,  525, 6860, 6865, 6867, 6881, 6897, 6910, 6919, 6935,
-     6944, 6953, 6977, 6986, 6995, 7026, 7030, 7039, 7070, 7081,
-     7084, 7112, 7125, 7126, 7156, 7167, 7169, 7178, 7203, 7212,
+     6941, 6939, 6960, 6986, 6983, 7004,  683, 3595,    0, 3604,
+        0, 3606, 3617, 3604, 3606,    0, 3617,    0, 3615, 3625,
+     3636, 3642, 3637,    0, 3662,    0, 3673,    0, 3664,    0,
+        0, 3684,    0, 3678, 3692, 3723, 3742,    0,    0,    0,
+        0,    0,    0, 3749, 3767, 3801,    0,    0, 3785,    0,
+     3806,    0, 3820,    0, 3802, 3815, 3829, 3855, 3844, 3859,
+        0, 3872, 3876, 3861, 3865,    0, 3909,    0, 3916,    0,
+     3930, 3931, 3930, 3918, 3967,    0,    0,    0,    0, 3957,
+     3964,  669, 7021, 7026, 7028, 7042, 7058, 7071, 7080, 7096,
+     7105, 7114, 7138, 7147, 7156, 7187, 7191, 7200, 7231, 7242,
 
-     7214, 7221, 7256, 7257, 7265, 7298, 7301, 7307, 7342, 7350,
-     7369, 7364, 7394, 7396, 7410, 7419, 7438, 7452, 7471, 7480,
-     7500, 7509, 7524, 7538, 7516, 7559, 7565, 7589, 7603, 7612,
-     7631, 7645, 7654, 7673, 7687, 7701, 7720, 7743, 7744, 7774,
-     7785, 7788, 7804, 7818, 7834, 7837,  529,    0,    0,    0,
-        0, 4157,    0,    0,  436, 4161, 4177,    0,    0, 4177,
-     4196, 4219,    0,    0,    0, 4258,    0,    0, 4276, 4280,
-        0,    0, 4284, 4299, 4293, 4301,    0,    0, 4319, 4304,
-     4316,    0,    0, 4320,    0, 4325, 4333, 4341, 4361, 4364,
-        0,    0,  527, 7848, 7872, 7878, 7881, 7901, 7916, 7925,
+     7245, 7273, 7286, 7287, 7317, 7328, 7330, 7339, 7364, 7373,
+     7375, 7382, 7417, 7418, 7426, 7459, 7462, 7468, 7503, 7511,
+     7530, 7525, 7555, 7557, 7571, 7580, 7599, 7613, 7632, 7641,
+     7661, 7670, 7685, 7699, 7677, 7720, 7726, 7750, 7764, 7773,
+     7792, 7806, 7815, 7834, 7848, 7862, 7881, 7904, 7905, 7935,
+     7946, 7949, 7965, 7979, 7995, 7998,  664,    0,    0,    0,
+        0, 3973,    0,    0,  450, 3975, 3984,    0,    0, 3981,
+     3974, 4021,    0,    0,    0, 4036,    0,    0, 4051, 4050,
+        0,    0, 4060, 4077, 4081, 4090,    0,    0, 4109, 4101,
+     4119,    0,    0, 4133,    0, 4144, 4158, 4177, 4199, 4202,
 
-     7955, 7940, 7970, 7969, 7984, 7999, 8008, 8038, 8033, 8052,
-     8074, 8013, 8054, 8084, 8108, 8095, 8131, 8139, 8150, 8151,
-     8156, 8185, 8188, 8199, 8218, 8232, 8251, 8262, 8281, 8292,
-     8295, 8311, 8335, 8341, 8358, 8380, 8388, 8393,  526, 4361,
-     4434,    0, 4360,    0,    0,    0, 4377, 4374,    0,    0,
-     4384, 4398, 4412, 4415,    0,    0,    0, 4405, 4419, 4429,
-        0, 4436,  524, 8418, 4781, 8406, 8432, 8444, 8446, 8468,
-     8480, 8498, 8506, 8524, 8546, 8551, 8555, 8568, 8590, 8598,
-     8603, 8612, 8642, 8644, 8647, 8656,  514,  438, 4433, 4446,
-        0,    0, 4434,    0,    0, 4469,    0,    0, 4477,    0,
+        0,    0,  657, 8009, 8033, 8039, 8042, 8062, 8077, 8086,
+     8091, 8115, 8116, 8130, 8144, 8145, 8169, 8183, 8170, 8195,
+     8198, 8214, 8227, 8230, 8258, 8271, 8272, 8302, 8313, 8315,
+     8324, 8349, 8358, 8367, 8391, 8400, 8414, 8442, 8445, 8456,
+     8475, 8486, 8499, 8510, 8537, 8538, 8539, 8563,  656, 4190,
+     4462,    0, 4193,    0,    0,    0, 4234, 4237,    0,    0,
+     4248, 4253, 4262, 4266,    0,    0,    0, 4254, 4275, 4292,
+        0, 4309,  652, 8578, 4510, 8577, 8592, 8616, 8617, 8631,
+     8655, 8646, 8670, 8685, 8700, 8662, 8716, 8724, 8729, 8738,
+     8763, 8764, 8777, 8782, 8812, 8821,  648,  452, 4302, 4318,
 
-      506, 8710, 4493, 8688, 8696, 8697, 8731, 8739, 8742, 8745,
-     8775, 8783, 8795, 8800,  470, 4558, 4499,    0,    0,    0,
-     4522,  468, 4698, 4536, 8803, 8808, 8844, 8842,  465, 4563,
-     8955,    0,  418, 4565,    0, 8851,  418, 4572,  390, 4578,
-      388, 4583,  386, 4591,  347, 4609,  343, 4617,  338, 4628,
-      335, 4636,  334, 4653,  332, 4679,  303, 8955,  293,    0,
-      299,  286,  248,  243, 8955,    0, 8955, 8924, 8929,  201,
-     8934, 8939, 8944, 8949
+        0,    0, 4308,    0,    0, 4320,    0,    0, 4328,    0,
+      639, 8853, 4362, 8834, 8856, 8875, 8855, 8863, 8901, 8904,
+     8907, 8910, 8954, 8955,  606, 4481, 4364,    0,    0,    0,
+     4449,  558, 4505, 4442, 8957, 8969, 8983, 8998,  478, 4466,
+     9132,    0,  431, 4468,    0, 9004,  431, 4467,  403, 4486,
+      401, 4497,  399, 4515,  360, 4532,  356, 4536,  351, 4549,
+      348, 4559,  347, 4568,  345, 4573,  316, 9132,  306,    0,
+      312,  299,  261,  256, 9132,    0, 9132, 9079, 9085,  214,
+     9087, 9093, 9099, 9105, 9111, 9117, 9119, 9125
     } ;
 
-static yyconst flex_int16_t yy_def[1375] =
+static const flex_int16_t yy_def[1389] =
     {   0,
-     1367,    1, 1368, 1368, 1367,    5, 1367, 1367, 1367, 1367,
-     1367, 1369, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1367, 1371, 1367, 1372, 1372, 1367,
-     1372, 1373, 1372, 1372, 1372, 1372, 1372, 1372, 1372, 1372,
-     1374, 1374,   62,   62,   62,   63,   65,   62,   65,   62,
-       62,   62,   62,   63,   63,   63,   62,   62,   62,   62,
-       65,   62,   62,   62, 1372, 1367, 1367, 1369, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1370, 1370, 1370,
+     1377,    1, 1378, 1378, 1377,    5, 1377, 1377, 1377, 1377,
+     1377, 1379, 1377, 1377, 1377, 1377, 1377, 1377, 1380, 1377,
+     1377, 1377, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1377, 1382, 1377, 1383,
+     1383, 1377, 1383, 1384, 1383, 1383, 1383, 1383, 1383, 1383,
+     1385, 1383, 1383, 1383, 1386, 1386,   66,   66,   66,   67,
+       69,   66,   69,   66,   66,   66,   66,   67,   67,   67,
+       66,   66,   66,   66,   69,   66,   66,   66, 1383, 1377,
+     1377, 1379, 1377, 1377, 1377, 1377, 1377, 1377, 1387, 1377,
 
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1367, 1371, 1367, 1372, 1372, 1372, 1373,
-     1372, 1372, 1372, 1372, 1372, 1372, 1372, 1372, 1372,   62,
+     1377, 1377, 1377, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1377,
+     1382, 1377, 1383, 1383, 1383, 1384, 1383, 1383, 1383, 1383,
 
-       62,   62,   65,   65,   65,   65,   65,   65,   62,   62,
-       65,   65,   65,   62,   62,   62,   65,   65,   65,   62,
-       65,   65,   65,   62,   65,   65,   62,   65,   62,   65,
-       62,   62,   65,   65,   65,   65,   62,   62,   65,   65,
-       62,   62,   62,   62,   65,   65,   65,   65,   65,   65,
-       65,   65,   65,   65,   65,   65,   62,   62,   62,   62,
-       65,   65,   65,   65,   65,   65,   62,   62,   62,   62,
-       62,   62,   65,   62,   62,   62,   63,   62,   62,   62,
-       65,   62,   62,   62,   62, 1372, 1367, 1367, 1367, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
+     1383, 1383, 1388, 1383, 1383, 1383, 1383,   66,   66,   66,
+       69,   69,   69,   69,   69,   69,   66,   66,   69,   69,
+       69,   66,   66,   66,   69,   69,   69,   66,   69,   69,
+       69,   66,   69,   69,   66,   69,   66,   69,   66,   66,
+       69,   69,   69,   69,   66,   66,   69,   69,   66,   66,
+       66,   66,   69,   69,   69,   69,   69,   69,   69,   69,
+       69,   69,   69,   69,   66,   66,   66,   66,   69,   69,
+       69,   69,   69,   69,   66,   66,   66,   66,   66,   66,
+       69,   66,   66,   66,   67,   66,   66,   66,   69,   66,
+       66,   66,   66, 1383, 1377, 1377, 1377, 1387, 1381, 1381,
 
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
 
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1372, 1372, 1372,   62,   62,   62,
-       62,   65,   65,   65,   65,   62,   62,   62,   62,   65,
-       65,   62,   62,   62,   62,   62,   62,   62,   65,   65,
-       62,   65,   65,   62,   62,   62,   62,   62,   62,   62,
-       62,   62,   62,   62,   62,   62,   62,   65,   65,   65,
-       65,   62,   62,   65,   62,   62,   65,   65,   65,   65,
-       62,   62,   62,   62,   62,   62,   62,   62,   62,   62,
-       65,   65,   65,   62,   62,   62,   62,   62,   62,   62,
-       62,   62,   62,   62,   65,   65,   65,   62,   62,   62,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1383, 1383, 1383, 1388,   66,   66,   66,
+       66,   69,   69,   69,   69,   66,   66,   66,   66,   69,
+       69,   66,   66,   66,   66,   66,   66,   66,   69,   69,
+       66,   69,   69,   66,   66,   66,   66,   66,   66,   66,
+       66,   66,   66,   66,   66,   66,   66,   69,   69,   69,
+       69,   66,   66,   69,   66,   66,   69,   69,   69,   69,
+       66,   66,   66,   66,   66,   66,   66,   66,   66,   66,
+       69,   69,   69,   66,   66,   66,   66,   66,   66,   66,
 
-       62,   65,   65,   65,   65,   65,   62,   62,   62,   62,
-       65,   65,   62,   62,   62,   62,   62,   62,   62,   65,
-       65,   65,   65,   65,   65,   65,   62,   62,   65,   65,
-       62,   62,   62,   62,   65,   65,   65,   65,   65,   65,
-       65,   65, 1367, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
+       66,   66,   66,   66,   69,   69,   69,   66,   66,   66,
+       66,   69,   69,   69,   69,   69,   66,   66,   66,   66,
+       69,   69,   66,   66,   66,   66,   66,   66,   66,   69,
+       69,   69,   69,   69,   69,   69,   66,   66,   69,   69,
+       66,   66,   66,   66,   69,   69,   69,   69,   69,   69,
+       69,   69, 1377, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
 
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1372,   65,   65,   62,   62,   62,   65,   62,   65,   62,
-       62,   62,   62,   62,   62,   62,   62,   62,   62,   62,
-       65,   62,   62,   62,   65,   65,   65,   65,   65,   65,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1383,   69,   69,   66,   66,   66,   69,   66,   69,   66,
+       66,   66,   66,   66,   66,   66,   66,   66,   66,   66,
 
-       65,   62,   65,   65,   65,   65,   65,   65,   65,   65,
-       65,   65,   62,   62,   62,   62,   62,   62,   62,   62,
-       62,   62,   62,   65,   65,   65,   62,   62,   65,   65,
-       65,   65,   65,   65,   65,   65,   65,   65,   65,   65,
-       62,   62,   62,   65,   65,   65,   62,   62,   62,   62,
-       62,   62,   62,   62,   62,   62,   62,   62,   62,   62,
-       62,   62,   62,   62,   62,   62,   62,   62,   65,   65,
-       62,   62,   62,   65,   62,   62,   62,   62,   62,   62,
-       65,   65,   65,   65,   65,   65,   65,   65,   65,   65,
-       62,   62,   62,   62,   62,   62,   62,   65, 1367, 1370,
+       69,   66,   66,   66,   69,   69,   69,   69,   69,   69,
+       69,   66,   69,   69,   69,   69,   69,   69,   69,   69,
+       69,   69,   66,   66,   66,   66,   66,   66,   66,   66,
+       66,   66,   66,   69,   69,   69,   66,   66,   69,   69,
+       69,   69,   69,   69,   69,   69,   69,   69,   69,   69,
+       66,   66,   66,   69,   69,   69,   66,   66,   66,   66,
+       66,   66,   66,   66,   66,   66,   66,   66,   66,   66,
+       66,   66,   66,   66,   66,   66,   66,   66,   69,   69,
+       66,   66,   66,   69,   66,   66,   66,   66,   66,   66,
+       69,   69,   69,   69,   69,   69,   69,   69,   69,   69,
 
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1372,   65,   65,
+       66,   66,   66,   66,   66,   66,   66,   69, 1377, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
 
-       65,   65,   62,   62,   62,   62,   62,   62,   62,   65,
-       65,   62,   62,   62,   65,   62,   62,   62,   65,   62,
-       62,   62,   62,   65,   62,   62,   62,   62,   62,   65,
-       62,   62,   62,   62,   62,   62,   62,   65,   65,   65,
-       65,   65,   65,   65,   65,   65,   62,   65,   65,   65,
-       65,   65,   65,   65,   62,   65,   65,   65,   65,   65,
-       65,   65,   62,   62,   62,   62,   62,   62,   62,   62,
-       62,   62,   62,   62,   62,   62,   62,   62,   62,   62,
-       65,   65,   65,   65,   65,   65,   65,   62,   62,   62,
-       62,   65,   65,   65,   65,   65, 1367, 1370, 1370, 1370,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1383,   69,   69,
+       69,   69,   66,   66,   66,   66,   66,   66,   66,   69,
+       69,   66,   66,   66,   69,   66,   66,   66,   69,   66,
+       66,   66,   66,   69,   66,   66,   66,   66,   66,   69,
+       66,   66,   66,   66,   66,   66,   66,   69,   69,   69,
+       69,   69,   69,   69,   69,   69,   66,   69,   69,   69,
+       69,   69,   69,   69,   66,   69,   69,   69,   69,   69,
+       69,   69,   66,   66,   66,   66,   66,   66,   66,   66,
+       66,   66,   66,   66,   66,   66,   66,   66,   66,   66,
+       69,   69,   69,   69,   69,   69,   69,   66,   66,   66,
 
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1372,   62,   62,   65,   65,   65,   62,   62,   65,
-       65,   65,   65,   65,   65,   65,   65,   65,   65,   65,
-       65,   65,   65,   65,   65,   65,   62,   62,   65,   65,
+       66,   69,   69,   69,   69,   69, 1377, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1383,   66,   66,   69,   69,   69,   66,   66,   69,
+       69,   69,   69,   69,   69,   69,   69,   69,   69,   69,
 
-       62,   65,   65,   65,   65,   65,   65,   65,   65,   62,
-       62,   62,   62,   65,   65,   65,   65,   65,   65,   65,
-       62,   62,   62,   62,   65,   65,   65,   65,   65,   65,
-       65,   65,   65,   65,   65,   65,   65,   65,   65,   65,
-       65,   65,   65,   65,   65,   65, 1367, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1372,   65,   65,   65,   65,   62,   62,   62,
+       69,   69,   69,   69,   69,   69,   66,   66,   69,   69,
+       66,   69,   69,   69,   69,   69,   69,   69,   69,   66,
+       66,   66,   66,   69,   69,   69,   69,   69,   69,   69,
+       66,   66,   66,   66,   69,   69,   69,   69,   69,   69,
+       69,   69,   69,   69,   69,   69,   69,   69,   69,   69,
+       69,   69,   69,   69,   69,   69, 1377, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
 
-       62,   62,   62,   62,   62,   62,   62,   62,   62,   62,
-       62,   65,   65,   65,   65,   65,   65,   65,   65,   62,
-       62,   65,   65,   65,   65,   65,   65,   65,   65,   65,
-       65,   65,   65,   65,   62,   62,   62,   62, 1367, 1370,
-     1367, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
-     1370, 1370, 1372,   62, 1372,   62,   62,   62,   62,   62,
-       62,   62,   62,   62,   62,   65,   65,   62,   62,   62,
-       62,   62,   62,   62,   62,   62, 1367, 1370, 1367, 1370,
-     1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370, 1370,
+     1381, 1381, 1383,   69,   69,   69,   69,   66,   66,   66,
+       66,   66,   66,   66,   66,   66,   66,   66,   66,   66,
+       66,   69,   69,   69,   69,   69,   69,   69,   69,   66,
+       66,   69,   69,   69,   69,   69,   69,   69,   69,   69,
+       69,   69,   69,   69,   66,   66,   66,   66, 1377, 1381,
+     1377, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1381, 1381, 1383,   66, 1383,   66,   66,   66,   66,   66,
+       66,   66,   66,   66,   66,   69,   69,   66,   66,   66,
+       66,   66,   66,   66,   66,   66, 1377, 1381, 1377, 1381,
 
-     1372,   62, 1372,   62,   62,   62,   65,   65,   65,   65,
-       65,   65,   62,   62, 1367, 1367, 1367, 1370, 1370, 1370,
-     1370, 1372, 1372, 1372,   62,   62,   62,   65, 1367, 1367,
-     1367, 1370, 1372, 1372, 1372,   65, 1367, 1367, 1372, 1372,
-     1367, 1367, 1372, 1372, 1367, 1367, 1372, 1372, 1367, 1367,
-     1372, 1372, 1367, 1367, 1372, 1372, 1367, 1367, 1372, 1372,
-     1367, 1372, 1367, 1372, 1367, 1372,    0, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367
+     1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381, 1381,
+     1383,   66, 1383,   66,   66,   66,   69,   69,   69,   69,
+       69,   69,   66,   66, 1377, 1377, 1377, 1381, 1381, 1381,
+     1381, 1383, 1383, 1383,   66,   66,   66,   69, 1377, 1377,
+     1377, 1381, 1383, 1383, 1383,   69, 1377, 1377, 1383, 1383,
+     1377, 1377, 1383, 1383, 1377, 1377, 1383, 1383, 1377, 1377,
+     1383, 1383, 1377, 1377, 1383, 1383, 1377, 1377, 1383, 1383,
+     1377, 1383, 1377, 1383, 1377, 1383,    0, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377
     } ;
 
-static yyconst flex_uint16_t yy_nxt[9032] =
+static const flex_int16_t yy_nxt[9211] =
     {   0,
         8,    9,   10,   11,   12,   13,   14,   15,   16,   17,
-       17,   17,   17,   17,   17,   17,   17,   17,   17,   18,
+       18,   18,   18,   18,   18,   18,   18,   18,   18,   18,
        19,   20,   21,   22,   23,   24,   25,   26,   27,   28,
        29,   30,   31,   32,   33,   34,   35,   36,   37,   38,
-       39,   40,   41,   42,   43,   37,   44,   37,    8,   21,
-       22,   23,   24,   25,   26,   27,   28,   29,   30,   31,
+       39,   40,   41,   42,   43,   44,   45,   39,   46,   39,
+        8,   23,   24,   25,   26,   27,   28,   29,   30,   31,
        32,   33,   34,   35,   36,   37,   38,   39,   40,   41,
-       42,   43,   37,   44,   37,   45,   48,   49,   50,   51,
-       52,   53,   54,   55,   56,   57,   57,   57,   57,   57,
-       57,   57,   57,   57,   57,   58,   59,   60,   61,   62,
+       42,   43,   44,   45,   39,   46,   39,   47,   50,   51,
+       52,   53,   54,   55,   56,   57,   58,   59,   60,   60,
+       60,   60,   60,   60,   60,   60,   60,   60,   61,   62,
 
        63,   64,   65,   66,   67,   68,   69,   70,   71,   72,
        73,   74,   75,   76,   77,   78,   79,   80,   81,   82,
-       83,   77,   84,   77,   48,   61,   62,   63,   64,   65,
+       83,   84,   85,   86,   87,   81,   88,   81,   50,   65,
        66,   67,   68,   69,   70,   71,   72,   73,   74,   75,
-       76,   77,   78,   79,   80,   81,   82,   83,   77,   84,
-       77,   85,   86,   86,   86,   86,   89,   91,   91,   91,
-       91,   91,   91,   91,   91,   91,   91,   90,   92,   93,
-       93,   93,   93,   93,   93,   93,   93,   93,   93,   94,
-       95,   99,  105,  100,  129,  131,  106,  109,  139,  101,
-      130,  102,  107,  132,  110,  103,  104,  140,  176,  133,
-
-      177,  111,  108,  178,  112,   98,  183,  113,   99,  105,
-      100,  129,  131,  106,  109,  139,  101,  130,  102,  107,
-      132,  110,  103,  104,  140,  176,  133,  177,  111,  108,
-      178,  112,  114,  183,  113,  119,  115,  120,  188,   86,
-      116,  141,  121,  290,  144,  142,  117,  122,  145,  118,
-      191,  143,   86,   86,  146,  181,  182,  196,  197,  114,
-     1366,  192,  119,  115,  120, 1365,  147,  116,  141,  121,
-      290,  144,  142,  117,  122,  145,  118,  123,  143,  156,
-      148,  146,  181,  182,  291,  124,  149,  150,  125,  296,
-      157,  126,  134,  147,  127, 1364,  158,  128,  135,  136,
-
-      137,  179,   86,   86,  123,  138,  156,  148, 1363,  180,
-     1362,  291,  124,  149,  150,  125,  296,  157,  126,  134,
-     1361,  127,  151,  158,  128,  135,  136,  137,  179,  297,
-      152,  159,  138,  292,  153,  160,  180,  154,  155,  161,
-      200,  293,  278,  301,  279,  162, 1359,  280, 1357,  151,
-      294, 1355,  200,  295, 1353,  302,  297,  152,  159, 1351,
-      292,  153,  160, 1349,  154,  155,  161,  200,  293,  278,
-      301,  279,  162,  163,  280,  164,  305,  294,  165,  200,
-      295,  166,  302,  167,  312,  168,  169,  193,  193,  193,
-      193,  193,  193,  193,  193,  193,  193,  188,   86, 1347,
-
-      163, 1345,  164,  305, 1343,  165,  298,  299,  166,  303,
-      167,  312,  168,  169,  170,  310,  304,  231,  171,  200,
-      300,  172,  173,  232,  200,  311,  320,  321,  174,  200,
-      322,  175, 1341,  298,  299, 1339,  303, 1241, 1241, 1316,
-     1316,  170,  310,  304,  231,  171,  200,  300,  172,  173,
-      232,  200,  311,  320,  321,  174,  200,  322,  175,  194,
-      195,  195,  195,  195,  195,  195,  195,  195,  195,  195,
-      187,  187,  323,  187,  187,  187,  187,  187,  187,  324,
-      233,  313, 1337, 1333,  200, 1329,  314,  327,  234,  187,
-      187,  187,  200,  333,  235,  201,  200,  202,  334,  323,
-
-      325,  326,  241,  203,  200,  204,  324,  233,  313,  205,
-      206,  200,  200,  314,  327,  234,  335,  338, 1322,  200,
-      333,  235,  201,  200,  202,  334, 1315,  325,  326,  241,
-      203,  200,  204, 1301,  339, 1287,  205,  206, 1263,  200,
-     1239, 1193, 1147,  335,  338,  187,  187,  187, 1072,  187,
-      187,  187,  187,  187,  187,  997,  898,  340,  242,  243,
-      246,  339,  200,  244,  247,  187,  187,  187,  200,  245,
-      248,  341,  207,  200,  344,  336,  208,  200,  200,  200,
-      200,  337,  209,  200,  340,  242,  243,  246,  345,  200,
-      244,  247,  210,  200,  799,  200,  245,  248,  341,  207,
-
-      200,  344,  336,  208,  200,  200,  200,  200,  337,  209,
-      200,  671,  543,  200,  346,  345,  283,  284,  347,  210,
-      200,  187,  211,  200,  261,  416,  200,  352,  262,  212,
-      200,  342,  263,  200,  343,  415,  213,  353,  264,  214,
-      200,  346,  215,  283,  284,  347,  200,  288,  200,  211,
-      200,  261,  348,  200,  352,  262,  212,  200,  342,  263,
-      200,  343,  349,  213,  353,  264,  214,  350,  351,  215,
-      287,  286,  281,  200,  216,  200,  200,  285,  217,  348,
-      282,  200,  218,  354,  355,  361,  200,  200,  219,  349,
-      356,  220,  357,  362,  350,  351,  200,  200,  200,  281,
-
-      199,  216,  198,  200,  285,  217,  187,  282,  200,  218,
-      354,  355,  361,  200,  200,  219,  189,  356,  220,  357,
-      362,  363,  364,  200,  200,  200,  200,  306,  307,  308,
-      200,  309,  315,  221,  316,  222,  200,  317,  367,  358,
-      223,  359,  368,  318,  369,  224,  200,  186,  363,  364,
-      319,  184,  360,  200,  306,  307,  308,  200,  309,  315,
-      221,  316,  222,  200,  317,  367,  358,  223,  359,  368,
-      318,  369,  224,  200,  225,  365,  370,  319,  366,  360,
-      371,  200,  226,  372,  373,  227,  374,  328,  228,  329,
-      377,  229,  375,  330,  230,   97,  376,  382,   96,  385,
-
-      331,  225,  365,  370,  332,  366,   87,  371,  200,  226,
-      372,  373,  227,  374,  328,  228,  329,  377,  229,  375,
-      330,  230,  236,  376,  382,  383,  385,  331,  237,  238,
-      239,  332,  378,  389,  386,  240,  384,  379,  391,  392,
-      200, 1367,  393,  387,  394,  380,  395,  390,   47,  236,
-      381,  388,  383,  398,  399,  237,  238,  239,   47,  378,
-      389,  386,  240,  384,  379,  391,  392,  200,  249,  393,
-      387,  394,  380,  395,  390,  200,  396,  381,  388,  400,
-      398,  399,  250,  406,  403,  200, 1367,  397,  251,  252,
-     1367,  404,  407,  401,  405,  249, 1367, 1367,  412,  408,
-
-      413,  414,  200,  396, 1367,  409,  400, 1367,  544,  250,
-      406,  403,  200,  402,  397,  251,  252,  200,  404,  407,
-      401,  405,  253,  410,  200,  412,  408,  413,  414,  545,
-      254,  200,  409,  546,  255,  544,  411,  256,  257, 1367,
-      402, 1367, 1367, 1367,  200, 1367, 1367, 1367, 1367,  253,
-      410,  200, 1367, 1367, 1367,  547,  545,  254,  200, 1367,
-      546,  255,  429,  411,  256,  257,  258,  200,  200,  200,
-      418,  200,  200,  200,  200,  200,  548,  259,  200,  200,
-      200,  200,  547,  260,  549,  550,  200, 1367,  200,  429,
-      551,  200, 1367,  258,  200,  200,  200,  418,  200,  200,
-
-      200,  200,  200,  548,  259,  200,  200,  200,  200, 1367,
-      260,  549,  550,  200,  265,  200,  266,  551,  200,  267,
-      200,  552,  268,  420,  269,  200,  270,  271, 1367, 1367,
-      200,  421, 1367, 1367,  553,  200,  200, 1367, 1367, 1367,
-     1367,  265, 1367,  266, 1367, 1367,  267,  200,  552,  268,
-      420,  269,  200,  270,  271,  200,  200,  200,  421,  200,
-      200,  553,  200,  200,  272,  200,  430,  200,  273,  200,
-      419,  274,  275,  424,  200,  200,  200,  557,  276,  200,
-      558,  277,  200,  200,  559,  560,  200,  200,  200, 1367,
-     1367,  272,  200,  430,  200,  273,  200,  419,  274,  275,
-
-      424,  200,  200,  200,  557,  276,  200,  558,  277, 1367,
-     1367,  559,  560, 1367, 1367,  200,   91,   91,   91,   91,
-       91,   91,   91,   91,   91,   91,  289,  289,  289,  289,
-      289,  289,  289,  289,  289,  289,   92,   93,   93,   93,
-       93,   93,   93,   93,   93,   93,   93,  193,  193,  193,
-      193,  193,  193,  193,  193,  193,  193,  417,  417,  417,
-      417,  417,  417,  417,  417,  417,  417,  194,  195,  195,
-      195,  195,  195,  195,  195,  195,  195,  195,  422,  425,
-      554,  423,  555,  561,  562,  563,  564, 1367,  200,  200,
-      200,  200,  565,  566,  200,  200,  200,  556,  200,  567,
-
-      200,  200, 1367, 1367,  200,  422,  425,  554,  423,  555,
-      561,  562,  563,  564,  200,  200,  200,  200,  200,  565,
-      566,  200,  200,  200,  556,  200,  567,  200,  200,  426,
-      427,  200,  431,  568,  200,  200, 1367,  200,  569,  432,
-      433,  200,  200,  428,  200,  572,  573,  200,  574,  575,
-     1367,  200,  576,  200, 1367,  577,  426,  427,  200,  431,
-      568,  200,  200,  200,  200,  569,  432,  433, 1367,  200,
-      428,  200,  572,  573,  200,  574,  575,  438,  200,  576,
-      200,  200,  577,  578, 1367,  200,  570,  439, 1367, 1367,
-      200,  434,  435,  436, 1367,  437,  200,  200,  200, 1367,
-
-      200,  571,  579,  200,  438,  200,  200,  200,  200,  440,
-      578,  200,  452,  570,  439,  200,  200,  200,  434,  435,
-      436,  200,  437,  200,  200,  200,  441,  200,  571,  579,
-      200,  442,  200,  200,  200,  580,  440, 1367,  200,  452,
-     1367,  581,  200,  200,  200, 1367, 1367, 1367,  200,  582,
-     1367, 1367, 1367,  441,  583, 1367,  584,  585,  442,  443,
-     1367,  444,  580, 1367,  445,  586,  587,  200,  581,  200,
-      446, 1367,  200,  448,  449, 1367,  582,  447,  200,  200,
-      200,  583,  200,  584,  585,  200,  443,  450,  444,  588,
-      200,  445,  586,  587,  200,  589,  200,  446,  200,  200,
-
-      448,  449,  200,  590,  447,  200,  200,  200,  451,  200,
-      591,  592,  200,  593,  450,  455,  588,  200,  200, 1367,
-     1367,  594,  589,  200,  200,  200,  200,  200, 1367,  200,
-      590,  200,  461,  463,  200,  451,  200,  591,  592,  200,
-      593,  595,  455,  200,  200,  200,  453,  454,  594, 1367,
-      200,  200,  596,  200,  200,  200, 1367,  200,  200,  461,
-      463,  200,  200,  200,  597,  598,  200,  200,  595,  599,
-      200,  200,  600,  453,  454,  601,  462,  602,  200,  596,
-     1367, 1367,  200,  200,  200, 1367, 1367, 1367,  200,  200,
-     1367,  597,  598, 1367,  200,  456,  599,  457, 1367,  600,
-
-     1367,  458,  601,  462,  602,  200,  603,  200,  459,  200,
-      200,  606,  460,  200,  464,  200,  200,  200, 1367,  466,
-      465,  200,  456,  607,  457,  467,  200,  200,  458,  200,
-     1367,  608,  200,  603,  200,  459,  200,  200,  606,  460,
-      200,  464,  609,  200,  200,  200,  466,  465,  200,  200,
-      607, 1367,  467,  200,  200,  468,  200,  200,  608,  200,
-      610,  200,  611,  604,  200,  200,  614,  469,  200,  609,
-      200,  615,  200,  605,  616,  470,  200,  200,  471,  200,
-      200,  472,  468, 1367,  200, 1367,  200,  610,  200,  611,
-      604,  200,  200,  614,  469,  200,  617,  200,  615,  618,
-
-      605,  616,  470, 1367,  200,  471,  200,  200,  472,  200,
-      200,  200,  200,  200,  619,  612,  200,  200,  200,  473,
-      200,  200,  200,  617,  474,  613,  618, 1367, 1367, 1367,
-      200, 1367, 1367, 1367, 1367,  620,  200,  200,  200,  200,
-      200,  619,  612,  200,  200,  621,  473,  200,  200,  200,
-      200,  474,  613,  622,  200,  200,  200,  200,  480,  481,
-      200,  475,  620,  200,  623,  200,  624,  200,  200,  625,
-      200, 1367,  621, 1367,  200,  200, 1367,  200,  200, 1367,
-      622,  200,  200,  200,  200,  480,  481,  200,  475, 1367,
-      200,  623,  200,  624,  482,  200,  625,  200,  476,  200,
-
-      483,  200,  200,  200,  626,  200,  200,  628,  477,  200,
-      200,  200,  200,  478,  479, 1367,  489,  200,  200,  200,
-     1367,  482,  200,  627, 1367,  476,  200,  483, 1367, 1367,
-      200,  626, 1367,  200,  628,  477,  200,  200,  500,  200,
-      478,  479,  200,  489,  200,  200,  200,  200,  200,  200,
-      627,  200,  200,  484,  490,  485,  503,  200,  200,  200,
-      504,  631,  632, 1367,  200,  500,  200,  200, 1367,  200,
-     1367, 1367,  633, 1367,  200,  200,  200,  629,  200,  200,
-      484,  490,  485,  503,  200,  200,  200,  504,  631,  632,
-      630,  200, 1367,  200,  200,  486,  634,  487,  200,  633,
-
-      491,  635,  636,  200,  629,  200,  200,  200,  488,  200,
-      200,  637,  638,  200,  200,  492,  639,  630,  200,  200,
-     1367,  640,  486,  634,  487,  200,  641,  491,  635,  636,
-     1367, 1367,  200,  200,  200,  488,  200,  200,  637,  638,
-      200,  200,  492,  639, 1367,  200,  200,  200,  640,  200,
-      495, 1367,  200,  641,  200,  493, 1367,  200,  494,  200,
-      496, 1367,  200,  200,  642,  200,  643, 1367,  644, 1367,
-      200,  200, 1367,  200,  200,  200,  200,  495,  200,  200,
-     1367,  200,  493,  200,  200,  494,  200,  496,  497,  200,
-      200,  642,  200,  643,  200,  644,  200,  200,  200,  498,
-
-      200,  200,  200, 1367,  645,  200,  200,  200, 1367,  200,
-      200, 1367, 1367,  646,  200,  497,  647,  648, 1367,  200,
-      649,  200, 1367,  200, 1367,  650,  498,  651,  200, 1367,
-      200,  645,  200,  200,  200,  200,  200,  200,  499,  200,
-      646,  200,  200,  647,  648,  200,  200,  649,  501,  200,
-     1367,  505,  650,  652,  651,  200,  200,  200,  653,  200,
-     1367,  200,  200,  502,  200,  499,  200,  200,  654,  200,
-      657,  200,  200, 1367,  510,  501,  200,  200,  505,  200,
-      652,  200,  200,  200,  660,  653,  200,  200,  200, 1367,
-      502,  200, 1367, 1367,  200,  654, 1367,  657,  200, 1367,
-
-      655,  510, 1367, 1367,  200,  511,  200,  200,  200,  656,
-     1367,  660,  200,  200,  200,  506,  512,  200,  200,  513,
-      507,  661,  662,  200, 1367,  200,  200,  655,  508,  658,
-      200,  659,  511,  509,  200,  200,  656,  517,  200,  200,
-      663,  200,  506,  512,  200,  200,  513,  507,  661,  662,
-      200,  518,  200,  200, 1367,  508,  658,  200,  659,  200,
-      509,  200,  200,  519,  517,  200,  514,  663,  200,  200,
-      664,  665,  200,  666,  669,  515, 1367,  200,  518,  200,
-     1367,  520,  200,  516, 1367,  200,  200,  200,  200,  200,
-      519, 1367, 1367,  514, 1367,  200,  200,  664,  665,  667,
-
-      666,  669,  515,  668,  200,  200,  200,  200,  520,  200,
-      516,  200,  200,  670,  200,  522,  200,  200,  523,  200,
-      521,  200,  200,  200,  800,  200,  667,  200,  801,  200,
-      668,  200,  200, 1367,  200, 1367,  802,  803,  200,  200,
-      670,  200,  522,  804,  200,  523,  200,  521,  200,  526,
-      200,  800,  200,  200,  200,  801,  200, 1367,  200,  200,
-      200,  524,  200,  802,  803,  805,  200,  200,  200,  200,
-      804,  200,  525,  200,  806,  200,  526,  200, 1367,  527,
-      200,  200,  807,  200,  528, 1367,  200,  200,  524,  200,
-     1367,  200,  805,  200,  200, 1367,  200,  808,  200,  525,
-
-      200,  806,  200,  200,  200,  529,  527,  535,  200,  807,
-      200,  528,  200,  200,  809,  810,  534,  200,  200,  200,
-      200,  200,  200,  200,  808,  530, 1367,  200, 1367, 1367,
-      200,  811,  529, 1367,  535, 1367, 1367,  200, 1367,  200,
-      200,  809,  810,  534,  200,  812,  200,  813,  200,  200,
-      200, 1367,  530,  531,  200,  536,  200,  200,  811,  814,
-      532,  537,  200,  533,  200,  538,  200,  200, 1367,  200,
-      815,  816,  812, 1367,  813,  200,  200, 1367,  539,  817,
-      531,  818,  536,  200,  200,  200,  814,  532,  537,  200,
-      533,  540,  538,  200,  200,  200,  200,  815,  816, 1367,
-
-      200,  200,  200,  200,  200,  539,  817,  819,  818,  542,
-      200,  200,  200,  200,  674,  541,  200,  200,  540,  820,
-      200,  200,  200,  200,  821,  822,  200,  200,  200,  823,
-      824,  200,  825,  200,  819, 1367,  542,  200,  200, 1367,
-      200,  674,  541,  200,  200, 1367,  820,  200,  200, 1367,
-      200,  821,  822,  200, 1367, 1367,  823,  824, 1367,  825,
-      200,  289,  289,  289,  289,  289,  289,  289,  289,  289,
-      289,  417,  417,  417,  417,  417,  417,  417,  417,  417,
-      417,  200,  672,  200,  673,  200,  200,  200,  200,  826,
-      827,  200,  200,  200,  200, 1367,  828,  829, 1367,  830,
-
-     1367,  200,  200,  200,  200, 1367, 1367, 1367,  200,  672,
-      200,  673,  200,  200,  200,  200,  826,  827,  200,  200,
-      200,  200,  675,  828,  829,  200,  830,  200,  200,  200,
-      200,  200,  200,  200,  200,  200,  200,  200,  200, 1367,
-      200,  200,  200, 1367,  831,  200,  200, 1367,  676,  675,
-      832, 1367,  200,  833,  200,  834, 1367, 1367,  200,  200,
-      200,  200,  200,  200,  200,  200,  200,  200,  200,  200,
-      677,  831,  200,  200,  200,  676,  200,  832,  200,  200,
-      833,  835,  834,  679,  200,  200,  200, 1367,  680,  200,
-      200,  836,  678,  200,  200,  200,  837,  677,  838,  200,
-
-      200,  200,  681,  200,  200,  200,  200,  839,  835,  200,
-      679,  200,  840,  200,  200,  680,  200,  200,  836,  678,
-      200,  200,  200,  837,  200,  838,  200,  200, 1367,  681,
-      200,  200, 1367,  685,  839, 1367,  200, 1367, 1367,  840,
-      200,  200,  682, 1367,  683,  200,  841,  200,  200,  200,
-      842,  200,  843, 1367,  200,  200,  844,  200,  200,  684,
-      685,  686,  200, 1367,  200,  200,  687,  200,  200,  682,
-      200,  683,  200,  841,  200,  200,  200,  842,  200,  843,
-      200,  200,  200,  844, 1367,  200,  684, 1367,  686,  200,
-      689,  200,  200,  687,  200,  200, 1367,  200,  200, 1367,
-
-      845,  200,  690,  846,  200,  200,  200,  200,  847,  688,
-      200,  200, 1367,  200,  200, 1367,  200,  689,  691,  850,
-     1367,  200, 1367,  200, 1367,  200,  200,  845,  848,  690,
-      846,  200,  851,  200,  852,  847,  688,  200,  200,  849,
-      200,  200,  200,  200,  200,  691,  850,  693,  692,  200,
-      200,  200,  853,  200,  200,  848,  200,  200,  200,  851,
-      854,  852,  857,  694,  858, 1367,  849,  200,  200,  200,
-      695,  200,  200, 1367,  693,  692,  200,  200,  200,  853,
-     1367,  200,  200,  200,  200,  200, 1367,  854,  200,  857,
-      694,  858,  696,  859,  200,  200, 1367,  695,  200,  200,
-
-      855,  856,  697,  698,  200,  860,  200,  200,  200,  200,
-      200, 1367,  861,  200,  862,  200,  200,  863,  699,  696,
-      859, 1367,  864,  200, 1367,  200,  200,  855,  856,  697,
-      698, 1367,  860,  200,  200,  200,  700,  200,  200,  861,
-      200,  862,  200,  200,  863,  699,  865,  701,  200,  864,
-      200,  200, 1367,  200,  866, 1367,  200,  200,  200, 1367,
-      200,  867,  868,  700,  869,  200,  200,  200, 1367,  200,
-     1367,  702, 1367,  865,  701,  200,  200, 1367,  200,  703,
-     1367,  866,  200,  200,  200,  200,  200,  200,  867,  868,
-     1367,  869,  200,  200,  200,  705,  870,  200,  702,  200,
-
-      200,  200,  200,  200,  200,  200,  703,  200,  704,  200,
-      706,  871,  872,  200, 1367,  200,  873,  200, 1367,  200,
-      200,  874,  705,  870,  200,  875,  200,  200,  200,  200,
-      876,  200,  200, 1367,  200,  704,  200,  706,  871,  872,
-      200,  707,  200,  873,  200,  200,  200,  200,  874,  200,
-      708, 1367,  875, 1367,  200,  200,  200,  876,  877,  200,
-      200,  200,  711,  200,  200,  200,  710,  200,  707,  200,
-      200,  200,  200,  200,  200, 1367,  200,  708,  709, 1367,
-      200,  200,  200,  200,  200,  877,  200,  200,  200,  711,
-      200,  200,  200,  710,  878,  879,  200,  200,  200, 1367,
-
-      200,  200,  200,  880,  200,  709,  714,  200,  712,  200,
-      200,  200,  881,  200,  200,  200,  200,  200,  882,  883,
-      713,  878,  879,  884,  715,  200,  200,  200,  200,  200,
-      880,  200,  200,  714, 1367,  712,  200,  200,  200,  881,
-      200,  200,  200,  200,  885,  882,  883,  713,  200,  886,
-      884,  715,  200,  200,  716,  200,  200,  887,  888,  200,
-      717,  200, 1367,  889,  200,  200,  200,  890,  718,  200,
-      200,  885,  891,  200, 1367,  200,  886,  719,  892,  200,
-      200,  716,  893,  200,  887,  888, 1367,  717,  200,  200,
-      889,  200, 1367,  200,  890,  718,  200,  200, 1367,  891,
-
-      200,  720,  721,  200,  719,  892,  200,  200,  200,  893,
-     1367,  894,  200,  200,  200,  895,  200, 1367,  896,  200,
-     1367, 1367,  897, 1367,  200,  200, 1367,  200,  720,  721,
-      200, 1367,  200, 1367,  722,  200, 1367,  200,  894,  200,
-      200,  200,  895,  200,  723,  896,  200,  724,  200,  897,
-      200,  200,  200,  200,  200,  200,  998, 1367,  200,  200,
-      200,  722,  200,  200,  200, 1367,  999, 1367,  200, 1367,
-      200,  723, 1000,  725,  724,  200, 1001,  200,  200, 1367,
-      200, 1002,  200,  998,  200,  200, 1003,  200,  200,  200,
-      200, 1367,  200,  999,  200,  200,  200,  726,  727, 1000,
-
-      725, 1367,  200, 1001,  200,  200,  200, 1367, 1002, 1367,
-      200,  200,  200, 1003, 1004,  200,  728, 1367,  729,  200,
-     1005,  200,  200,  200,  726,  727,  200, 1367,  200,  200,
-      730,  200,  731,  200,  200, 1006,  200,  200,  200,  200,
-      200, 1004,  200,  728,  732,  729, 1007, 1005,  200,  200,
-      200, 1367,  200,  200,  733,  200,  200,  730, 1367,  731,
-      200,  200, 1006,  200,  200,  200,  200,  200, 1008,  200,
-     1009,  732,  734, 1007, 1010,  200,  200,  200,  200,  200,
-      735,  733,  200,  200,  200,  200, 1367,  200, 1011,  200,
-      200,  200, 1367,  200,  200, 1008, 1367, 1009, 1012,  734,
-
-      737, 1010, 1367,  200,  200,  200,  200,  735,  200,  200,
-      200,  200,  200,  200,  736, 1011,  200,  200,  200,  200,
-      200,  200,  200,  738,  742, 1012,  200,  737, 1013,  200,
-     1367,  200,  200,  200, 1367,  200, 1014,  200, 1015,  200,
-      200,  736,  200,  739,  200,  200,  200,  200,  200,  200,
-      738,  742, 1016,  200,  200, 1013,  200,  200,  200,  200,
-      743,  200,  200, 1014,  200, 1015,  200,  200,  200,  200,
-      739,  200,  745, 1367, 1017,  200, 1367,  200,  200, 1016,
-     1018,  200, 1367, 1019,  200,  200, 1367,  743,  200,  200,
-     1020,  200,  740,  200,  200,  200,  200,  200, 1367,  745,
-
-      200, 1017,  741,  200,  200,  200,  200, 1018, 1021,  744,
-     1019, 1367, 1022,  200, 1367, 1367,  200, 1020,  200,  740,
-      200,  200,  200,  200,  200,  200, 1023,  200,  200,  741,
-      200,  200, 1024,  200,  746, 1021,  744, 1025,  200, 1022,
-      200,  200,  747,  200, 1026,  200,  200, 1367,  200,  200,
-      200, 1027,  200, 1023, 1367,  200,  200, 1028,  200, 1024,
-      748,  746,  200, 1367, 1025,  200,  200,  200,  200,  747,
-     1029, 1026,  200,  200,  200, 1367,  200,  200, 1027, 1367,
-      749,  200, 1030,  200, 1028, 1367,  200,  748,  200,  200,
-      200, 1031,  751,  200,  200,  750,  200, 1029, 1367,  200,
-
-      200,  200,  200,  200, 1367, 1032,  752,  749,  200, 1030,
-      200, 1033,  200,  200, 1367,  200,  200,  200, 1031,  751,
-     1367,  200,  750,  200, 1034,  200,  200,  200,  200,  200,
-      756,  200, 1032,  752,  753,  200, 1367,  200, 1033,  200,
-      200,  200, 1367,  200, 1037, 1038, 1367,  761,  200,  200,
-     1367, 1034,  200,  200,  200,  200, 1367,  756,  200,  200,
-     1039,  753,  200,  200,  759,  200, 1367,  200,  200,  754,
-      200, 1037, 1038,  200,  761,  200,  200,  200, 1040, 1367,
-     1041,  200, 1035,  200, 1042, 1036,  200, 1039,  755, 1043,
-      200,  759,  200,  200, 1367, 1044,  754,  200, 1045, 1046,
-
-      200,  760,  200, 1367,  200, 1040,  200, 1041,  200, 1035,
-      200, 1042, 1036,  200, 1047,  755, 1043, 1048,  200,  762,
-      200,  757, 1044,  200, 1049, 1045, 1046, 1367,  760,  200,
-      200, 1367,  200,  200,  758,  200, 1050,  200, 1051,  200,
-      200, 1047,  200, 1367, 1048,  200,  762, 1367,  757, 1052,
-      200, 1049, 1053, 1367,  763, 1367,  200,  200,  200,  200,
-     1367,  758,  200, 1050,  200, 1051,  200,  200,  200,  200,
-      200,  200, 1054,  765,  200, 1367, 1052,  200,  200, 1053,
-      200,  763,  764, 1367,  766,  200,  200,  200, 1367,  200,
-      200,  200, 1055, 1367,  200,  200,  200,  200,  200, 1054,
-
-      765,  200,  768, 1367,  200,  200,  200,  200,  200,  764,
-      200,  766,  200,  200,  200,  767, 1056,  200,  200, 1055,
-      200,  200,  200,  200,  770,  200,  200, 1057,  200,  768,
-      200,  769, 1058,  200,  200,  200,  200,  200,  774,  200,
-      200,  200,  767, 1056,  200,  200,  200,  200,  200,  200,
-      200,  770,  200,  200, 1057,  200,  200,  200,  769, 1058,
-      200,  200, 1059,  200, 1060,  774,  200,  200,  200,  771,
-      200,  200,  200,  200,  200,  200,  200,  200, 1061,  200,
-      200, 1062, 1063,  200, 1064,  200,  773,  200,  772, 1059,
-      200, 1060,  200,  200,  200,  200,  771,  200, 1065,  200,
-
-      775,  200,  200,  200,  200, 1061,  200,  200, 1062, 1063,
-     1367, 1064,  200,  773, 1367,  772,  200,  200,  200,  200,
-     1066,  200,  200,  200,  776, 1065,  200,  775,  200, 1067,
-      777,  200,  200, 1068,  200, 1069,  200,  200,  778, 1070,
-     1071,  200,  200,  200, 1148,  200,  200, 1066, 1367, 1367,
-      200,  776, 1367, 1367, 1367,  200, 1067,  777, 1367,  200,
-     1068,  200, 1069,  200,  200,  778, 1070, 1071,  200,  200,
-      200, 1148,  200,  200,  200,  781,  780,  200,  779,  200,
-      200,  200,  200, 1149,  200,  200,  200, 1367, 1150, 1367,
-      200, 1151, 1152, 1153, 1367,  200, 1367,  200, 1154,  200,
-
-      200,  200,  781,  780,  200,  779,  200,  200,  200,  200,
-     1149,  200,  200,  200,  200, 1150,  782,  200, 1151, 1152,
-     1153,  200,  200,  783,  200, 1154,  200,  200,  200, 1367,
-      200, 1155,  784, 1367,  785, 1156, 1157,  200, 1158, 1367,
-     1159,  200,  200,  782,  200, 1160, 1161, 1367,  200, 1367,
-      783,  200, 1367,  200, 1162,  200,  200,  200, 1155,  784,
-      200,  785, 1156, 1157,  200, 1158,  786, 1159,  787,  200,
-      200,  200, 1160, 1161,  200, 1367,  200,  200,  789,  790,
-      788, 1162,  200,  200,  200, 1367,  200,  200, 1163,  200,
-      200, 1367,  200,  786, 1367,  787, 1367,  200, 1367, 1367,
-
-     1367,  200,  200,  200,  200,  789,  790,  788, 1367,  200,
-     1164,  200,  792,  200, 1165, 1163,  200,  200,  200,  200,
-      200,  200, 1166,  200,  200,  200,  200,  791,  200,  200,
-      200,  200, 1367,  200, 1367,  793,  200, 1164, 1167,  792,
-     1367, 1165, 1168, 1367, 1367,  200, 1367,  200,  200, 1166,
-      200,  200,  200,  200,  791,  200, 1169,  200,  200,  200,
-      200,  200,  793,  200, 1170, 1167,  200,  794,  200, 1168,
-      795,  200, 1171,  797,  796,  200, 1367,  200, 1367,  200,
-      200, 1172, 1367, 1169,  200, 1367,  200, 1367,  200,  200,
-     1173, 1170, 1367,  200,  794,  200, 1367,  795,  200, 1171,
-
-      797,  796,  200,  200,  200,  200,  200,  200, 1172,  798,
-      200,  200,  200, 1174,  200,  200,  200, 1173,  899,  200,
-     1367,  200, 1175,  200,  200, 1367, 1367,  900,  200, 1367,
-      200, 1176,  200,  200, 1367, 1367,  798,  200, 1367,  200,
-     1174,  200,  200,  200, 1367,  899,  200,  200,  200, 1175,
-      200,  200,  200,  200,  900,  200,  200, 1177, 1176,  200,
-      200,  904,  200,  901, 1178,  200,  200, 1179, 1180,  200,
-      200,  200,  902, 1181,  200,  200, 1367,  905,  903,  200,
-      200,  200, 1367,  200, 1177,  200,  200,  200,  904,  200,
-      901, 1178,  200,  200, 1179, 1180,  200,  200,  200,  902,
-
-     1181, 1182,  200,  907,  905,  903, 1367,  200,  200,  200,
-     1367,  906,  200,  200,  200,  200,  200, 1183, 1367,  200,
-     1367,  200, 1367,  200,  200,  200, 1184, 1185, 1182, 1186,
-      907, 1187, 1367,  908,  200,  200,  200,  200,  906, 1188,
-      200,  200,  200,  200, 1183,  200,  200,  200,  200,  200,
-      200, 1189,  200, 1184, 1185,  200, 1186,  200, 1187,  200,
-      908, 1190,  200,  200,  200,  200, 1188,  909,  200,  200,
-     1367,  200,  200, 1191,  200,  200,  200, 1192, 1189,  200,
-     1367,  200,  200, 1240,  200,  200,  200, 1242, 1190,  200,
-      200,  200,  200,  910,  909,  200,  200,  200,  200, 1243,
-
-     1191,  911,  200, 1244, 1192,  200,  200,  200,  200, 1367,
-     1240,  200,  200, 1367, 1242,  200,  200,  200,  200, 1367,
-      910,  200,  200,  200,  200,  200, 1243,  200,  911,  200,
-     1244,  200,  200,  200,  200,  200,  912, 1245,  200,  200,
-      913,  200,  200,  200,  200,  200,  914, 1246,  200,  915,
-      200,  200,  200,  200,  200, 1367,  200, 1367,  200,  200,
-      200,  200,  200,  912, 1245,  200,  200,  913,  200,  200,
-      200,  200,  200,  914, 1246,  200,  915, 1367,  200,  200,
-      200,  200,  917, 1367,  200,  200,  200,  200,  200,  200,
-      916,  924,  200, 1247,  200,  200,  200,  200,  200, 1367,
-
-     1248, 1367,  200,  200,  918,  200,  200,  200,  200,  917,
-      200,  200,  200, 1249,  200,  200,  200,  916,  924, 1367,
-     1247,  200,  200, 1250,  200, 1251,  200, 1248,  200, 1252,
-      200,  918,  200,  200,  200,  919, 1253,  200,  200,  200,
-     1249,  200,  200, 1254, 1367, 1255,  200,  920, 1256, 1367,
-     1250,  200, 1251,  200, 1367,  200, 1252, 1367,  921, 1367,
-      200, 1257,  919, 1253, 1258,  200,  200, 1259,  200,  200,
-     1254,  200, 1255,  200,  920, 1256,  200,  200,  200,  200,
-     1367,  200, 1260,  922,  200,  921,  923, 1261, 1257,  200,
-     1262, 1258, 1367, 1367, 1259,  200,  200,  200,  200, 1367,
-
-     1288, 1290,  200,  200,  200, 1291,  200,  200,  200, 1260,
-      922,  200, 1367,  923, 1261, 1292,  200, 1262,  925,  200,
-      200,  200,  200, 1293,  200,  200,  200, 1288, 1290,  200,
-      200,  200, 1291, 1294,  200, 1241, 1241,  200, 1367,  200,
-     1295, 1296, 1292, 1367,  200,  925,  200,  200,  200,  200,
-     1293, 1297,  200,  200, 1367,  926, 1298,  200,  200, 1299,
-     1294, 1300, 1367,  200,  200,  200,  200, 1295, 1296, 1317,
-      200,  200, 1318, 1289, 1319,  200,  200,  200, 1297,  200,
-     1367,  927,  926, 1298,  200, 1367, 1299, 1367, 1300,  200,
-      200,  200,  200,  200, 1367,  928, 1317,  200,  200, 1318,
-
-     1289, 1319,  200,  200,  200,  200,  200,  200,  927, 1320,
-     1367,  200,  200, 1321,  929, 1367,  200,  200,  200,  200,
-      200,  200,  928, 1367,  931,  200,  200,  930, 1367, 1324,
-      200,  200,  200, 1367,  200,  200, 1320,  200, 1367,  200,
-     1321,  929,  200, 1331,  200,  933,  200,  200,  200,  200,
-      932,  931, 1367,  200,  930,  200, 1324, 1332,  200, 1316,
-     1316,  200,  200,  200,  200,  200, 1367, 1367,  200,  200,
-     1331,  200,  933,  200,  200,  200,  200,  932, 1367,  200,
-     1335,  200,  200,  200, 1332, 1338, 1367, 1340,  200,  200,
-      200,  200,  200,  200,  934,  200, 1367,  200,  200,  200,
-
-      200, 1330,  200,  935, 1367,  200,  200, 1335,  200,  936,
-      200, 1342, 1338,  200, 1340,  200,  200, 1344,  200,  937,
-      200,  934, 1367,  200,  200,  200,  200,  200, 1330, 1346,
-      935,  200,  200,  200, 1367,  200,  936, 1348, 1342, 1350,
-      200,  200,  200,  200, 1344,  200,  937, 1352, 1367,  200,
-      200,  200,  200,  938,  200,  200, 1346,  200,  200, 1367,
-      200,  200,  200, 1354, 1348,  200, 1350,  200,  200, 1367,
-      200, 1356,  200, 1367, 1352,  200,  200,  200,  200,  200,
-      938, 1358,  200,  200,  200,  200,  939,  200,  200,  200,
-     1354,  940,  200,  200,  200,  200,  200, 1367, 1356, 1323,
-
-     1316,  200,  200,  200,  200, 1367,  200, 1360, 1358, 1367,
-      200,  942,  200,  939,  200,  200,  200,  200,  940,  200,
-      200,  200,  200,  200,  200,  200, 1367,  200,  200,  200,
-      200,  200,  941,  200, 1360,  200, 1367,  200,  942, 1367,
-      200, 1334,  200, 1367,  200,  944,  200, 1367,  200, 1367,
-     1367,  200,  200,  200,  200, 1367,  200,  200,  200,  941,
-      200, 1367,  200,  200,  200, 1367,  943,  200, 1334,  200,
-     1367,  200,  944,  200, 1367,  945,  200, 1367, 1367, 1367,
-      200,  200, 1265, 1241,  200,  200, 1367,  200, 1367, 1367,
-      200,  946,  200,  943, 1367, 1367,  200,  200,  200,  200,
-
-      200,  200,  945,  200, 1367, 1367,  200, 1367,  200, 1367,
-     1367,  200,  200, 1367,  200, 1367, 1367, 1367,  946,  200,
-     1303, 1367, 1367, 1367,  200,  947,  200,  949,  200,  200,
-      200, 1367,  200,  200,  200, 1367,  948,  200,  200,  200,
-     1367,  200,  200,  200, 1367, 1367, 1367, 1303,  200, 1367,
-     1367, 1367,  947,  200,  949, 1367,  200,  200, 1367,  200,
-      200,  200,  200,  948,  200, 1367,  200,  200,  200,  200,
-      200,  200,  200,  200,  200,  200,  200, 1367,  200, 1367,
-      200,  200,  950,  200, 1367, 1367,  200,  200, 1367,  200,
-      200, 1367,  200, 1367,  200, 1367, 1367,  200,  200,  200,
-
-      200,  200,  200,  200,  951,  200,  200, 1367,  200,  950,
-      200,  200, 1367,  200, 1367, 1367,  200,  200, 1367,  200,
-     1367, 1367,  952, 1367,  200, 1367,  200, 1367, 1367,  200,
-      200,  951,  200,  200,  200,  953, 1367, 1367,  200,  200,
-      200, 1367,  200,  200,  200,  200,  200, 1367, 1367,  952,
-      200,  954,  955,  200,  956,  200,  200,  200,  200,  200,
-      200,  200,  953, 1367, 1367,  200,  200,  200, 1367,  200,
-      200,  200,  200,  200, 1367, 1367, 1367,  200,  954,  955,
-     1367,  956,  200,  200,  200,  200,  200,  200, 1367,  200,
-      957,  200,  200,  958,  200, 1367,  200,  200,  200,  200,
-
-      959, 1367,  200,  200,  200,  975,  200, 1367, 1367,  200,
-      200,  200,  200,  200,  200,  200,  200,  957,  200, 1367,
-      958,  200,  200,  200,  960,  200,  200,  959,  200,  200,
-      200,  200,  975,  200,  200, 1367,  200,  200, 1367,  200,
-     1367,  200,  200,  200,  200, 1367, 1367,  200, 1367,  200,
-     1367,  960, 1367,  200, 1367,  200,  961,  978, 1367,  200,
-     1367,  200,  200,  200,  200, 1367,  200, 1367, 1367,  200,
-      200,  200,  200, 1367,  200,  962, 1367,  200, 1367, 1367,
-      200,  200,  200,  961,  978, 1367,  200,  200, 1367,  200,
-      200,  200, 1367,  200, 1367, 1367,  200,  200, 1367,  200,
-
-     1367, 1367,  962,  200,  200, 1367,  200,  200,  200,  200,
-      964,  963, 1367,  200,  200,  200,  200, 1367, 1367,  200,
-     1367, 1367, 1367,  200,  200,  200,  200, 1367, 1367, 1367,
-      200, 1367, 1367,  200,  200,  200, 1367,  964,  963, 1367,
-      200,  965,  200,  200, 1367,  200,  200, 1367, 1367, 1367,
-      200,  200,  200,  200, 1367,  966,  967, 1367, 1367,  200,
-      200,  200,  200,  200,  200, 1367, 1367, 1367,  965,  200,
-      200, 1367,  200, 1367, 1367, 1367, 1367, 1367,  200,  200,
-      200, 1367,  966,  967, 1367,  968,  200,  200,  200,  200,
-      200,  200, 1367, 1367,  200,  200,  200,  200,  200, 1367,
-
-     1367, 1367, 1367, 1367,  200,  200,  200,  200, 1367, 1367,
-     1367, 1367,  968,  200,  200, 1367,  200,  200, 1367, 1367,
-     1367,  200,  200,  200, 1367,  200,  969, 1367, 1367, 1367,
-     1367,  200,  200,  200, 1367,  200, 1367, 1367,  200,  200,
-      200,  200,  200,  970,  200,  200, 1367, 1367,  200, 1367,
-      200,  971, 1367,  969, 1367,  200, 1367, 1367,  200, 1367,
-      200, 1367,  200, 1367,  200,  200,  200,  200,  200,  200,
-      970,  200,  200,  973,  200,  200,  200,  200,  971,  972,
-      200, 1367,  200, 1367,  200,  200,  200,  200, 1367,  200,
-     1367,  200, 1367,  200,  200,  200,  200,  974,  200,  200,
-
-      973,  200, 1367,  200,  200, 1367,  972,  200, 1367,  200,
-     1367,  200, 1367,  200,  200,  977,  200, 1367,  976,  200,
-      200, 1367, 1367,  200,  974,  200,  200,  200,  200,  200,
-     1367, 1367,  200,  200,  200,  200,  200,  200,  200,  200,
-     1367, 1367,  977,  200, 1367,  976,  200,  979,  200, 1367,
-     1367,  200,  200,  200,  200,  200,  200,  200, 1367,  200,
-      200,  200,  200, 1367,  200,  200,  200,  200, 1367,  200,
-      200, 1367,  981,  980,  979,  200,  200,  200,  200,  200,
-      200,  200,  200, 1367,  200, 1367, 1367,  982, 1367,  200,
-     1367,  200,  200, 1367,  200,  200,  200,  200, 1367,  981,
-
-      980,  200, 1367,  200,  200, 1367,  200, 1367,  200,  200,
-     1367,  200, 1367,  200,  982, 1367,  200,  200,  200,  200,
-     1367, 1367,  200,  200,  200,  200, 1367,  200,  200,  200,
-     1367,  200,  983,  200, 1367, 1367,  984,  200,  200, 1367,
-      200,  200, 1367, 1367,  200, 1367, 1367, 1367, 1367, 1367,
-      200, 1367,  200, 1367,  200,  200,  200,  200,  200,  983,
-      200, 1367,  200,  984,  200,  985, 1367,  200,  200, 1367,
-     1367,  200, 1367,  200,  200,  992,  200, 1367,  200,  200,
-      986,  200,  200,  200,  200,  200,  200, 1367, 1367,  200,
-     1367, 1367,  985, 1367,  200,  200, 1367,  200,  200,  987,
-
-      200,  200,  992,  200,  200,  200,  200,  986,  200,  200,
-      200, 1367,  200,  200, 1367, 1367,  200, 1367,  200,  989,
-     1367, 1367,  200,  200,  200,  988,  987,  200,  200,  200,
-      200,  200,  200, 1367,  200,  990,  200,  200, 1367,  200,
-     1367, 1367,  200,  200, 1367,  200,  989, 1367, 1367, 1367,
-      200, 1367,  988,  991,  200,  200,  200,  200,  200,  200,
-      200,  200,  990,  200,  200,  200,  200,  200,  200,  200,
-      200,  993,  200,  200, 1367, 1367, 1367, 1367,  200, 1367,
-      991, 1367, 1367,  200, 1367,  200, 1367,  200,  200, 1367,
-      200, 1367,  200, 1367,  200,  200, 1367,  200,  993,  200,
-
-      200, 1367,  200,  200,  995,  200,  200,  200,  200, 1367,
-      200, 1367,  200,  200,  200,  200,  200, 1367,  994, 1367,
-      200, 1367,  200,  200,  200,  200,  200,  200, 1367,  200,
-      200,  995,  996,  200,  200,  200,  200,  200, 1367,  200,
-      200,  200, 1367,  200, 1367,  994, 1367,  200, 1367,  200,
-      200,  200,  200,  200,  200,  200, 1367,  200,  200,  996,
-      200, 1367,  200,  200,  200,  200,  200,  200,  200,  200,
-      200,  200, 1367,  200, 1367, 1367,  200, 1367,  200, 1367,
-     1073,  200,  200, 1367,  200,  200, 1367,  200, 1367,  200,
-     1367, 1367,  200,  200,  200,  200,  200,  200,  200, 1367,
-
-      200, 1367, 1074,  200, 1367,  200,  200, 1073,  200, 1367,
-      200, 1075,  200, 1367,  200,  200, 1367, 1367, 1367, 1367,
-      200,  200,  200, 1367, 1367, 1367, 1367, 1367, 1367, 1074,
-      200,  200, 1367,  200, 1367, 1367,  200,  200, 1075,  200,
-      200,  200,  200, 1367, 1367, 1367,  200,  200,  200,  200,
-     1367, 1076, 1367, 1367, 1078,  200,  200,  200,  200,  200,
-     1077, 1367, 1367,  200,  200,  200, 1367,  200,  200, 1367,
-     1367, 1367, 1367,  200,  200,  200, 1367, 1367, 1076, 1367,
-     1367, 1078,  200,  200,  200, 1367,  200, 1077, 1079, 1367,
-      200,  200,  200, 1367,  200,  200,  200,  200, 1080,  200,
-
-      200,  200,  200,  200,  200, 1081, 1367, 1367,  200,  200,
-      200,  200, 1367, 1367, 1367, 1079, 1367,  200,  200, 1367,
-     1367,  200,  200,  200,  200, 1080,  200,  200, 1082, 1367,
-      200,  200, 1081, 1367, 1367,  200,  200,  200,  200, 1367,
-     1083,  200,  200, 1084,  200,  200,  200, 1367,  200,  200,
-      200, 1367,  200,  200,  200, 1082, 1367, 1367, 1085, 1367,
-      200, 1367,  200, 1367,  200,  200, 1367, 1083,  200,  200,
-     1084,  200,  200,  200,  200,  200,  200,  200, 1367,  200,
-      200,  200, 1086, 1367, 1367, 1085, 1087,  200, 1367,  200,
-      200,  200,  200, 1367,  200, 1088, 1367,  200, 1367,  200,
-
-      200,  200,  200,  200, 1367, 1367, 1367,  200, 1089, 1086,
-      200, 1367,  200, 1087, 1367, 1367,  200,  200,  200,  200,
-      200,  200, 1088, 1367,  200, 1367,  200,  200,  200,  200,
-     1367, 1367, 1367, 1367,  200, 1089,  200,  200,  200,  200,
-     1367, 1367, 1090,  200, 1367,  200,  200,  200,  200, 1367,
-      200, 1367,  200,  200, 1092,  200,  200, 1367,  200,  200,
-     1367, 1091, 1367,  200,  200,  200,  200, 1367, 1367, 1090,
-     1093, 1367,  200,  200,  200,  200, 1094,  200, 1367,  200,
-      200, 1092,  200,  200, 1367,  200,  200, 1367, 1091, 1367,
-      200,  200,  200,  200, 1095, 1367,  200, 1093,  200,  200,
-
-      200,  200, 1367, 1094,  200, 1367,  200,  200, 1367,  200,
-     1367, 1096, 1367, 1367,  200, 1367,  200,  200, 1367,  200,
-      200, 1095, 1367,  200,  200,  200, 1367,  200, 1367, 1367,
-      200,  200,  200,  200,  200, 1097, 1367, 1367, 1096, 1098,
-      200,  200, 1367,  200,  200,  200, 1100,  200,  200, 1099,
-      200,  200,  200, 1367,  200,  200, 1367,  200,  200,  200,
-      200,  200, 1097, 1367, 1367,  200, 1098,  200,  200, 1367,
-      200,  200,  200, 1100,  200,  200, 1099,  200,  200,  200,
-     1367,  200,  200, 1367,  200,  200,  200,  200, 1367,  200,
-      200, 1102,  200,  200,  200,  200,  200,  200, 1367,  200,
-
-     1104,  200,  200, 1367, 1101,  200,  200,  200, 1367,  200,
-     1367,  200,  200,  200, 1367,  200,  200,  200, 1102,  200,
-      200,  200, 1367,  200, 1367,  200,  200, 1104, 1367,  200,
-     1103, 1101, 1367,  200,  200,  200,  200, 1367,  200,  200,
-      200,  200,  200,  200, 1106, 1105,  200, 1367,  200,  200,
-      200,  200,  200,  200, 1367, 1367,  200, 1103, 1367, 1367,
-     1367,  200,  200, 1367, 1367,  200, 1367,  200,  200, 1367,
-      200, 1106, 1105, 1367, 1367,  200,  200,  200,  200,  200,
-      200,  200,  200,  200,  200,  200,  200,  200,  200,  200,
-     1107,  200,  200,  200,  200,  200, 1367,  200, 1367, 1367,
-
-      200, 1367, 1367, 1367, 1367,  200,  200, 1367,  200,  200,
-     1367,  200,  200,  200,  200, 1367,  200, 1107,  200,  200,
-      200,  200,  200,  200,  200,  200, 1367,  200, 1367, 1109,
-      200, 1108,  200,  200,  200,  200,  200, 1367, 1367,  200,
-     1367, 1110, 1367, 1367, 1111, 1367,  200, 1367, 1367,  200,
-      200, 1367,  200, 1367, 1367, 1367, 1109,  200, 1108, 1367,
-      200,  200,  200,  200, 1367, 1112,  200,  200, 1110, 1367,
-     1367, 1111,  200,  200, 1367, 1367,  200,  200,  200,  200,
-      200,  200, 1367, 1367, 1367,  200,  200, 1367, 1367, 1367,
-      200,  200, 1112, 1367,  200, 1367, 1367, 1367, 1367,  200,
-
-     1367, 1113, 1367, 1367,  200,  200,  200,  200,  200,  200,
-     1367,  200,  200,  200, 1367, 1367,  200,  200,  200, 1367,
-      200,  200,  200,  200, 1367,  200, 1367,  200, 1113, 1367,
-      200, 1367,  200, 1367, 1367,  200,  200, 1367,  200, 1367,
-     1367, 1114, 1367,  200, 1367,  200, 1367,  200,  200,  200,
-      200,  200,  200,  200,  200,  200, 1116,  200, 1367,  200,
-     1115,  200,  200, 1367, 1367,  200, 1367,  200, 1114,  200,
-     1367, 1367,  200, 1367,  200, 1367, 1367, 1367,  200,  200,
-      200, 1367,  200, 1116, 1367, 1367, 1367, 1115,  200, 1367,
-     1367,  200,  200,  200,  200, 1367,  200, 1367,  200, 1117,
-
-      200,  200,  200,  200, 1367, 1118,  200,  200, 1119,  200,
-     1367,  200,  200, 1367, 1367, 1367,  200, 1367,  200, 1367,
-      200,  200, 1367, 1367, 1367,  200, 1117,  200, 1367,  200,
-      200, 1367, 1118, 1367,  200, 1119,  200, 1367,  200,  200,
-      200, 1367,  200,  200,  200, 1120,  200,  200,  200,  200,
-     1367,  200,  200, 1367, 1367,  200,  200, 1367, 1367, 1367,
-      200, 1367, 1367, 1367,  200,  200, 1367,  200, 1367,  200,
-      200,  200, 1120,  200,  200, 1121,  200, 1367,  200,  200,
-      200, 1367,  200,  200, 1122,  200,  200,  200, 1367,  200,
-      200,  200,  200, 1367, 1367,  200,  200,  200, 1367, 1123,
-
-     1367, 1367, 1121, 1367, 1367,  200,  200,  200, 1367, 1367,
-     1367, 1122,  200,  200,  200,  200,  200,  200,  200,  200,
-     1367, 1367,  200,  200,  200,  200, 1123, 1124, 1367, 1367,
-     1367, 1367,  200,  200,  200,  200, 1367, 1367, 1367, 1125,
-     1126,  200,  200,  200,  200,  200,  200, 1367, 1367,  200,
-      200,  200,  200,  200, 1124, 1367, 1367, 1127, 1367,  200,
-      200,  200,  200,  200, 1128,  200, 1125, 1126,  200,  200,
-      200,  200,  200,  200, 1367,  200,  200,  200,  200, 1367,
-      200, 1367, 1367, 1367, 1127,  200,  200,  200,  200, 1129,
-      200, 1128,  200,  200,  200,  200,  200,  200,  200,  200,
-
-      200, 1367,  200,  200,  200,  200, 1130,  200, 1367, 1131,
-     1367,  200,  200,  200,  200,  200, 1129,  200, 1367,  200,
-      200,  200,  200,  200,  200,  200, 1132,  200, 1367,  200,
-      200,  200,  200, 1130,  200, 1367, 1131, 1367,  200,  200,
-      200,  200,  200, 1367,  200, 1367,  200, 1133,  200,  200,
-      200, 1367,  200, 1132,  200, 1367,  200, 1134,  200,  200,
-      200,  200,  200, 1367, 1367,  200,  200, 1135,  200,  200,
-     1367,  200,  200, 1367, 1133,  200, 1367, 1367, 1367,  200,
-     1367,  200, 1367, 1367, 1134,  200, 1367,  200,  200,  200,
-     1367, 1367,  200, 1367, 1135,  200, 1367, 1367,  200,  200,
-
-      200, 1367,  200,  200, 1367,  200, 1136,  200,  200, 1367,
-      200, 1137,  200, 1138, 1367,  200,  200, 1367, 1140, 1367,
-     1367, 1367, 1367,  200,  200, 1367,  200,  200,  200,  200,
-      200,  200,  200, 1136,  200, 1367,  200,  200, 1137,  200,
-     1138, 1139,  200,  200, 1367, 1140, 1367, 1367, 1367, 1367,
-      200,  200,  200,  200,  200,  200, 1367, 1367,  200,  200,
-      200, 1367,  200,  200,  200, 1141, 1367,  200, 1139,  200,
-     1143, 1367,  200, 1367,  200,  200, 1367, 1142,  200,  200,
-      200,  200,  200, 1367, 1367,  200,  200,  200,  200,  200,
-      200,  200, 1141, 1367,  200, 1367,  200, 1143,  200,  200,
-
-     1367,  200,  200, 1367, 1142,  200,  200,  200, 1367,  200,
-      200,  200,  200,  200, 1367,  200,  200,  200, 1144, 1367,
-     1367, 1145, 1367,  200, 1367,  200,  200, 1367, 1367, 1367,
-     1367, 1367,  200,  200,  200, 1367, 1367,  200,  200,  200,
-      200, 1367, 1367,  200,  200, 1144, 1367, 1146, 1145, 1367,
-      200, 1367, 1367,  200, 1367,  200, 1367,  200,  200,  200,
-      200,  200,  200, 1367, 1367,  200,  200,  200, 1367, 1367,
-      200,  200, 1367, 1367, 1146, 1367,  200, 1367,  200, 1367,
-     1367, 1367,  200,  200,  200,  200, 1194,  200,  200,  200,
-      200,  200,  200, 1367,  200,  200,  200,  200, 1367, 1367,
-
-      200,  200, 1195,  200, 1367,  200,  200,  200, 1367, 1367,
-      200,  200,  200, 1194,  200,  200,  200,  200,  200, 1367,
-     1367,  200,  200,  200, 1367, 1367,  200,  200,  200, 1195,
-      200, 1367, 1196,  200,  200, 1367, 1197,  200,  200,  200,
-      200,  200,  200,  200, 1367,  200,  200, 1367,  200,  200,
-     1367, 1367, 1367,  200, 1367,  200,  200,  200, 1367, 1196,
-     1198, 1367, 1367, 1197,  200,  200, 1367,  200,  200,  200,
-      200, 1367,  200,  200, 1367, 1199,  200,  200, 1367,  200,
-      200, 1367,  200,  200,  200, 1367, 1200, 1198,  200,  200,
-     1367, 1367,  200,  200, 1367,  200, 1367,  200,  200, 1367,
-
-     1367, 1367, 1199, 1367,  200, 1367,  200,  200, 1367, 1367,
-      200,  200,  200, 1200, 1367,  200,  200,  200, 1367,  200,
-      200,  200,  200, 1367, 1367,  200,  200, 1201,  200, 1202,
-      200,  200, 1367, 1367, 1367,  200, 1367,  200, 1367,  200,
-      200, 1367, 1367, 1367,  200, 1367,  200, 1367,  200,  200,
-     1203, 1367, 1367,  200, 1201,  200, 1202,  200,  200,  200,
-     1367,  200,  200, 1204, 1367,  200,  200,  200, 1367, 1367,
-      200,  200,  200, 1367,  200,  200, 1367, 1203, 1367,  200,
-     1205, 1367, 1367, 1367,  200, 1367,  200, 1367,  200, 1367,
-     1204, 1367,  200,  200, 1367, 1367, 1367,  200,  200,  200,
-
-     1367,  200,  200,  200, 1206,  200,  200, 1205, 1367, 1367,
-      200,  200, 1367, 1367,  200,  200,  200,  200, 1367,  200,
-     1367,  200, 1367, 1367,  200, 1367,  200, 1367, 1367,  200,
-      200, 1206,  200, 1367, 1367, 1367, 1207,  200, 1367, 1367,
-     1367,  200,  200,  200,  200,  200,  200,  200,  200, 1367,
-     1367,  200,  200,  200, 1367, 1367,  200,  200,  200,  200,
-      200, 1208, 1367, 1207, 1367,  200,  200, 1367, 1367, 1367,
-      200,  200,  200, 1367,  200, 1367, 1367, 1367, 1367,  200,
-     1367, 1367, 1367, 1367,  200,  200,  200,  200, 1208,  200,
-     1367,  200,  200,  200, 1367, 1209,  200,  200,  200,  200,
-
-      200,  200,  200, 1367,  200,  200, 1367,  200,  200, 1367,
-     1367, 1367,  200, 1367,  200,  200,  200, 1367,  200, 1367,
-     1367, 1367, 1209,  200,  200, 1367,  200,  200,  200,  200,
-     1367,  200,  200, 1367,  200,  200,  200, 1367, 1210,  200,
-      200,  200,  200,  200, 1212,  200, 1367,  200,  200, 1367,
-      200,  200,  200, 1211,  200, 1367, 1213,  200, 1367, 1367,
-      200,  200, 1367,  200, 1367, 1210,  200,  200, 1367, 1367,
-      200, 1212,  200, 1367,  200,  200, 1367,  200, 1367,  200,
-     1211,  200, 1367, 1213,  200, 1367, 1367,  200,  200,  200,
-      200,  200,  200,  200, 1367, 1367,  200,  200,  200, 1367,
-
-      200,  200,  200, 1367, 1367,  200, 1367, 1367, 1367, 1367,
-      200, 1367, 1367, 1367, 1367, 1367,  200,  200,  200,  200,
-     1367, 1367, 1367,  200,  200,  200, 1367,  200,  200,  200,
-     1367,  200,  200,  200,  200, 1367,  200,  200,  200, 1367,
-      200,  200,  200,  200, 1367, 1367,  200,  200, 1367, 1367,
-     1367, 1367,  200, 1367, 1367, 1367, 1367, 1367,  200, 1367,
-      200,  200, 1367,  200, 1367,  200, 1367,  200,  200,  200,
-      200, 1367, 1367,  200,  200,  200, 1215,  200, 1367,  200,
-      200, 1214,  200, 1367, 1367, 1367,  200,  200, 1367, 1367,
-      200, 1216, 1367, 1367,  200,  200,  200, 1367, 1367,  200,
-
-      200, 1367,  200, 1215,  200,  200, 1367,  200, 1214,  200,
-      200, 1367, 1367,  200,  200,  200, 1367,  200, 1216, 1367,
-      200,  200,  200,  200,  200, 1367,  200,  200, 1367,  200,
-      200,  200,  200, 1367, 1367, 1367, 1217,  200, 1367, 1367,
-      200,  200,  200,  200, 1367,  200, 1367,  200, 1367, 1367,
-      200,  200, 1218, 1367,  200,  200,  200,  200,  200,  200,
-     1367, 1367, 1367, 1217,  200, 1367, 1367,  200,  200, 1367,
-      200,  200,  200,  200, 1219, 1367, 1367,  200,  200, 1218,
-     1367,  200,  200,  200, 1367,  200,  200,  200, 1367, 1367,
-     1367,  200,  200, 1367, 1367, 1367, 1367,  200,  200, 1367,
-
-      200, 1219, 1367, 1367,  200,  200,  200, 1367, 1367, 1367,
-      200,  200,  200,  200,  200,  200,  200, 1367, 1367,  200,
-      200, 1220, 1367, 1367,  200,  200,  200, 1367, 1367, 1367,
-     1221,  200, 1367,  200, 1367,  200,  200, 1367,  200, 1222,
-      200, 1367,  200,  200, 1367,  200,  200,  200, 1220,  200,
-     1223, 1225,  200,  200,  200,  200,  200, 1221, 1367, 1367,
-      200,  200,  200,  200,  200, 1367, 1222, 1367,  200, 1367,
-      200, 1367,  200,  200,  200, 1367,  200, 1223, 1225, 1367,
-     1367,  200,  200,  200, 1224, 1367, 1367,  200,  200, 1226,
-     1367,  200,  200, 1367,  200,  200, 1367,  200,  200,  200,
-
-      200,  200, 1367, 1367,  200,  200, 1367, 1367, 1367, 1367,
-      200, 1224, 1367, 1227, 1367, 1367, 1226, 1367, 1367,  200,
-     1367,  200,  200, 1367,  200,  200,  200,  200, 1367,  200,
-     1367,  200,  200, 1367,  200, 1367,  200,  200,  200, 1367,
-     1227, 1367, 1367, 1228, 1367,  200, 1367,  200,  200,  200,
-     1367,  200, 1229, 1367, 1367, 1367,  200,  200, 1367, 1367,
-     1367,  200, 1367,  200,  200,  200,  200, 1367, 1367, 1367,
-     1228,  200,  200, 1367,  200,  200,  200, 1367,  200, 1229,
-     1230, 1367, 1367, 1367,  200,  200, 1367,  200, 1367,  200,
-      200,  200, 1367,  200,  200, 1367, 1367, 1367,  200,  200,
-
-     1367, 1367, 1367,  200, 1367,  200, 1231, 1230,  200, 1367,
-     1367, 1367,  200,  200,  200, 1367,  200,  200,  200, 1367,
-      200,  200,  200, 1232, 1367, 1367,  200,  200, 1367, 1367,
-     1367, 1367,  200, 1231,  200,  200,  200, 1367, 1367, 1367,
-      200,  200, 1233, 1367, 1367,  200,  200,  200, 1367,  200,
-     1232, 1367, 1367,  200,  200,  200, 1367, 1367, 1367,  200,
-      200,  200, 1367,  200, 1367,  200, 1367, 1234,  200, 1233,
-     1367, 1367, 1367,  200, 1367, 1367,  200,  200,  200,  200,
-      200, 1367,  200,  200,  200, 1235, 1367,  200,  200,  200,
-     1367, 1367,  200, 1367, 1234, 1367, 1367, 1367, 1367, 1236,
-
-     1367, 1367, 1367,  200,  200,  200,  200,  200, 1367,  200,
-      200,  200, 1235, 1367,  200,  200,  200, 1367,  200,  200,
-      200,  200, 1367,  200, 1367,  200, 1236, 1367,  200, 1367,
-      200, 1367, 1367,  200,  200, 1367,  200,  200, 1367,  200,
-     1367,  200, 1367, 1367,  200,  200,  200,  200,  200,  200,
-      200,  200,  200,  200, 1367,  200, 1367,  200,  200, 1367,
-      200, 1367, 1367,  200,  200, 1367,  200,  200, 1367,  200,
-     1238,  200,  200, 1237,  200, 1367,  200,  200,  200,  200,
-      200,  200,  200,  200, 1367,  200, 1367, 1367,  200, 1367,
-      200, 1367, 1367,  200,  200, 1367,  200, 1238, 1367,  200,
-
-     1237,  200, 1367, 1367,  200,  200,  200,  200,  200,  200,
-      200,  200,  200,  200,  200,  200,  200,  200,  200, 1367,
-      200,  200, 1367,  200, 1367, 1367,  200, 1264, 1367, 1367,
-     1367,  200,  200, 1367,  200, 1367, 1367,  200,  200,  200,
-      200,  200,  200,  200,  200,  200,  200,  200,  200, 1367,
-      200,  200,  200,  200, 1264,  200, 1265, 1241,  200, 1367,
-     1367,  200,  200, 1367,  200, 1367, 1266, 1367, 1367,  200,
-      200,  200, 1367,  200,  200, 1367,  200, 1367,  200,  200,
-     1367,  200,  200, 1367, 1367,  200,  200, 1367,  200,  200,
-     1367,  200, 1267, 1266, 1367,  200,  200,  200,  200,  200,
-
-      200,  200, 1367,  200, 1367,  200,  200, 1367,  200, 1367,
-      200, 1367,  200,  200,  200,  200,  200, 1367,  200, 1267,
-      200, 1367,  200,  200, 1367, 1268,  200,  200,  200,  200,
-      200, 1367,  200,  200,  200,  200, 1367,  200,  200, 1367,
-     1367,  200,  200,  200,  200,  200,  200,  200, 1271, 1269,
-     1367, 1367, 1268,  200,  200, 1367,  200,  200,  200,  200,
-     1367,  200,  200,  200,  200,  200, 1270, 1367,  200,  200,
-     1367,  200,  200,  200,  200, 1271, 1269, 1367,  200,  200,
-      200,  200,  200, 1367,  200,  200,  200,  200,  200,  200,
-      200,  200, 1367, 1270,  200,  200,  200, 1367,  200,  200,
-
-      200,  200, 1367, 1367,  200,  200,  200, 1367, 1367,  200,
-      200,  200, 1367, 1367,  200,  200,  200,  200, 1367,  200,
-      200,  200, 1367, 1367,  200,  200,  200,  200, 1273,  200,
-      200,  200, 1272, 1367, 1367,  200, 1367,  200, 1367, 1367,
-      200,  200, 1367,  200,  200, 1367,  200,  200,  200, 1367,
-     1367,  200, 1367,  200, 1367, 1273,  200,  200, 1367, 1272,
-     1367, 1367,  200, 1367,  200, 1367,  200,  200,  200, 1367,
-      200,  200,  200, 1367,  200,  200,  200, 1275, 1367,  200,
-      200,  200,  200,  200,  200,  200,  200,  200, 1367, 1274,
-      200,  200, 1276,  200, 1367,  200, 1367,  200,  200,  200,
-
-     1367,  200,  200,  200, 1275, 1367,  200, 1367,  200,  200,
-      200,  200,  200,  200,  200, 1367, 1274,  200,  200, 1276,
-     1277,  200,  200,  200,  200,  200, 1367, 1367,  200,  200,
-      200, 1367,  200,  200,  200, 1367, 1367, 1367, 1367,  200,
-     1367, 1367, 1278, 1367,  200,  200, 1367, 1277,  200, 1367,
-      200,  200,  200,  200, 1367,  200, 1367,  200,  200,  200,
-      200,  200, 1367,  200, 1367,  200,  200,  200, 1367, 1278,
-     1367,  200,  200, 1279, 1367, 1367, 1367,  200,  200, 1367,
-      200, 1367, 1367, 1280,  200,  200,  200, 1367, 1367, 1367,
-      200,  200,  200, 1367,  200,  200,  200,  200, 1367,  200,
-
-     1279, 1367,  200, 1367,  200, 1367, 1367,  200, 1367, 1367,
-     1280,  200, 1367,  200,  200, 1367,  200, 1367,  200, 1367,
-     1367,  200,  200,  200,  200,  200,  200,  200,  200,  200,
-      200, 1367,  200, 1281,  200,  200, 1367,  200, 1367, 1367,
-      200,  200, 1367,  200,  200, 1367,  200, 1367,  200, 1367,
-     1282,  200,  200,  200,  200,  200,  200,  200, 1367,  200,
-     1281, 1367,  200, 1367,  200, 1367, 1367,  200,  200, 1283,
-      200,  200, 1367,  200,  200,  200,  200, 1282,  200, 1367,
-      200,  200, 1284,  200, 1285, 1367,  200, 1367,  200, 1367,
-     1367, 1367, 1367, 1367,  200,  200, 1283,  200, 1367, 1367,
-
-     1367,  200,  200,  200,  200, 1367, 1286,  200,  200, 1284,
-      200, 1285, 1367,  200,  200,  200,  200, 1367,  200,  200,
-     1367,  200, 1367,  200,  200, 1367,  200, 1367, 1367,  200,
-     1367,  200,  200, 1286,  200, 1367,  200,  200, 1367,  200,
-     1367,  200,  200,  200,  200,  200,  200, 1367,  200, 1367,
-      200,  200,  200,  200,  200, 1367,  200, 1302,  200,  200,
-     1367,  200,  200,  200,  200, 1367,  200, 1367,  200,  200,
-      200,  200,  200, 1304,  200,  200,  200, 1367,  200,  200,
-      200,  200,  200, 1367, 1302,  200, 1367, 1367, 1367,  200,
-      200,  200,  200, 1367,  200,  200, 1367,  200,  200,  200,
-
-     1304,  200, 1367,  200,  200,  200,  200,  200, 1305,  200,
-      200, 1367, 1367, 1367,  200, 1367,  200,  200, 1367,  200,
-     1367,  200, 1367, 1367,  200,  200,  200, 1367,  200, 1367,
-     1367,  200,  200,  200,  200, 1305,  200,  200, 1367, 1306,
-     1367,  200,  200,  200,  200, 1367, 1367, 1367, 1367, 1367,
-      200,  200,  200,  200,  200,  200, 1367, 1367, 1367,  200,
-      200,  200, 1367,  200, 1367, 1367, 1306, 1367, 1367,  200,
-      200,  200,  200, 1367, 1367, 1367,  200,  200, 1367,  200,
-     1367,  200,  200, 1309,  200, 1307, 1308,  200,  200, 1367,
-      200,  200,  200, 1367, 1310,  200,  200,  200,  200,  200,
-
-      200, 1367, 1367,  200,  200, 1367, 1367, 1367, 1367,  200,
-     1309,  200, 1307, 1308,  200,  200,  200,  200,  200,  200,
-      200, 1310,  200,  200,  200,  200,  200,  200,  200,  200,
-     1367,  200, 1367,  200,  200, 1367,  200, 1367,  200,  200,
-     1367,  200,  200,  200,  200, 1367, 1367,  200,  200,  200,
-     1367,  200, 1367,  200, 1367,  200,  200, 1367, 1311, 1367,
-      200,  200, 1367,  200, 1367,  200,  200, 1367,  200,  200,
-      200,  200,  200,  200, 1313,  200,  200,  200,  200, 1312,
-      200, 1314,  200,  200, 1367, 1311,  200, 1367,  200, 1367,
-      200, 1367,  200,  200, 1367,  200, 1367,  200, 1367,  200,
-
-      200, 1313,  200, 1367,  200,  200, 1312,  200, 1314,  200,
-      200, 1323, 1316,  200, 1325,  200, 1367,  200,  200,  200,
-      200, 1367,  200,  200,  200, 1367,  200,  200, 1367,  200,
-     1367, 1367,  200,  200,  200, 1367,  200, 1367, 1367, 1367,
-      200, 1325,  200,  200, 1367,  200,  200, 1367, 1367,  200,
-      200,  200, 1367,  200,  200, 1367,  200, 1367, 1367,  200,
-      200,  200, 1367,  200,  200, 1367,  200,  200, 1367,  200,
-      200, 1326,  200,  200,  200,  200,  200,  200,  200,  200,
-      200, 1367,  200,  200,  200, 1327, 1367,  200, 1367, 1367,
-      200,  200, 1367,  200, 1367, 1367, 1367, 1367, 1326,  200,
-
-     1367,  200,  200,  200,  200,  200,  200,  200,  200,  200,
-      200,  200, 1327, 1367,  200,  200,  200,  200,  200, 1367,
-      200,  200, 1367,  200, 1367,  200,  200, 1367,  200,  200,
-      200, 1328, 1367,  200,  200,  200,  200,  200,  200,  200,
-     1367,  200,  200,  200,  200,  200,  200,  200,  200,  200,
-      200, 1367,  200,  200,  200,  200,  200,  200, 1328, 1367,
-      200,  200, 1367,  200, 1367,  200,  200, 1367,  200, 1367,
-      200,  200, 1367,  200,  200,  200,  200, 1336, 1367, 1367,
-      200,  200,  200, 1367,  200, 1367,  200,  200, 1367, 1367,
-      200,  200, 1367, 1367, 1367, 1367,  200,  200, 1367, 1367,
-
-     1367,  200,  200, 1367, 1336, 1367, 1367,  200, 1367,  200,
-     1367,  200, 1367,  200,  200, 1367, 1367,  200,  200, 1367,
-     1367, 1367, 1367,  200,   46,   46,   46,   46,   46,   88,
-     1367, 1367,   88,   88,  185,  185,  185, 1367,  185,  187,
-     1367,  187,  187,  187,  190, 1367,  190,  190,  190,  200,
-     1367,  200,  200,  200,    7, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367
+       76,   77,   78,   79,   80,   81,   82,   83,   84,   85,
+       86,   87,   81,   88,   81,   89,   90,   90,   90,   90,
+       93,   93,   93,   93,   93,   93,   93,   93,   93,   93,
+       94,   96,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   95,   97,   98,   98,   98,   98,   98,   98,   98,
+       98,   98,   98,  100,  101,  105,  111,  106,  135,  137,
+
+      112,  115,  145,  107,  136,  108,  113,  138,  116,  109,
+      110,  146,  182,  139,  183,  117,  114,  184,  118,   99,
+      189,  119,  105,  111,  106,  135,  137,  112,  115,  145,
+      107,  136,  108,  113,  138,  116,  109,  110,  146,  182,
+      139,  183,  117,  114,  184,  118,  120,  189,  119,  125,
+      121,  126,  194,   90,  122,  147,  127,  299,  150,  148,
+      123,  128,  151,  124,  198,  149,   90,   90,  152,  187,
+      188,  204,  205,  120, 1376,  199,  125,  121,  126, 1375,
+      153,  122,  147,  127,  299,  150,  148,  123,  128,  151,
+      124,  129,  149,  162,  154,  152,  187,  188,  300,  130,
+
+      155,  156,  131,  305,  163,  132,  140,  153,  133, 1374,
+      164,  134,  141,  142,  143,  185,   90,   90,  129,  144,
+      162,  154, 1373,  186, 1372,  300,  130,  155,  156,  131,
+      305,  163,  132,  140, 1371,  133,  157,  164,  134,  141,
+      142,  143,  185,  306,  158,  165,  144,  301,  159,  166,
+      186,  160,  161,  167,  208,  302,  286,  310,  287,  168,
+     1369,  288, 1367,  157,  303, 1365,  208,  304, 1363,  311,
+      306,  158,  165, 1361,  301,  159,  166, 1359,  160,  161,
+      167,  208,  302,  286,  310,  287,  168,  169,  288,  170,
+      314,  303,  171,  208,  304,  172,  311,  173,  321,  174,
+
+      175,  197,  197,  197,  197,  197,  197,  197,  197,  197,
+      197,  194,   90, 1357,  169, 1355,  170,  314, 1353,  171,
+      307,  308,  172,  312,  173,  321,  174,  175,  176,  319,
+      313,  239,  177,  208,  309,  178,  179,  240,  208,  320,
+      329,  330,  180,  208,  331,  181, 1351,  307,  308, 1349,
+      312, 1251, 1251, 1326, 1326,  176,  319,  313,  239,  177,
+      208,  309,  178,  179,  240,  208,  320,  329,  330,  180,
+      208,  331,  181,  200,  200,  200,  200,  200,  200,  200,
+      200,  200,  200,  201,  202,  202,  202,  202,  202,  202,
+      202,  202,  202,  202,  193,  193, 1347,  193,  193,  193,
+
+      193,  193,  193,  193,  193,  193,  193,  193,  193,  193,
+      193,  193,  193,  193,  193,  193,  193,  193,  241,  208,
+      250,  251,  208,  208,  208,  252,  242,  332,  333,  249,
+      208,  253,  243,  315,  316,  317,  336,  318,  322,  208,
+      208,  208,  208,  323,  193,  241,  208,  250,  251,  208,
+      208,  208,  252,  242,  332,  333,  249,  208,  253,  243,
+      315,  316,  317,  336,  318,  322,  208,  208,  208,  208,
+      323,  193,  193,  193, 1343,  193,  193,  193,  193,  193,
+      193,  193,   93,   93,   93,   93,   93,   93,   93,   93,
+       93,   93,  193,  193,  193,  193,  254,  342,  208,  209,
+
+      255,  210,  208,  334,  335,  343,  256,  211,  208,  212,
+      344,  345,  347,  213,  214,  348,  208,  346,  208,  349,
+      350,  353, 1339,  254,  342,  208,  209,  255,  210,  208,
+      334,  335,  343,  256,  211,  208,  212,  344,  345,  347,
+      213,  214,  348,  208,  346,  208,  349,  350,  353,  193,
+      193,  193, 1332,  193,  193,  193,  193,  193,  193,  193,
+      269, 1325, 1311,  354,  270,  355, 1297,  356,  271, 1273,
+      193,  193,  193,  193,  272,  289, 1249,  351,  215,  208,
+      352,  361,  216,  290,  208,  362, 1203,  269,  217,  208,
+      354,  270,  355,  208,  356,  271,  291,  292,  218,  208,
+
+     1157,  272,  289,  208,  351,  215,  208,  352,  361,  216,
+      290,  208,  362,  208, 1082,  217,  208,  363, 1007,  908,
+      208,  809,  681,  291,  292,  218,  208,  193,  219,  293,
+      208,  357,  208,  208,  364,  220,  208,  370,  371,  208,
+      208,  358,  221,  372,  363,  222,  359,  360,  223,  208,
+      373,  376,  208,  553,  425,  219,  293,  424,  357,  208,
+      208,  364,  220,  208,  370,  371,  208,  296,  358,  221,
+      372,  295,  222,  359,  360,  223,  208,  373,  376,  208,
+      224,  324,  377,  325,  225,  337,  326,  338,  226,  378,
+      379,  339,  327,  365,  227,  366,  380,  228,  340,  328,
+
+      374,  381,  341,  375,  208,  294,  382,  224,  324,  377,
+      325,  225,  337,  326,  338,  226,  378,  379,  339,  327,
+      365,  227,  366,  380,  228,  340,  328,  374,  381,  341,
+      375,  208,  208,  382,  383,  367,  208,  368,  386,  229,
+      384,  230,  208,  391,  385,  207,  231,  394,  369,  400,
+      206,  232,  208,  193,  195,  192,  401,  402,  190,  208,
+      103,  383,  367,  208,  368,  386,  229,  384,  230,  208,
+      391,  385,  387,  231,  394,  369,  400,  388,  232,  208,
+      233,  392,  398,  401,  402,  389,  395,  208,  234,  403,
+      390,  235,  393,  404,  236,  396,  399,  237,  407,  387,
+
+      238,  102,  408,  397,  388,  409,   91,  233,  392,  398,
+     1377,  410,  389,  395,  208,  234,  403,  390,  235,  393,
+      404,  236,  396,  399,  237,  407,  405,  238,  244,  408,
+      397,  411,  409,  412,  245,  246,  247,  406,  410,  415,
+      413,  248,  416,  414,  417,  421,  208,   49,  422,  423,
+      418,  554,  419,  405,   49,  244,  555, 1377,  411,  556,
+      412,  245,  246,  247,  406,  420,  415,  413,  248,  416,
+      414,  417,  421,  208,  257,  422,  423,  418,  554,  419,
+      208,  208,  557,  555,  208, 1377,  556, 1377,  258,  558,
+      208,  208,  420, 1377,  259,  260, 1377, 1377,  559,  560,
+
+      208,  257,  561, 1377,  562,  563,  567,  208,  208,  557,
+     1377,  208,  430, 1377,  208,  258,  558,  208,  208,  208,
+      431,  259,  260,  208,  208,  559,  560,  208,  261,  561,
+      208,  562,  563,  567,  568,  569,  262,  208,  208,  430,
+      263,  208,  208,  264,  265, 1377,  208,  431,  208,  570,
+      208,  208, 1377,  429,  571,  261, 1377,  208,  208, 1377,
+      572,  568,  569,  262,  208,  208,  573,  263,  574,  208,
+      264,  265,  266,  428,  208,  208,  570, 1377,  208,  208,
+      429,  571, 1377,  267,  208,  208,  208,  572,  575,  268,
+      576,  577,  208,  573,  208,  574,  578,  579, 1377,  266,
+
+      428,  208,  208, 1377,  208,  208,  208,  582,  434,  208,
+      267,  208,  583,  208,  208,  575,  268,  576,  577,  208,
+      273,  208,  274,  578,  579,  275,  208, 1377,  276,  208,
+      277,  208,  278,  279,  582,  434,  208, 1377,  584,  583,
+      585,  208,  208, 1377, 1377,  435, 1377,  273, 1377,  274,
+     1377, 1377,  275,  208,  208,  276,  208,  277, 1377,  278,
+      279,  208,  564,  586,  565,  584,  208,  585,  439,  208,
+      280,  580,  435,  208,  281,  208,  587,  282,  283,  566,
+      208,  208,  588,  208,  284,  208,  581,  285,  208,  564,
+      586,  565,  589,  208,  208,  439, 1377,  280,  580, 1377,
+
+      208,  281,  208,  587,  282,  283,  566,  208, 1377,  588,
+     1377,  284,  208,  581,  285, 1377, 1377, 1377, 1377,  589,
+     1377,  208,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,  297,  297,  297,  297,  297,  297,  297,  297,
+      297,  297,   97,   98,   98,   98,   98,   98,   98,   98,
+       98,   98,   98,  197,  197,  197,  197,  197,  197,  197,
+      197,  197,  197,  200,  200,  200,  200,  200,  200,  200,
+      200,  200,  200,  426,  426,  426,  426,  426,  426,  426,
+      426,  426,  426,  201,  202,  202,  202,  202,  202,  202,
+      202,  202,  202,  202,  193,  193,  590,  193,  193,  193,
+
+      193,  193,  193,  193, 1377, 1377,  591,  592,  208,  208,
+      593,  594,  208,  208,  193,  193,  193,  193,  440,  208,
+      441,  448,  208,  590, 1377,  208,  595,  442,  208,  208,
+     1377,  449,  208,  591,  592,  208,  208,  593,  594,  208,
+      208,  208, 1377, 1377, 1377,  440,  208,  441,  448,  208,
+     1377,  443,  208,  595,  442,  208,  208,  208,  449,  208,
+      596,  208,  208, 1377,  208,  597,  598,  208,  208,  208,
+      450,  193,  432,  599,  208,  433,  601,  208,  443,  602,
+      603,  600,  604,  208,  208,  208,  605,  596,  208,  208,
+      208,  208,  597,  598,  208,  208,  208,  450, 1377,  432,
+
+      599,  208,  433,  601,  208, 1377,  602,  603,  600,  604,
+      208, 1377,  208,  605, 1377,  208,  606,  208,  607,  208,
+      608,  609,  208,  436,  437,  208,  208,  610,  208,  208,
+      451,  208,  458,  459,  611,  452,  208,  438,  208,  612,
+      613,  208,  208,  606, 1377,  607,  208,  608,  609, 1377,
+      436,  437,  208,  208,  610,  208,  208,  451,  208,  458,
+      459,  611,  452,  208,  438,  208,  612,  613,  208,  444,
+      445,  446, 1377,  447, 1377, 1377,  208, 1377,  616,  617,
+      618,  208,  297,  297,  297,  297,  297,  297,  297,  297,
+      297,  297,  208, 1377,  208, 1377,  444,  445,  446,  208,
+
+      447,  460,  614,  208,  208,  616,  617,  618,  208,  453,
+      619,  454,  615,  208,  455,  620,  621,  208,  624,  208,
+      456,  208,  208,  461,  622,  625,  208,  457,  460,  614,
+      626,  208,  208,  208,  623,  627,  453,  619,  454,  615,
+      208,  455,  620,  621,  208,  624,  208,  456,  208,  208,
+      461,  622,  625,  462,  457,  465,  628,  626,  208,  208,
+      208,  623,  627,  629,  208,  471,  208,  208, 1377,  630,
+     1377,  208,  208,  208,  631,  208,  208,  208,  632,  633,
+      462,  634,  465,  628,  635,  208,  463,  464,  638, 1377,
+      629,  208,  471,  208,  208,  208,  630,  208,  208,  208,
+
+      641,  631,  208,  208,  208,  632,  633,  208,  634, 1377,
+     1377,  635,  636,  463,  464,  638,  472,  642,  208, 1377,
+     1377, 1377,  208,  208,  208, 1377,  643,  641,  208,  208,
+     1377,  637, 1377,  644,  208,  466,  208,  467, 1377,  636,
+      208,  468,  645,  472,  642,  208,  473,  208,  469,  646,
+      208, 1377,  470,  643, 1377,  208,  208,  208,  637,  474,
+      644,  208,  466,  208,  467,  475,  208,  208,  468,  645,
+     1377,  208,  647,  473,  208,  469,  646,  208,  477,  470,
+      208,  208,  648,  208,  208,  208,  474,  476,  208, 1377,
+      208,  208,  475,  208, 1377,  208,  208,  208,  208,  647,
+
+      208,  478, 1377,  649,  208,  477,  479,  208,  208,  648,
+      650,  208,  208,  208,  476,  482,  208,  208,  208,  208,
+      208,  208,  208,  208,  208,  208,  480,  208,  478,  481,
+      649,  208,  208,  479,  208, 1377,  651,  650,  208,  208,
+      208,  483,  482,  208,  208,  652,  208,  208,  208, 1377,
+      208,  639,  208,  480,  484,  208,  481,  208,  208,  208,
+      208,  208,  208,  651,  640,  208,  208,  208,  483,  208,
+      208,  208,  652, 1377,  653,  208,  485,  208,  639,  654,
+      655,  484,  208,  656,  208,  208, 1377,  208,  208,  208,
+      490,  640,  208, 1377,  208,  208,  208,  208,  657, 1377,
+
+      208,  653,  208,  485,  208, 1377,  654,  655,  491, 1377,
+      656,  658,  208,  486,  208,  208,  208,  490,  659, 1377,
+      208,  208,  208,  487,  208,  657,  208,  208,  488,  489,
+     1377,  208,  539,  208, 1377,  491,  492, 1377,  658,  208,
+      486,  208, 1377,  208,  660,  659,  208,  208,  208,  208,
+      487,  208,  540,  208,  661,  488,  489,  208,  493,  539,
+      208,  208,  208,  492,  208, 1377,  208,  208,  499,  208,
+     1377,  660,  662,  208,  208, 1377,  208,  208, 1377,  540,
+      663,  661, 1377,  510,  208,  493, 1377,  208,  208,  208,
+      208,  208,  500,  208,  208,  499,  208,  208, 1377,  662,
+
+     1377,  208,  208,  208,  208,  208, 1377,  663,  664,  208,
+      510,  494,  665,  495,  208,  208, 1377,  208,  667,  500,
+      208,  666,  670,  513,  208,  208, 1377,  514, 1377,  208,
+      208, 1377,  208,  208,  671,  664,  208, 1377,  494,  665,
+      495, 1377,  208,  208, 1377,  667, 1377,  672,  666,  670,
+      513,  673,  208,  496,  514,  497,  208,  668,  501,  669,
+      208,  671,  674,  208,  208,  208,  498,  208,  208,  675,
+      208,  208,  208,  502,  672,  676,  208,  208,  673,  679,
+      496, 1377,  497,  208,  668,  501,  669,  680, 1377,  674,
+      208,  208,  208,  498,  208,  208,  675,  810,  208,  208,
+
+      502, 1377,  676,  208,  208,  208,  679,  208,  505, 1377,
+      208,  811,  208,  503,  680,  208,  504,  208,  506, 1377,
+      208,  208,  677,  208,  810, 1377,  678, 1377,  208,  208,
+     1377,  208,  208,  208,  208,  505,  208,  208,  811,  208,
+      503,  208,  208,  504,  208,  506,  507,  208,  208,  677,
+      208,  812,  208,  678,  208,  208,  208,  508,  208,  208,
+      208, 1377,  813,  208,  208,  208, 1377,  208,  208, 1377,
+     1377,  814,  208,  507,  815,  816, 1377,  208,  812,  208,
+     1377,  208, 1377,  817,  508,  818,  208, 1377,  208,  813,
+      208,  208,  208,  208,  208,  208,  509,  208,  814,  208,
+
+      208,  815,  816,  208,  208, 1377,  511,  208, 1377,  515,
+      817,  819,  818,  208,  208,  208,  820,  208, 1377,  208,
+      208,  512,  208,  509,  208,  208,  821,  208,  822,  208,
+      208,  823,  520,  511,  208,  208,  515,  208,  819,  208,
+      208,  208,  824,  820,  208,  208,  208, 1377,  512,  208,
+     1377, 1377,  208,  821, 1377,  822,  208, 1377,  823,  520,
+      825, 1377,  208,  521,  208,  208,  208,  826, 1377,  824,
+      208,  208,  208,  516,  522,  208,  208,  523,  517,  827,
+      828,  208, 1377,  208,  208,  829,  518,  825,  208,  830,
+      521,  519,  208,  208,  826,  527,  208,  208,  831,  208,
+
+      516,  522,  208,  208,  523,  517,  827,  828,  208,  528,
+      208,  208,  829,  518, 1377,  208,  830,  208,  519,  208,
+      208,  529,  527,  208,  524,  831,  208,  208,  832,  833,
+      208,  834,  835,  525,  836,  208,  528,  208, 1377,  530,
+      208,  526, 1377,  208,  208,  208,  208,  208,  529, 1377,
+     1377,  524, 1377,  208,  208,  832,  833,  837,  834,  835,
+      525,  836,  208,  208,  208,  208,  530,  208,  526,  208,
+      208,  838,  208,  532,  208,  208,  533,  208,  531,  208,
+      208,  208,  839,  208,  837,  208,  840,  208,  841,  208,
+      208, 1377,  208, 1377,  842,  843,  208,  208,  838,  208,
+
+      532,  844,  208,  533,  208,  531,  208,  536,  208,  839,
+      208,  208,  208,  840,  208,  841,  208,  208,  208,  534,
+      208,  842,  843,  845,  208,  208,  208,  208,  844,  208,
+      535,  208,  846,  208,  536,  208,  847,  537,  208,  208,
+      848,  208,  538, 1377,  208,  208,  534,  208,  849,  208,
+      845,  208,  208, 1377,  208, 1377,  208,  535,  208,  846,
+      208,  850,  208,  847,  537, 1377,  208,  848,  208,  538,
+      208,  851,  544,  208,  545,  849,  208,  208,  208,  541,
+      208,  852,  208,  208,  853,  854,  542, 1377,  850,  543,
+      208, 1377,  208,  208, 1377, 1377, 1377,  208,  851,  544,
+
+      208,  545,  208,  855,  208, 1377,  541,  208,  852,  208,
+      208,  853,  854,  542,  550, 1377,  543,  208,  208,  208,
+      208,  546,  548,  208,  208,  856,  208,  547,  208,  208,
+      855,  857,  208,  208,  208,  549, 1377,  860,  861,  862,
+     1377,  550,  208,  863, 1377,  208, 1377, 1377,  546,  548,
+      208,  208,  856,  208,  547,  208, 1377, 1377,  857,  208,
+      208,  208,  549,  208,  860,  861,  862,  208,  552,  208,
+      863,  208,  208,  208,  858,  208,  208,  684,  551,  208,
+      864,  208,  208,  208,  208,  859,  865,  866,  867,  208,
+      208,  208,  208, 1377,  208,  552, 1377, 1377,  208,  208,
+
+      208,  858,  208,  208,  684,  551,  208,  864,  208,  208,
+      208,  208,  859,  865,  866,  867,  208, 1377,  208,  208,
+      426,  426,  426,  426,  426,  426,  426,  426,  426,  426,
+      193,  193,  868,  193,  193,  193,  193,  193,  193,  193,
+     1377, 1377,  869,  870,  682,  208,  871,  872,  208,  208,
+      193,  193,  193,  193,  208,  208,  208,  683,  208,  868,
+     1377,  208,  873,  208,  208,  208, 1377,  208,  208,  869,
+      870,  682,  208,  871,  872,  208,  208,  208, 1377, 1377,
+     1377,  208,  208,  208,  683,  208, 1377,  685,  208,  873,
+      208,  208,  208,  208,  208,  208, 1377,  208,  208,  208,
+
+      208,  208, 1377,  686,  208,  208,  208,  193, 1377,  874,
+      208,  208, 1377,  208,  685,  875, 1377,  876,  877,  208,
+      208,  878, 1377,  687,  208,  208,  208,  208,  208,  208,
+      686,  208,  208,  208,  879,  208,  874,  208,  208,  208,
+      208,  208,  875,  208,  876,  877,  208,  689,  878,  688,
+      687,  208,  690,  208,  208,  880,  208,  881,  208,  208,
+     1377,  879,  208,  208,  208,  691,  208,  208,  208, 1377,
+      208,  882,  208,  883,  689,  884,  688,  208,  208,  690,
+      208,  208,  880,  208,  881, 1377,  208,  208,  885,  886,
+      208,  208,  691,  208,  208, 1377,  695, 1377,  882,  208,
+
+      883, 1377,  884,  208,  208,  692, 1377,  693,  208,  887,
+      208,  208,  208,  888,  208,  885,  886,  208,  208,  889,
+      208,  208,  694,  695,  696,  208, 1377,  208,  208,  697,
+      208,  208,  692,  208,  693,  208,  887,  208,  208,  208,
+      888,  208, 1377,  208,  208,  208,  889, 1377,  208,  694,
+     1377,  696,  208,  699,  208,  208,  697,  208,  208, 1377,
+      208,  208, 1377,  890,  208,  700,  891,  208,  208,  208,
+      208,  892,  698,  208,  208,  893,  208,  208, 1377,  208,
+      699,  701,  894, 1377,  208, 1377,  208, 1377,  208,  208,
+      890,  895,  700,  891,  208,  896,  208,  897,  892,  698,
+
+      208,  208,  893,  208,  208,  208,  208,  208,  701,  894,
+      703,  702,  208,  208,  208,  898,  208,  208,  895,  208,
+      208,  208,  896,  899,  897,  900,  704,  901, 1377,  902,
+      208,  208,  208,  705,  208,  208,  903,  703,  702,  208,
+      208,  208,  898, 1377,  208,  208,  208,  208,  208, 1377,
+      899,  208,  900,  704,  901,  706,  902,  208,  208, 1377,
+      705,  208,  208,  903,  904,  707,  708,  208,  905,  208,
+      208,  208,  208,  208, 1377,  906,  208,  907,  208,  208,
+     1008,  709,  706, 1377, 1377, 1009,  208, 1377,  208,  208,
+     1010,  904,  707,  708, 1377,  905,  208,  208,  208,  710,
+
+      208,  208,  906,  208,  907,  208,  208, 1008,  709, 1011,
+      711,  208, 1009,  208,  208, 1377,  208, 1010, 1377,  208,
+      208,  208, 1377,  208, 1012, 1013,  710, 1014,  208,  208,
+      208, 1377,  208, 1377,  712, 1377, 1011,  711,  208,  208,
+     1377,  208,  713, 1377, 1377,  208,  208,  208,  208,  208,
+      208, 1012, 1013, 1377, 1014,  208,  208,  208,  715, 1015,
+      208,  712,  208,  208,  208,  208,  208,  208,  208,  713,
+      208,  714,  208,  716, 1016, 1017,  208, 1377,  208, 1018,
+      208, 1377,  208,  208, 1019,  715, 1015,  208, 1020,  208,
+      208,  208,  208, 1021,  208,  208, 1377,  208,  714,  208,
+
+      716, 1016, 1017,  208,  717,  208, 1018,  208,  208,  208,
+      208, 1019,  208,  718, 1377, 1020, 1377,  208,  208,  208,
+     1021, 1022,  208,  208,  208,  721,  208,  208,  208,  720,
+      208,  717,  208,  208,  208,  208,  208,  208, 1377,  208,
+      718,  719, 1377,  208,  208,  208,  208,  208, 1022,  208,
+      208,  208,  721,  208,  208,  208,  720, 1023, 1024,  208,
+      208,  208, 1377,  208,  208,  208, 1025,  208,  719,  724,
+      208,  722,  208,  208,  208, 1026,  208,  208,  208,  208,
+      208, 1027, 1028,  723, 1023, 1024, 1029,  725,  208,  208,
+      208,  208,  208, 1025,  208,  208,  724, 1377,  722,  208,
+
+      208,  208, 1026,  208,  208,  208,  208, 1030, 1027, 1028,
+      723,  208, 1031, 1029,  725,  208,  208,  726,  208,  208,
+     1032, 1033,  208,  727,  208, 1377, 1034,  208,  208,  208,
+     1035,  728,  208,  208, 1030, 1036,  208, 1377,  208, 1031,
+      729, 1037,  208,  208,  726, 1038,  208, 1032, 1033, 1377,
+      727,  208,  208, 1034,  208, 1377,  208, 1035,  728,  208,
+      208, 1377, 1036,  208,  730,  731,  208,  729, 1037,  208,
+      208,  208, 1038, 1377, 1039,  208,  208,  208, 1040,  208,
+     1377, 1041,  208, 1377, 1377, 1042, 1377,  208,  208, 1377,
+      208,  730,  731,  208, 1377,  208, 1377,  732,  208, 1377,
+
+      208, 1039,  208,  208,  208, 1040,  208,  733, 1041,  208,
+      734,  208, 1042,  208,  208,  208,  208,  208,  208, 1043,
+     1377,  208,  208,  208,  732,  208,  208,  208, 1377, 1044,
+     1377,  208, 1377,  208,  733, 1047,  735,  734,  208, 1048,
+      208,  208, 1377,  208, 1049,  208, 1043,  208,  208, 1050,
+      208,  208,  208,  208, 1377,  208, 1044,  208,  208,  208,
+      736,  737, 1047,  735, 1377,  208, 1048,  208,  208,  208,
+     1377, 1049, 1377,  208,  208,  208, 1050, 1051,  208,  738,
+     1377,  739,  208, 1052,  208,  208,  208,  736,  737,  208,
+     1377,  208,  208,  740,  208,  741,  208,  208, 1053,  208,
+
+      208,  208,  208,  208, 1051,  208,  738,  742,  739, 1054,
+     1052,  208,  208,  208, 1377,  208,  208,  743,  208,  208,
+      740, 1377,  741,  208,  208, 1053,  208,  208,  208,  208,
+      208, 1055,  208, 1056,  742,  744, 1054, 1377,  208,  208,
+      208,  208,  208,  745,  743,  208,  208,  208,  208, 1377,
+      208, 1057,  208,  208,  208, 1377,  208,  208, 1055, 1377,
+     1056, 1045,  744,  747, 1046, 1377,  208,  208,  208,  208,
+      745,  208,  208,  208,  208,  208,  208,  746, 1057,  208,
+      208,  208,  208,  208,  208,  208,  748,  752, 1045,  208,
+      747, 1046,  208, 1377,  208,  208,  208, 1377,  208, 1058,
+
+      208, 1059,  208,  208,  746,  208,  749,  208,  208,  208,
+      208,  208,  208,  748,  752, 1060,  208,  208, 1061,  208,
+      208,  208,  208,  753,  208,  208, 1058,  208, 1059,  208,
+      208,  208,  208,  749,  208,  755, 1377, 1062,  208, 1377,
+      208,  208, 1060, 1063,  208, 1061, 1064,  208,  208, 1377,
+      753,  208,  208, 1065,  208,  750,  208,  208,  208,  208,
+      208, 1377,  755,  208, 1062,  751,  208,  208,  208,  208,
+     1063, 1066,  754, 1064, 1377, 1067,  208, 1377, 1377,  208,
+     1065,  208,  750,  208,  208,  208,  208,  208,  208, 1068,
+      208,  208,  751,  208,  208, 1069,  208,  756, 1066,  754,
+
+     1070,  208, 1067,  208,  208,  757,  208, 1071,  208,  208,
+     1377,  208,  208,  208, 1072,  208, 1068, 1377,  208,  208,
+     1073,  208, 1069,  758,  756,  208, 1377, 1070,  208,  208,
+      208,  208,  757, 1074, 1071,  208,  208,  208, 1377,  208,
+      208, 1072, 1377,  759,  208, 1075,  208, 1073, 1377,  208,
+      758,  208,  208,  208, 1076,  761,  208,  208,  760,  208,
+     1074, 1377,  208,  208,  208,  208,  208, 1377, 1077,  762,
+      759,  208, 1075,  208, 1078,  208,  208, 1377,  208,  208,
+      208, 1076,  761, 1377,  208,  760,  208, 1079,  208,  208,
+      208,  208,  208,  766,  208, 1077,  762,  763,  208, 1377,
+
+      208, 1078,  208,  208,  208, 1377,  208, 1080, 1081, 1377,
+      771,  208,  208, 1377, 1079,  208,  208,  208,  208, 1377,
+      766,  208,  208, 1158,  763,  208,  208,  769,  208, 1377,
+      208,  208,  764,  208, 1080, 1081,  208,  771,  208,  208,
+      208, 1159, 1377, 1160,  208, 1161,  208, 1162, 1163,  208,
+     1158,  765, 1164,  208,  769,  208,  208, 1377, 1165,  764,
+      208, 1166, 1167,  208,  770,  208, 1377,  208, 1159,  208,
+     1160,  208, 1161,  208, 1162, 1163,  208, 1168,  765, 1164,
+     1169,  208,  772,  208,  767, 1165,  208, 1170, 1166, 1167,
+     1377,  770,  208,  208, 1377,  208,  208,  768,  208, 1171,
+
+      208, 1172,  208,  208, 1168,  208, 1377, 1169,  208,  772,
+     1377,  767, 1173,  208, 1170, 1174, 1377,  773, 1377,  208,
+      208,  208,  208, 1377,  768,  208, 1171,  208, 1172,  208,
+      208,  208,  208,  208,  208, 1175,  775,  208, 1377, 1173,
+      208,  208, 1174,  208,  773,  774, 1377,  776,  208,  208,
+      208, 1377,  208,  208,  208, 1176, 1377,  208,  208,  208,
+      208,  208, 1175,  775,  208,  778, 1377,  208,  208,  208,
+      208,  208,  774,  208,  776,  208,  208,  208,  777, 1177,
+      208,  208, 1176,  208,  208,  208,  208,  780,  208,  208,
+     1178,  208,  778,  208,  779, 1179,  208,  208,  208,  208,
+
+      208,  784,  208,  208,  208,  777, 1177,  208,  208,  208,
+      208,  208,  208,  208,  780,  208,  208, 1178,  208,  208,
+      208,  779, 1179,  208,  208, 1180,  208, 1181,  784,  208,
+      208,  208,  781,  208,  208,  208,  208,  208,  208,  208,
+      208, 1182,  208,  208, 1183, 1184,  208, 1185,  208,  783,
+      208,  782, 1180,  208, 1181,  208,  208,  208,  208,  781,
+      208, 1186,  208,  785,  208,  208,  208,  208, 1182,  208,
+      208, 1183, 1184, 1377, 1185,  208,  783, 1377,  782,  208,
+      208,  208,  208, 1187,  208,  208,  208,  786, 1186,  208,
+      785,  208, 1188,  787,  208,  208, 1189,  208, 1190,  208,
+
+      208,  788, 1191, 1192,  208,  208,  208, 1193,  208,  208,
+     1187, 1377, 1377,  208,  786, 1377, 1377, 1377,  208, 1188,
+      787, 1377,  208, 1189,  208, 1190,  208,  208,  788, 1191,
+     1192,  208,  208,  208, 1193,  208,  208,  208,  791,  790,
+      208,  789,  208,  208,  208,  208, 1194,  208,  208,  208,
+     1377, 1195, 1377,  208, 1196, 1197, 1198, 1377,  208, 1377,
+      208, 1199,  208,  208,  208,  791,  790,  208,  789,  208,
+      208,  208,  208, 1194,  208,  208,  208,  208, 1195,  792,
+      208, 1196, 1197, 1198,  208,  208,  793,  208, 1199,  208,
+      208,  208, 1377,  208, 1200,  794, 1377,  795, 1201, 1202,
+
+      208, 1250, 1377, 1252,  208,  208,  792,  208, 1253, 1254,
+     1377,  208, 1377,  793,  208, 1377,  208, 1255,  208,  208,
+      208, 1200,  794,  208,  795, 1201, 1202,  208, 1250,  796,
+     1252,  797,  208,  208,  208, 1253, 1254,  208, 1377,  208,
+      208,  799,  800,  798, 1255,  208,  208,  208, 1377,  208,
+      208, 1256,  208,  208, 1377,  208,  796, 1377,  797, 1377,
+      208, 1377, 1377, 1377,  208,  208,  208,  208,  799,  800,
+      798, 1377,  208, 1257,  208,  802,  208, 1258, 1256,  208,
+      208,  208,  208,  208,  208, 1259,  208,  208,  208,  208,
+      801,  208,  208,  208,  208, 1377,  208, 1377,  803,  208,
+
+     1257, 1260,  802, 1377, 1258, 1261, 1377, 1377,  208, 1377,
+      208,  208, 1259,  208,  208,  208,  208,  801,  208, 1262,
+      208,  208,  208,  208,  208,  803,  208, 1263, 1260,  208,
+      804,  208, 1261,  805,  208, 1264,  807,  806,  208, 1377,
+      208, 1377,  208,  208, 1265, 1377, 1262,  208, 1377,  208,
+     1377,  208,  208, 1266, 1263, 1377,  208,  804,  208, 1377,
+      805,  208, 1264,  807,  806,  208,  208,  208,  208,  208,
+      208, 1265,  808,  208,  208,  208, 1267,  208,  208,  208,
+     1266,  909,  208, 1377,  208, 1268,  208,  208, 1377, 1377,
+      910,  208, 1377,  208, 1269,  208,  208, 1377, 1377,  808,
+
+      208, 1377,  208, 1267,  208,  208,  208, 1377,  909,  208,
+      208,  208, 1268,  208,  208,  208,  208,  910,  208,  208,
+     1270, 1269,  208,  208,  914,  208,  911, 1271,  208,  208,
+     1272, 1298,  208,  208,  208,  912, 1300,  208,  208, 1377,
+      915,  913,  208,  208,  208, 1377,  208, 1270,  208,  208,
+      208,  914,  208,  911, 1271,  208,  208, 1272, 1298,  208,
+      208,  208,  912, 1300, 1301,  208,  917,  915,  913, 1377,
+      208,  208,  208, 1377,  916,  208,  208,  208,  208,  208,
+     1302, 1377,  208, 1377,  208, 1377,  208,  208,  208, 1303,
+     1304, 1301, 1305,  917, 1306, 1377,  918,  208,  208,  208,
+
+      208,  916, 1307,  208,  208,  208,  208, 1302,  208,  208,
+      208,  208,  208,  208, 1308,  208, 1303, 1304,  208, 1305,
+      208, 1306,  208,  918, 1309,  208,  208,  208,  208, 1307,
+      919,  208,  208, 1377,  208,  208, 1310,  208,  208,  208,
+     1327, 1308,  208, 1377,  208,  208, 1328,  208,  208,  208,
+     1329, 1309,  208,  208,  208,  208,  920,  919,  208,  208,
+      208,  208, 1330, 1310,  921,  208, 1331, 1327,  208,  208,
+      208,  208, 1377, 1328,  208,  208, 1377, 1329,  208,  208,
+      208,  208, 1377,  920,  208,  208,  208,  208,  208, 1330,
+      208,  921,  208, 1331,  208,  208,  208,  208,  208,  922,
+
+     1334,  208,  208,  923,  208,  208,  208,  208,  208,  924,
+     1341,  208,  925,  208,  208,  208,  208,  208, 1377,  208,
+     1377,  208,  208,  208,  208,  208,  922, 1334,  208,  208,
+      923,  208,  208,  208,  208,  208,  924, 1341,  208,  925,
+     1377,  208,  208,  208,  208,  927, 1377,  208,  208,  208,
+      208,  208,  208,  926,  934,  208, 1377,  208,  208,  208,
+      208,  208, 1377, 1251, 1251,  208,  208,  928,  208,  208,
+      208,  208,  927,  208,  208,  208, 1377,  208,  208,  208,
+      926,  934, 1326, 1326,  208,  208, 1342,  208, 1345,  208,
+     1348,  208, 1350,  208,  928,  208,  208,  208,  929, 1377,
+
+      208,  208,  208, 1299,  208,  208, 1333, 1326, 1352,  208,
+      930, 1275, 1251, 1342,  208, 1345,  208, 1348,  208, 1350,
+     1377,  931, 1377,  208, 1377,  929, 1340, 1354,  208,  208,
+     1299,  208,  208, 1377,  208, 1352,  208,  930, 1377,  208,
+      208,  208,  208, 1377,  208, 1356,  932,  208,  931,  933,
+     1344, 1313,  208, 1340, 1354, 1377, 1377, 1377,  208,  208,
+      208,  208, 1377, 1358, 1360,  208,  208,  208, 1362,  208,
+      208,  208, 1356,  932,  208, 1377,  933, 1344, 1313,  208,
+     1377,  935,  208,  208,  208,  208, 1364,  208,  208,  208,
+     1358, 1360,  208,  208,  208, 1362, 1366,  208, 1368, 1377,
+
+      208, 1377,  208, 1370, 1377, 1377, 1377,  208,  935,  208,
+      208,  208,  208, 1364, 1377,  208,  208, 1377,  936, 1377,
+      208,  208, 1377, 1366, 1377, 1368,  208,  208,  208,  208,
+     1370, 1377, 1377,  208,  208, 1377, 1377, 1377,  208,  208,
+      208, 1377,  208, 1377,  937,  936, 1377,  208, 1377, 1377,
+     1377, 1377,  208,  208,  208,  208,  208, 1377,  938, 1377,
+      208,  208, 1377, 1377, 1377,  208,  208,  208,  208,  208,
+      208,  937, 1377, 1377,  208,  208, 1377,  939, 1377,  208,
+      208,  208,  208,  208,  208,  938, 1377,  941,  208,  208,
+      940, 1377, 1377,  208,  208,  208, 1377,  208,  208, 1377,
+
+      208, 1377,  208, 1377,  939,  208, 1377,  208,  943,  208,
+      208,  208,  208,  942,  941, 1377,  208,  940,  208, 1377,
+     1377,  208, 1377, 1377,  208,  208,  208,  208,  208, 1377,
+     1377,  208,  208, 1377,  208,  943,  208,  208,  208,  208,
+      942, 1377,  208, 1377,  208,  208,  208, 1377, 1377, 1377,
+     1377,  208,  208,  208,  208,  208,  208,  944,  208, 1377,
+      208,  208,  208,  208, 1377,  208,  945, 1377,  208,  208,
+     1377,  208,  946,  208, 1377, 1377,  208, 1377,  208,  208,
+     1377,  208,  947,  208,  944, 1377,  208,  208,  208,  208,
+      208, 1377, 1377,  945,  208,  208,  208, 1377,  208,  946,
+
+     1377, 1377, 1377,  208,  208,  208,  208, 1377,  208,  947,
+     1377, 1377,  208,  208,  208,  208,  948,  208,  208, 1377,
+      208,  208, 1377,  208,  208,  208, 1377, 1377,  208, 1377,
+      208,  208, 1377,  208, 1377,  208, 1377, 1377,  208,  208,
+      208,  208,  208,  948, 1377,  208,  208,  208,  208,  949,
+      208,  208,  208, 1377,  950,  208,  208,  208,  208,  208,
+     1377, 1377, 1377, 1377,  208,  208,  208,  208, 1377,  208,
+     1377, 1377, 1377,  208,  952,  208,  949,  208,  208,  208,
+      208,  950,  208,  208,  208,  208,  208,  208,  208, 1377,
+      208,  208,  208,  208,  208,  951,  208, 1377,  208, 1377,
+
+      208,  952, 1377,  208, 1377,  208, 1377,  208,  954,  208,
+     1377,  208, 1377, 1377,  208,  208,  208,  208, 1377,  208,
+      208,  208,  951,  208, 1377,  208,  208,  208, 1377,  953,
+      208, 1377,  208, 1377,  208,  954,  208, 1377,  955,  208,
+     1377, 1377, 1377,  208,  208, 1377, 1377,  208,  208, 1377,
+      208, 1377, 1377,  208,  956,  208,  953, 1377, 1377,  208,
+      208,  208,  208,  208,  208,  955,  208, 1377, 1377,  208,
+     1377,  208, 1377, 1377,  208,  208, 1377,  208, 1377, 1377,
+     1377,  956,  208, 1377, 1377, 1377, 1377,  208,  957,  208,
+      959,  208,  208,  208, 1377,  208,  208,  208, 1377,  958,
+
+      208,  208,  208, 1377,  208,  208,  208, 1377, 1377, 1377,
+     1377,  208, 1377, 1377, 1377,  957,  208,  959, 1377,  208,
+      208, 1377,  208,  208,  208,  208,  958,  208, 1377,  208,
+      208,  208,  208,  208,  208,  208,  208,  208,  208,  208,
+     1377,  208, 1377,  208,  208,  960,  208, 1377, 1377,  208,
+      208, 1377,  208,  208, 1377,  208, 1377,  208, 1377, 1377,
+      208,  208,  208,  208,  208,  208,  208,  961,  208,  208,
+     1377,  208,  960,  208,  208, 1377,  208, 1377, 1377,  208,
+      208, 1377,  208, 1377, 1377,  962, 1377,  208, 1377,  208,
+     1377, 1377,  208,  208,  961,  208,  208,  208,  963, 1377,
+
+     1377,  208,  208,  208, 1377,  208,  208,  208,  208,  208,
+     1377, 1377,  962,  208,  964,  965,  208,  966,  208,  208,
+      208,  208,  208,  208,  208,  963, 1377, 1377,  208,  208,
+      208, 1377,  208,  208,  208,  208,  208, 1377, 1377, 1377,
+      208,  964,  965, 1377,  966,  208,  208,  208,  208,  208,
+      208, 1377,  208,  967,  208,  208,  968,  208, 1377,  208,
+      208,  208,  208,  969, 1377,  208,  208,  208,  985,  208,
+     1377, 1377,  208,  208,  208,  208,  208,  208,  208,  208,
+      967,  208, 1377,  968,  208,  208,  208,  970,  208,  208,
+      969,  208,  208,  208,  208,  985,  208,  208, 1377,  208,
+
+      208, 1377,  208, 1377,  208,  208,  208,  208, 1377, 1377,
+      208, 1377,  208, 1377,  970, 1377,  208, 1377,  208,  971,
+      988, 1377,  208, 1377,  208,  208,  208,  208, 1377,  208,
+     1377, 1377,  208,  208,  208,  208, 1377,  208,  972, 1377,
+      208, 1377, 1377,  208,  208,  208,  971,  988, 1377,  208,
+      208, 1377,  208,  208,  208, 1377,  208, 1377, 1377,  208,
+      208, 1377,  208, 1377, 1377,  972,  208,  208, 1377,  208,
+      208,  208,  208,  974,  973, 1377,  208,  208,  208,  208,
+     1377, 1377,  208, 1377, 1377, 1377,  208,  208,  208,  208,
+     1377, 1377, 1377,  208, 1377, 1377,  208,  208,  208, 1377,
+
+      974,  973, 1377,  208,  975,  208,  208, 1377,  208,  208,
+     1377, 1377, 1377,  208,  208,  208,  208, 1377,  976,  977,
+     1377, 1377,  208,  208,  208,  208,  208,  208, 1377, 1377,
+     1377,  975,  208,  208, 1377,  208, 1377, 1377, 1377, 1377,
+     1377,  208,  208,  208, 1377,  976,  977, 1377,  978,  208,
+      208,  208,  208,  208,  208, 1377, 1377,  208,  208,  208,
+      208,  208, 1377, 1377, 1377, 1377, 1377,  208,  208,  208,
+      208, 1377, 1377, 1377, 1377,  978,  208,  208, 1377,  208,
+      208, 1377, 1377, 1377,  208,  208,  208, 1377,  208,  979,
+     1377, 1377, 1377, 1377,  208,  208,  208, 1377,  208, 1377,
+
+     1377,  208,  208,  208,  208,  208,  980,  208,  208, 1377,
+     1377,  208, 1377,  208,  981, 1377,  979, 1377,  208, 1377,
+     1377,  208, 1377,  208, 1377,  208, 1377,  208,  208,  208,
+      208,  208,  208,  980,  208,  208,  983,  208,  208,  208,
+      208,  981,  982,  208, 1377,  208, 1377,  208,  208,  208,
+      208, 1377,  208, 1377,  208, 1377,  208,  208,  208,  208,
+      984,  208,  208,  983,  208, 1377,  208,  208, 1377,  982,
+      208, 1377,  208, 1377,  208, 1377,  208,  208,  987,  208,
+     1377,  986,  208,  208, 1377, 1377,  208,  984,  208,  208,
+      208,  208,  208, 1377, 1377,  208,  208,  208,  208,  208,
+
+      208,  208,  208, 1377, 1377,  987,  208, 1377,  986,  208,
+      989,  208, 1377, 1377,  208,  208,  208,  208,  208,  208,
+      208, 1377,  208,  208,  208,  208, 1377,  208,  208,  208,
+      208, 1377,  208,  208, 1377,  991,  990,  989,  208,  208,
+      208,  208,  208,  208,  208,  208, 1377,  208, 1377, 1377,
+      992, 1377,  208, 1377,  208,  208, 1377,  208,  208,  208,
+      208, 1377,  991,  990,  208, 1377,  208,  208, 1377,  208,
+     1377,  208,  208, 1377,  208, 1377,  208,  992, 1377,  208,
+      208,  208,  208, 1377, 1377,  208,  208,  208,  208, 1377,
+      208,  208,  208, 1377,  208,  993,  208, 1377, 1377,  994,
+
+      208,  208, 1377,  208,  208, 1377, 1377,  208, 1377, 1377,
+     1377, 1377, 1377,  208, 1377,  208, 1377,  208,  208,  208,
+      208,  208,  993,  208, 1377,  208,  994,  208,  995, 1377,
+      208,  208, 1377, 1377,  208, 1377,  208,  208, 1002,  208,
+     1377,  208,  208,  996,  208,  208,  208,  208,  208,  208,
+     1377, 1377,  208, 1377, 1377,  995, 1377,  208,  208, 1377,
+      208,  208,  997,  208,  208, 1002,  208,  208,  208,  208,
+      996,  208,  208,  208, 1377,  208,  208, 1377, 1377,  208,
+     1377,  208,  999, 1377, 1377,  208,  208,  208,  998,  997,
+      208,  208,  208,  208,  208,  208, 1377,  208, 1000,  208,
+
+      208, 1377,  208, 1377, 1377,  208,  208, 1377,  208,  999,
+     1377, 1377, 1377,  208, 1377,  998, 1001,  208,  208,  208,
+      208,  208,  208,  208,  208, 1000,  208,  208,  208,  208,
+      208,  208,  208,  208, 1003,  208,  208, 1377, 1377, 1377,
+     1377,  208, 1377, 1001, 1377, 1377,  208, 1377,  208, 1377,
+      208,  208, 1377,  208, 1377,  208, 1377,  208,  208, 1377,
+      208, 1003,  208,  208, 1377,  208,  208, 1005,  208,  208,
+      208,  208, 1377,  208, 1377,  208,  208,  208,  208,  208,
+     1377, 1004, 1377,  208, 1377,  208,  208,  208,  208,  208,
+      208, 1377,  208,  208, 1005, 1006,  208,  208,  208,  208,
+
+      208, 1377,  208,  208,  208, 1377,  208, 1377, 1004, 1377,
+      208, 1377,  208,  208,  208,  208,  208,  208,  208, 1377,
+      208,  208, 1006,  208, 1377,  208,  208,  208,  208,  208,
+      208,  208,  208,  208,  208, 1377,  208, 1377, 1377,  208,
+     1377,  208, 1377, 1083,  208,  208, 1377,  208,  208, 1377,
+      208, 1377,  208, 1377, 1377,  208,  208,  208,  208,  208,
+      208,  208, 1377,  208, 1377, 1084,  208, 1377,  208,  208,
+     1083,  208, 1377,  208, 1085,  208, 1377,  208,  208, 1377,
+     1377, 1377, 1377,  208,  208,  208, 1377, 1377, 1377, 1377,
+     1377, 1377, 1084,  208,  208, 1377,  208, 1377, 1377,  208,
+
+      208, 1085,  208,  208,  208,  208, 1377, 1377, 1377,  208,
+      208,  208,  208, 1377, 1086, 1377, 1377, 1088,  208,  208,
+      208,  208,  208, 1087, 1377, 1377,  208,  208,  208, 1377,
+      208,  208, 1377, 1377, 1377, 1377,  208,  208,  208, 1377,
+     1377, 1086, 1377, 1377, 1088,  208,  208,  208, 1377,  208,
+     1087, 1089, 1377,  208,  208,  208, 1377,  208,  208,  208,
+      208, 1090,  208,  208,  208,  208,  208,  208, 1091, 1377,
+     1377,  208,  208,  208,  208, 1377, 1377, 1377, 1089, 1377,
+      208,  208, 1377, 1377,  208,  208,  208,  208, 1090,  208,
+      208, 1092, 1377,  208,  208, 1091, 1377, 1377,  208,  208,
+
+      208,  208, 1377, 1093,  208,  208, 1094,  208,  208,  208,
+     1377,  208,  208,  208, 1377,  208,  208,  208, 1092, 1377,
+     1377, 1095, 1377,  208, 1377,  208, 1377,  208,  208, 1377,
+     1093,  208,  208, 1094,  208,  208,  208,  208,  208,  208,
+      208, 1377,  208,  208,  208, 1096, 1377, 1377, 1095, 1097,
+      208, 1377,  208,  208,  208,  208, 1377,  208, 1098, 1377,
+      208, 1377,  208,  208,  208,  208,  208, 1377, 1377, 1377,
+      208, 1099, 1096,  208, 1377,  208, 1097, 1377, 1377,  208,
+      208,  208,  208,  208,  208, 1098, 1377,  208, 1377,  208,
+      208,  208,  208, 1377, 1377, 1377, 1377,  208, 1099,  208,
+
+      208,  208,  208, 1377, 1377, 1100,  208, 1377,  208,  208,
+      208,  208, 1377,  208, 1377,  208,  208, 1102,  208,  208,
+     1377,  208,  208, 1377, 1101, 1377,  208,  208,  208,  208,
+     1377, 1377, 1100, 1103, 1377,  208,  208,  208,  208, 1104,
+      208, 1377,  208,  208, 1102,  208,  208, 1377,  208,  208,
+     1377, 1101, 1377,  208,  208,  208,  208, 1105, 1377,  208,
+     1103,  208,  208,  208,  208, 1377, 1104,  208, 1377,  208,
+      208, 1377,  208, 1377, 1106, 1377, 1377,  208, 1377,  208,
+      208, 1377,  208,  208, 1105, 1377,  208,  208,  208, 1377,
+      208, 1377, 1377,  208,  208,  208,  208,  208, 1107, 1377,
+
+     1377, 1106, 1108,  208,  208, 1377,  208,  208,  208, 1110,
+      208,  208, 1109,  208,  208,  208, 1377,  208,  208, 1377,
+      208,  208,  208,  208,  208, 1107, 1377, 1377,  208, 1108,
+      208,  208, 1377,  208,  208,  208, 1110,  208,  208, 1109,
+      208,  208,  208, 1377,  208,  208, 1377,  208,  208,  208,
+      208, 1377,  208,  208, 1112,  208,  208,  208,  208,  208,
+      208, 1377,  208, 1114,  208,  208, 1377, 1111,  208,  208,
+      208, 1377,  208, 1377,  208,  208,  208, 1377,  208,  208,
+      208, 1112,  208,  208,  208, 1377,  208, 1377,  208,  208,
+     1114, 1377,  208, 1113, 1111, 1377,  208,  208,  208,  208,
+
+     1377,  208,  208,  208,  208,  208,  208, 1116, 1115,  208,
+     1377,  208,  208,  208,  208,  208,  208, 1377, 1377,  208,
+     1113, 1377, 1377, 1377,  208,  208, 1377, 1377,  208, 1377,
+      208,  208, 1377,  208, 1116, 1115, 1377, 1377,  208,  208,
+      208,  208,  208,  208,  208,  208,  208,  208,  208,  208,
+      208,  208,  208, 1117,  208,  208,  208,  208,  208, 1377,
+      208, 1377, 1377,  208, 1377, 1377, 1377, 1377,  208,  208,
+     1377,  208,  208, 1377,  208,  208,  208,  208, 1377,  208,
+     1117,  208,  208,  208,  208,  208,  208,  208,  208, 1377,
+      208, 1377, 1119,  208, 1118,  208,  208,  208,  208,  208,
+
+     1377, 1377,  208, 1377, 1120, 1377, 1377, 1121, 1377,  208,
+     1377, 1377,  208,  208, 1377,  208, 1377, 1377, 1377, 1119,
+      208, 1118, 1377,  208,  208,  208,  208, 1377, 1122,  208,
+      208, 1120, 1377, 1377, 1121,  208,  208, 1377, 1377,  208,
+      208,  208,  208,  208,  208, 1377, 1377, 1377,  208,  208,
+     1377, 1377, 1377,  208,  208, 1122, 1377,  208, 1377, 1377,
+     1377, 1377,  208, 1377, 1123, 1377, 1377,  208,  208,  208,
+      208,  208,  208, 1377,  208,  208,  208, 1377, 1377,  208,
+      208,  208, 1377,  208,  208,  208,  208, 1377,  208, 1377,
+      208, 1123, 1377,  208, 1377,  208, 1377, 1377,  208,  208,
+
+     1377,  208, 1377, 1377, 1124, 1377,  208, 1377,  208, 1377,
+      208,  208,  208,  208,  208,  208,  208,  208,  208, 1126,
+      208, 1377,  208, 1125,  208,  208, 1377, 1377,  208, 1377,
+      208, 1124,  208, 1377, 1377,  208, 1377,  208, 1377, 1377,
+     1377,  208,  208,  208, 1377,  208, 1126, 1377, 1377, 1377,
+     1125,  208, 1377, 1377,  208,  208,  208,  208, 1377,  208,
+     1377,  208, 1127,  208,  208,  208,  208, 1377, 1128,  208,
+      208, 1129,  208, 1377,  208,  208, 1377, 1377, 1377,  208,
+     1377,  208, 1377,  208,  208, 1377, 1377, 1377,  208, 1127,
+      208, 1377,  208,  208, 1377, 1128, 1377,  208, 1129,  208,
+
+     1377,  208,  208,  208, 1377,  208,  208,  208, 1130,  208,
+      208,  208,  208, 1377,  208,  208, 1377, 1377,  208,  208,
+     1377, 1377, 1377,  208, 1377, 1377, 1377,  208,  208, 1377,
+      208, 1377,  208,  208,  208, 1130,  208,  208, 1131,  208,
+     1377,  208,  208,  208, 1377,  208,  208, 1132,  208,  208,
+      208, 1377,  208,  208,  208,  208, 1377, 1377,  208,  208,
+      208, 1377, 1133, 1377, 1377, 1131, 1377, 1377,  208,  208,
+      208, 1377, 1377, 1377, 1132,  208,  208,  208,  208,  208,
+      208,  208,  208, 1377, 1377,  208,  208,  208,  208, 1133,
+     1134, 1377, 1377, 1377, 1377,  208,  208,  208,  208, 1377,
+
+     1377, 1377, 1135, 1136,  208,  208,  208,  208,  208,  208,
+     1377, 1377,  208,  208,  208,  208,  208, 1134, 1377, 1377,
+     1137, 1377,  208,  208,  208,  208,  208, 1138,  208, 1135,
+     1136,  208,  208,  208,  208,  208,  208, 1377,  208,  208,
+      208,  208, 1377,  208, 1377, 1377, 1377, 1137,  208,  208,
+      208,  208, 1139,  208, 1138,  208,  208,  208,  208,  208,
+      208,  208,  208,  208, 1377,  208,  208,  208,  208, 1140,
+      208, 1377, 1141, 1377,  208,  208,  208,  208,  208, 1139,
+      208, 1377,  208,  208,  208,  208,  208,  208,  208, 1142,
+      208, 1377,  208,  208,  208,  208, 1140,  208, 1377, 1141,
+
+     1377,  208,  208,  208,  208,  208, 1377,  208, 1377,  208,
+     1143,  208,  208,  208, 1377,  208, 1142,  208, 1377,  208,
+     1144,  208,  208,  208,  208,  208, 1377, 1377,  208,  208,
+     1145,  208,  208, 1377,  208,  208, 1377, 1143,  208, 1377,
+     1377, 1377,  208, 1377,  208, 1377, 1377, 1144,  208, 1377,
+      208,  208,  208, 1377, 1377,  208, 1377, 1145,  208, 1377,
+     1377,  208,  208,  208, 1377,  208,  208, 1377,  208, 1146,
+      208,  208, 1377,  208, 1147,  208, 1148, 1377,  208,  208,
+     1377, 1150, 1377, 1377, 1377, 1377,  208,  208, 1377,  208,
+      208,  208,  208,  208,  208,  208, 1146,  208, 1377,  208,
+
+      208, 1147,  208, 1148, 1149,  208,  208, 1377, 1150, 1377,
+     1377, 1377, 1377,  208,  208,  208,  208,  208,  208, 1377,
+     1377,  208,  208,  208, 1377,  208,  208,  208, 1151, 1377,
+      208, 1149,  208, 1153, 1377,  208, 1377,  208,  208, 1377,
+     1152,  208,  208,  208,  208,  208, 1377, 1377,  208,  208,
+      208,  208,  208,  208,  208, 1151, 1377,  208, 1377,  208,
+     1153,  208,  208, 1377,  208,  208, 1377, 1152,  208,  208,
+      208, 1377,  208,  208,  208,  208,  208, 1377,  208,  208,
+      208, 1154, 1377, 1377, 1155, 1377,  208, 1377,  208,  208,
+     1377, 1377, 1377, 1377, 1377,  208,  208,  208, 1377, 1377,
+
+      208,  208,  208,  208, 1377, 1377,  208,  208, 1154, 1377,
+     1156, 1155, 1377,  208, 1377, 1377,  208, 1377,  208, 1377,
+      208,  208,  208,  208,  208,  208, 1377, 1377,  208,  208,
+      208, 1377, 1377,  208,  208, 1377, 1377, 1156, 1377,  208,
+     1377,  208, 1377, 1377, 1377,  208,  208,  208,  208, 1204,
+      208,  208,  208,  208,  208,  208, 1377,  208,  208,  208,
+      208, 1377, 1377,  208,  208, 1205,  208, 1377,  208,  208,
+      208, 1377, 1377,  208,  208,  208, 1204,  208,  208,  208,
+      208,  208, 1377, 1377,  208,  208,  208, 1377, 1377,  208,
+      208,  208, 1205,  208, 1377, 1206,  208,  208, 1377, 1207,
+
+      208,  208,  208,  208,  208,  208,  208, 1377,  208,  208,
+     1377,  208,  208, 1377, 1377, 1377,  208, 1377,  208,  208,
+      208, 1377, 1206, 1208, 1377, 1377, 1207,  208,  208, 1377,
+      208,  208,  208,  208, 1377,  208,  208, 1377, 1209,  208,
+      208, 1377,  208,  208, 1377,  208,  208,  208, 1377, 1210,
+     1208,  208,  208, 1377, 1377,  208,  208, 1377,  208, 1377,
+      208,  208, 1377, 1377, 1377, 1209, 1377,  208, 1377,  208,
+      208, 1377, 1377,  208,  208,  208, 1210, 1377,  208,  208,
+      208, 1377,  208,  208,  208,  208, 1377, 1377,  208,  208,
+     1211,  208, 1212,  208,  208, 1377, 1377, 1377,  208, 1377,
+
+      208, 1377,  208,  208, 1377, 1377, 1377,  208, 1377,  208,
+     1377,  208,  208, 1213, 1377, 1377,  208, 1211,  208, 1212,
+      208,  208,  208, 1377,  208,  208, 1214, 1377,  208,  208,
+      208, 1377, 1377,  208,  208,  208, 1377,  208,  208, 1377,
+     1213, 1377,  208, 1215, 1377, 1377, 1377,  208, 1377,  208,
+     1377,  208, 1377, 1214, 1377,  208,  208, 1377, 1377, 1377,
+      208,  208,  208, 1377,  208,  208,  208, 1216,  208,  208,
+     1215, 1377, 1377,  208,  208, 1377, 1377,  208,  208,  208,
+      208, 1377,  208, 1377,  208, 1377, 1377,  208, 1377,  208,
+     1377, 1377,  208,  208, 1216,  208, 1377, 1377, 1377, 1217,
+
+      208, 1377, 1377, 1377,  208,  208,  208,  208,  208,  208,
+      208,  208, 1377, 1377,  208,  208,  208, 1377, 1377,  208,
+      208,  208,  208,  208, 1218, 1377, 1217, 1377,  208,  208,
+     1377, 1377, 1377,  208,  208,  208, 1377,  208, 1377, 1377,
+     1377, 1377,  208, 1377, 1377, 1377, 1377,  208,  208,  208,
+      208, 1218,  208, 1377,  208,  208,  208, 1377, 1219,  208,
+      208,  208,  208,  208,  208,  208, 1377,  208,  208, 1377,
+      208,  208, 1377, 1377, 1377,  208, 1377,  208,  208,  208,
+     1377,  208, 1377, 1377, 1377, 1219,  208,  208, 1377,  208,
+      208,  208,  208, 1377,  208,  208, 1377,  208,  208,  208,
+
+     1377, 1220,  208,  208,  208,  208,  208, 1222,  208, 1377,
+      208,  208, 1377,  208,  208,  208, 1221,  208, 1377, 1223,
+      208, 1377, 1377,  208,  208, 1377,  208, 1377, 1220,  208,
+      208, 1377, 1377,  208, 1222,  208, 1377,  208,  208, 1377,
+      208, 1377,  208, 1221,  208, 1377, 1223,  208, 1377, 1377,
+      208,  208,  208,  208,  208,  208,  208, 1377, 1377,  208,
+      208,  208, 1377,  208,  208,  208, 1377, 1377,  208, 1377,
+     1377, 1377, 1377,  208, 1377, 1377, 1377, 1377, 1377,  208,
+      208,  208,  208, 1377, 1377, 1377,  208,  208,  208, 1377,
+      208,  208,  208, 1377,  208,  208,  208,  208, 1377,  208,
+
+      208,  208, 1377,  208,  208,  208,  208, 1377, 1377,  208,
+      208, 1377, 1377, 1377, 1377,  208, 1377, 1377, 1377, 1377,
+     1377,  208, 1377,  208,  208, 1377,  208, 1377,  208, 1377,
+      208,  208,  208,  208, 1377, 1377,  208,  208,  208, 1225,
+      208, 1377,  208,  208, 1224,  208, 1377, 1377, 1377,  208,
+      208, 1377, 1377,  208, 1226, 1377, 1377,  208,  208,  208,
+     1377, 1377,  208,  208, 1377,  208, 1225,  208,  208, 1377,
+      208, 1224,  208,  208, 1377, 1377,  208,  208,  208, 1377,
+      208, 1226, 1377,  208,  208,  208,  208,  208, 1377,  208,
+      208, 1377,  208,  208,  208,  208, 1377, 1377, 1377, 1227,
+
+      208, 1377, 1377,  208,  208,  208,  208, 1377,  208, 1377,
+      208, 1377, 1377,  208,  208, 1228, 1377,  208,  208,  208,
+      208,  208,  208, 1377, 1377, 1377, 1227,  208, 1377, 1377,
+      208,  208, 1377,  208,  208,  208,  208, 1229, 1377, 1377,
+      208,  208, 1228, 1377,  208,  208,  208, 1377,  208,  208,
+      208, 1377, 1377, 1377,  208,  208, 1377, 1377, 1377, 1377,
+      208,  208, 1377,  208, 1229, 1377, 1377,  208,  208,  208,
+     1377, 1377, 1377,  208,  208,  208,  208,  208,  208,  208,
+     1377, 1377,  208,  208, 1230, 1377, 1377,  208,  208,  208,
+     1377, 1377, 1377, 1231,  208, 1377,  208, 1377,  208,  208,
+
+     1377,  208, 1232,  208, 1377,  208,  208, 1377,  208,  208,
+      208, 1230,  208, 1233, 1235,  208,  208,  208,  208,  208,
+     1231, 1377, 1377,  208,  208,  208,  208,  208, 1377, 1232,
+     1377,  208, 1377,  208, 1377,  208,  208,  208, 1377,  208,
+     1233, 1235, 1377, 1377,  208,  208,  208, 1234, 1377, 1377,
+      208,  208, 1236, 1377,  208,  208, 1377,  208,  208, 1377,
+      208,  208,  208,  208,  208, 1377, 1377,  208,  208, 1377,
+     1377, 1377, 1377,  208, 1234, 1377, 1237, 1377, 1377, 1236,
+     1377, 1377,  208, 1377,  208,  208, 1377,  208,  208,  208,
+      208, 1377,  208, 1377,  208,  208, 1377,  208, 1377,  208,
+
+      208,  208, 1377, 1237, 1377, 1377, 1238, 1377,  208, 1377,
+      208,  208,  208, 1377,  208, 1239, 1377, 1377, 1377,  208,
+      208, 1377, 1377, 1377,  208, 1377,  208,  208,  208,  208,
+     1377, 1377, 1377, 1238,  208,  208, 1377,  208,  208,  208,
+     1377,  208, 1239, 1240, 1377, 1377, 1377,  208,  208, 1377,
+      208, 1377,  208,  208,  208, 1377,  208,  208, 1377, 1377,
+     1377,  208,  208, 1377, 1377, 1377,  208, 1377,  208, 1241,
+     1240,  208, 1377, 1377, 1377,  208,  208,  208, 1377,  208,
+      208,  208, 1377,  208,  208,  208, 1242, 1377, 1377,  208,
+      208, 1377, 1377, 1377, 1377,  208, 1241,  208,  208,  208,
+
+     1377, 1377, 1377,  208,  208, 1243, 1377, 1377,  208,  208,
+      208, 1377,  208, 1242, 1377, 1377,  208,  208,  208, 1377,
+     1377, 1377,  208,  208,  208, 1377,  208, 1377,  208, 1377,
+     1244,  208, 1243, 1377, 1377, 1377,  208, 1377, 1377,  208,
+      208,  208,  208,  208, 1377,  208,  208,  208, 1245, 1377,
+      208,  208,  208, 1377, 1377,  208, 1377, 1244, 1377, 1377,
+     1377, 1377, 1246, 1377, 1377, 1377,  208,  208,  208,  208,
+      208, 1377,  208,  208,  208, 1245, 1377,  208,  208,  208,
+     1377,  208,  208,  208,  208, 1377,  208, 1377,  208, 1246,
+     1377,  208, 1377,  208, 1377, 1377,  208,  208, 1377,  208,
+
+      208, 1377,  208, 1377,  208, 1377, 1377,  208,  208,  208,
+      208,  208,  208,  208,  208,  208,  208, 1377,  208, 1377,
+      208,  208, 1377,  208, 1377, 1377,  208,  208, 1377,  208,
+      208, 1377,  208, 1248,  208,  208, 1247,  208, 1377,  208,
+      208,  208,  208,  208,  208,  208,  208, 1377,  208, 1377,
+     1377,  208, 1377,  208, 1377, 1377,  208,  208, 1377,  208,
+     1248, 1377,  208, 1247,  208, 1377, 1377,  208,  208,  208,
+      208,  208,  208,  208,  208,  208,  208,  208,  208,  208,
+      208,  208, 1377,  208,  208, 1377,  208, 1377, 1377,  208,
+     1274, 1377, 1275, 1251,  208,  208, 1377,  208, 1377, 1377,
+
+      208,  208,  208,  208,  208,  208,  208,  208,  208,  208,
+      208,  208, 1377,  208,  208,  208,  208, 1274,  208,  208,
+     1377,  208, 1377,  208,  208,  208, 1377,  208, 1377,  208,
+     1377, 1377,  208, 1377,  208, 1377,  208,  208, 1377,  208,
+     1277,  208,  208, 1276,  208,  208,  208,  208,  208, 1377,
+      208,  208,  208,  208,  208, 1377,  208, 1377,  208, 1377,
+     1377,  208,  208,  208,  208, 1377,  208, 1277,  208, 1377,
+     1276,  208,  208, 1278,  208,  208,  208,  208,  208, 1377,
+      208,  208,  208,  208, 1377,  208, 1377, 1377, 1377,  208,
+      208,  208,  208,  208, 1377,  208, 1377,  208,  208,  208,
+
+     1278,  208,  208,  208,  208,  208, 1377,  208,  208,  208,
+      208,  208, 1279, 1280, 1377,  208, 1377,  208,  208,  208,
+      208,  208, 1377,  208,  208,  208,  208,  208,  208,  208,
+      208,  208, 1377,  208,  208,  208,  208, 1377,  208, 1279,
+     1280, 1377,  208,  208,  208,  208,  208, 1377,  208,  208,
+      208, 1281, 1377,  208,  208, 1377,  208,  208,  208, 1377,
+      208,  208,  208,  208,  208,  208, 1377,  208, 1377,  208,
+      208, 1377,  208,  208,  208, 1377,  208,  208, 1281, 1377,
+     1377, 1377, 1377,  208, 1282, 1377, 1377, 1377,  208,  208,
+     1377,  208,  208,  208,  208,  208,  208, 1377, 1377,  208,
+
+      208,  208, 1377, 1377,  208,  208, 1283,  208,  208,  208,
+     1377, 1282, 1377,  208,  208, 1377, 1377, 1377,  208,  208,
+      208, 1377,  208, 1377, 1377, 1377, 1377,  208, 1377, 1377,
+     1377, 1377,  208, 1283,  208,  208,  208,  208, 1377,  208,
+      208,  208, 1377, 1285,  208,  208,  208,  208,  208,  208,
+      208, 1377,  208,  208, 1284,  208,  208, 1377, 1377, 1377,
+      208, 1377, 1286,  208,  208, 1377,  208, 1377, 1377, 1377,
+     1285,  208,  208, 1377,  208,  208,  208,  208, 1377,  208,
+      208, 1284,  208,  208,  208, 1377, 1287,  208, 1377, 1286,
+      208,  208, 1377,  208, 1377,  208,  208, 1377, 1377,  208,
+
+      208, 1377,  208, 1377,  208,  208, 1377, 1377, 1377,  208,
+     1377,  208, 1377, 1287,  208, 1377, 1377, 1288,  208, 1377,
+      208, 1377,  208,  208, 1377, 1377,  208,  208,  208,  208,
+     1377,  208,  208,  208, 1377,  208,  208,  208,  208, 1377,
+     1377,  208,  208, 1289, 1288, 1377, 1377,  208, 1290,  208,
+     1377,  208, 1377,  208, 1377,  208,  208, 1377, 1377, 1377,
+      208,  208,  208, 1377,  208,  208, 1377, 1377, 1377,  208,
+     1289, 1377, 1377, 1377,  208, 1290,  208,  208,  208,  208,
+      208, 1377,  208,  208,  208, 1377, 1377,  208,  208,  208,
+     1377,  208,  208,  208, 1377, 1377, 1377, 1377,  208, 1291,
+
+     1377, 1377, 1377,  208,  208, 1377,  208,  208, 1377,  208,
+      208,  208,  208, 1377,  208, 1377,  208,  208,  208,  208,
+      208,  208,  208,  208, 1377,  208, 1291, 1292,  208, 1377,
+      208, 1377, 1377,  208,  208, 1293,  208,  208, 1377,  208,
+     1377,  208, 1377, 1377,  208,  208,  208,  208,  208,  208,
+      208, 1377,  208, 1294, 1292,  208, 1377,  208, 1377, 1377,
+      208,  208, 1293,  208, 1377, 1295, 1296,  208,  208,  208,
+      208,  208,  208,  208,  208,  208,  208,  208, 1377,  208,
+     1294, 1377, 1377, 1377,  208,  208,  208,  208, 1377, 1377,
+     1377,  208, 1295, 1296,  208,  208,  208,  208,  208, 1377,
+
+     1377,  208,  208,  208,  208,  208,  208, 1377, 1377,  208,
+      208,  208,  208,  208,  208,  208,  208, 1377,  208, 1312,
+      208, 1377,  208, 1377,  208,  208,  208, 1377,  208, 1377,
+      208, 1377,  208,  208, 1377, 1314,  208,  208,  208, 1377,
+      208, 1377,  208,  208,  208,  208, 1312,  208,  208,  208,
+     1377,  208,  208,  208,  208,  208, 1377,  208, 1377,  208,
+     1377, 1377, 1314,  208,  208,  208, 1377,  208, 1377,  208,
+     1377,  208,  208, 1377,  208,  208,  208, 1377,  208,  208,
+     1377,  208,  208,  208,  208, 1315,  208,  208, 1377, 1316,
+      208,  208,  208,  208,  208, 1377,  208,  208,  208, 1318,
+
+     1377,  208,  208,  208,  208,  208,  208, 1377,  208,  208,
+      208,  208, 1315,  208,  208, 1377, 1316,  208,  208, 1377,
+      208,  208, 1377,  208,  208,  208, 1318, 1377,  208,  208,
+      208,  208,  208,  208, 1377,  208,  208, 1377,  208, 1377,
+      208, 1317, 1377, 1377,  208,  208, 1319, 1377,  208, 1377,
+      208,  208, 1320,  208, 1377,  208,  208,  208,  208,  208,
+      208,  208,  208,  208, 1377,  208,  208,  208, 1317, 1377,
+      208, 1377,  208, 1319, 1377,  208,  208,  208,  208, 1320,
+      208, 1377, 1377,  208,  208,  208,  208, 1377,  208,  208,
+      208,  208,  208,  208,  208,  208,  208,  208, 1377,  208,
+
+     1377,  208,  208,  208,  208,  208, 1377, 1377, 1377,  208,
+      208,  208, 1321,  208, 1323,  208, 1322, 1377,  208,  208,
+      208, 1377,  208,  208, 1377,  208, 1377, 1377,  208,  208,
+      208, 1377,  208, 1377, 1377, 1377,  208,  208,  208, 1321,
+      208, 1323,  208, 1322,  208, 1377, 1377,  208, 1324,  208,
+      208, 1377,  208,  208, 1333, 1326, 1377,  208, 1377,  208,
+      208, 1377, 1335, 1377, 1377, 1377,  208,  208, 1377,  208,
+     1377,  208,  208, 1377, 1377, 1324,  208,  208, 1377, 1377,
+      208,  208,  208, 1377,  208,  208,  208,  208,  208, 1335,
+      208,  208,  208,  208,  208, 1377,  208, 1336,  208,  208,
+
+      208,  208,  208,  208,  208,  208, 1377,  208,  208,  208,
+      208,  208,  208,  208, 1377,  208, 1377,  208,  208,  208,
+     1377,  208, 1377,  208, 1336,  208, 1377,  208,  208,  208,
+      208,  208,  208, 1377,  208, 1377,  208,  208,  208,  208,
+      208,  208,  208,  208,  208,  208, 1337,  208,  208,  208,
+      208,  208,  208, 1377,  208, 1377, 1377,  208, 1377, 1377,
+     1377, 1377, 1377,  208, 1377,  208,  208, 1377,  208,  208,
+      208,  208,  208, 1337,  208,  208,  208, 1377,  208,  208,
+     1377,  208,  208,  208,  208,  208,  208,  208, 1377,  208,
+     1377, 1377, 1338,  208, 1377,  208, 1377,  208, 1377, 1377,
+
+     1377,  208,  208,  208, 1377,  208, 1377,  208, 1377,  208,
+      208,  208,  208,  208,  208,  208,  208,  208, 1377, 1338,
+      208,  208,  208, 1377,  208, 1377, 1377, 1377,  208,  208,
+      208,  208,  208,  208,  208, 1346, 1377, 1377,  208,  208,
+      208,  208,  208, 1377,  208,  208,  208, 1377,  208, 1377,
+     1377,  208, 1377, 1377, 1377, 1377, 1377, 1377,  208, 1377,
+      208, 1377, 1346, 1377, 1377, 1377,  208,  208,  208, 1377,
+     1377, 1377,  208,  208, 1377, 1377, 1377, 1377,  208,   48,
+       48,   48,   48,   48,   48,   92, 1377, 1377,   92,   92,
+       92,  104,  104,  191,  191,  191, 1377,  191,  191,  193,
+
+     1377,  193,  193,  193,  193,  196, 1377,  196,  196,  196,
+      196,  203, 1377,  203,  203,  203,  203,  208, 1377,  208,
+      208,  208,  208,  298,  298,  427, 1377,  427,  427,  427,
+      427,    7, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377
     } ;
 
-static yyconst flex_int16_t yy_chk[9032] =
+static const flex_int16_t yy_chk[9211] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -1871,7 +2119,7 @@ static yyconst flex_int16_t yy_chk[9032] =
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    1,    5,    5,    5,    5,
+        1,    1,    1,    1,    1,    1,    1,    1,    5,    5,
         5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
         5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
 
@@ -1880,984 +2128,1003 @@ static yyconst flex_int16_t yy_chk[9032] =
         5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
         5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
         5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
-        5,    5,    9,    9,   10,   10,   15,   16,   16,   16,
-       16,   16,   16,   16,   16,   16,   16,   15,   17,   17,
-       17,   17,   17,   17,   17,   17,   17,   17,   17,   18,
-       18,   21,   22,   21,   27,   28,   22,   23,   30,   21,
-       27,   21,   22,   28,   23,   21,   21,   31,   41,   28,
-
-       41,   23,   22,   41,   23, 1370,   44,   23,   21,   22,
-       21,   27,   28,   22,   23,   30,   21,   27,   21,   22,
-       28,   23,   21,   21,   31,   41,   28,   41,   23,   22,
-       41,   23,   24,   44,   23,   25,   24,   25,   49,   49,
-       24,   32,   25,   99,   33,   32,   24,   25,   33,   24,
-       55,   32,   50,   50,   33,   43,   43,   58,   58,   24,
-     1364,   55,   25,   24,   25, 1363,   34,   24,   32,   25,
-       99,   33,   32,   24,   25,   33,   24,   26,   32,   36,
-       34,   33,   43,   43,  100,   26,   34,   34,   26,  103,
-       36,   26,   29,   34,   26, 1362,   36,   26,   29,   29,
-
-       29,   42,   86,   86,   26,   29,   36,   34, 1361,   42,
-     1359,  100,   26,   34,   34,   26,  103,   36,   26,   29,
-     1357,   26,   35,   36,   26,   29,   29,   29,   42,  104,
-       35,   38,   29,  101,   35,   38,   42,   35,   35,   38,
-       81,  101,   81,  106,   81,   38, 1355,   81, 1353,   35,
-      102, 1351,   81,  102, 1349,  107,  104,   35,   38, 1347,
-      101,   35,   38, 1345,   35,   35,   38,   81,  101,   81,
-      106,   81,   38,   39,   81,   39,  110,  102,   39,   81,
-      102,   39,  107,   39,  113,   39,   39,   56,   56,   56,
-       56,   56,   56,   56,   56,   56,   56,  188,  188, 1343,
-
-       39, 1341,   39,  110, 1339,   39,  105,  105,   39,  109,
-       39,  113,   39,   39,   40,  112,  109,   67,   40,   67,
-      105,   40,   40,   67,   67,  112,  116,  116,   40,   67,
-      117,   40, 1337,  105,  105, 1333,  109, 1155, 1155, 1288,
-     1288,   40,  112,  109,   67,   40,   67,  105,   40,   40,
-       67,   67,  112,  116,  116,   40,   67,  117,   40,   57,
-       57,   57,   57,   57,   57,   57,   57,   57,   57,   57,
-       61,   61,  118,   61,   61,   61,   61,   61,   61,  119,
-       68,  114, 1329, 1322,   68, 1315,  114,  121,   68,   61,
-       61,   61,   70,  123,   68,   61,   70,   61,  124,  118,
-
-      120,  120,   70,   61,   68,   61,  119,   68,  114,   61,
-       61,   68,   70,  114,  121,   68,  125,  127, 1301,   70,
-      123,   68,   61,   70,   61,  124, 1287,  120,  120,   70,
-       61,   68,   61, 1263,  128, 1239,   61,   61, 1193,   70,
-     1147, 1072,  997,  125,  127,   61,   62,   62,  898,   62,
-       62,   62,   62,   62,   62,  799,  671,  129,   71,   72,
-       73,  128,   71,   72,   73,   62,   62,   62,   71,   72,
-       73,  130,   62,   77,  132,  126,   62,   77,   71,   72,
-       73,  126,   62,   77,  129,   71,   72,   73,  133,   71,
-       72,   73,   62,   77,  543,   71,   72,   73,  130,   62,
-
-       77,  132,  126,   62,   77,   71,   72,   73,  126,   62,
-       77,  416,  288,   83,  135,  133,   83,   83,  136,   62,
-       77,   62,   63,   83,   78,  192,   63,  138,   78,   63,
-       63,  131,   78,   83,  131,  190,   63,  139,   78,   63,
-       83,  135,   63,   83,   83,  136,   63,   90,   78,   63,
-       83,   78,  137,   63,  138,   78,   63,   63,  131,   78,
-       83,  131,  137,   63,  139,   78,   63,  137,  137,   63,
-       88,   85,   82,   63,   64,   78,   82,   84,   64,  137,
-       82,   84,   64,  140,  141,  144,   82,   84,   64,  137,
-      142,   64,  142,  145,  137,  137,   82,   84,   64,   82,
-
-       60,   64,   59,   82,   84,   64,   52,   82,   84,   64,
-      140,  141,  144,   82,   84,   64,   51,  142,   64,  142,
-      145,  146,  147,   82,   84,   64,   65,  111,  111,  111,
-       65,  111,  115,   65,  115,   65,   65,  115,  149,  143,
-       65,  143,  150,  115,  151,   65,   65,   47,  146,  147,
-      115,   45,  143,   65,  111,  111,  111,   65,  111,  115,
-       65,  115,   65,   65,  115,  149,  143,   65,  143,  150,
-      115,  151,   65,   65,   66,  148,  153,  115,  148,  143,
-      154,   66,   66,  155,  156,   66,  157,  122,   66,  122,
-      159,   66,  158,  122,   66,   20,  158,  161,   19,  163,
-
-      122,   66,  148,  153,  122,  148,   11,  154,   66,   66,
-      155,  156,   66,  157,  122,   66,  122,  159,   66,  158,
-      122,   66,   69,  158,  161,  162,  163,  122,   69,   69,
-       69,  122,  160,  165,  164,   69,  162,  160,  166,  167,
-       69,    7,  168,  164,  169,  160,  170,  165,    4,   69,
-      160,  164,  162,  172,  173,   69,   69,   69,    3,  160,
-      165,  164,   69,  162,  160,  166,  167,   69,   74,  168,
-      164,  169,  160,  170,  165,   74,  171,  160,  164,  174,
-      172,  173,   74,  177,  176,   74,    0,  171,   74,   74,
-        0,  176,  178,  175,  176,   74,    0,    0,  181,  179,
-
-      182,  183,   74,  171,    0,  179,  174,    0,  291,   74,
-      177,  176,   74,  175,  171,   74,   74,   75,  176,  178,
-      175,  176,   75,  180,   75,  181,  179,  182,  183,  293,
-       75,   75,  179,  294,   75,  291,  180,   75,   75,    0,
-      175,    0,    0,    0,   75,    0,    0,    0,    0,   75,
-      180,   75,    0,    0,    0,  296,  293,   75,   75,    0,
-      294,   75,  208,  180,   75,   75,   76,  208,  200,  208,
-      201,  201,  200,   76,  208,  201,  298,   76,  200,  208,
-       76,  201,  296,   76,  299,  300,   76,    0,  200,  208,
-      301,  201,    0,   76,  208,  200,  208,  201,  201,  200,
-
-       76,  208,  201,  298,   76,  200,  208,   76,  201,    0,
-       76,  299,  300,   76,   79,  200,   79,  301,  201,   79,
-       79,  302,   79,  203,   79,  203,   79,   79,    0,    0,
-      203,  203,    0,    0,  303,  203,   79,    0,    0,    0,
-        0,   79,    0,   79,    0,    0,   79,   79,  302,   79,
-      203,   79,  203,   79,   79,  202,  209,  203,  203,  202,
-      209,  303,  203,   79,   80,  202,  209,  205,   80,  205,
-      202,   80,   80,  205,  205,  202,  209,  305,   80,  205,
-      306,   80,  202,  209,  307,  308,  202,  209,   80,    0,
-        0,   80,  202,  209,  205,   80,  205,  202,   80,   80,
-
-      205,  205,  202,  209,  305,   80,  205,  306,   80,    0,
-        0,  307,  308,    0,    0,   80,   91,   91,   91,   91,
-       91,   91,   91,   91,   91,   91,   92,   92,   92,   92,
-       92,   92,   92,   92,   92,   92,   93,   93,   93,   93,
-       93,   93,   93,   93,   93,   93,   93,  193,  193,  193,
-      193,  193,  193,  193,  193,  193,  193,  194,  194,  194,
-      194,  194,  194,  194,  194,  194,  194,  195,  195,  195,
-      195,  195,  195,  195,  195,  195,  195,  195,  204,  206,
-      304,  204,  304,  309,  310,  311,  312,    0,  206,  204,
-      206,  204,  313,  314,  210,  206,  204,  304,  210,  315,
-
-      206,  204,    0,    0,  210,  204,  206,  304,  204,  304,
-      309,  310,  311,  312,  210,  206,  204,  206,  204,  313,
-      314,  210,  206,  204,  304,  210,  315,  206,  204,  207,
-      207,  210,  211,  316,  211,  207,    0,  207,  317,  211,
-      212,  210,  207,  207,  211,  319,  320,  207,  321,  322,
-        0,  212,  323,  212,    0,  324,  207,  207,  212,  211,
-      316,  211,  207,  212,  207,  317,  211,  212,    0,  207,
-      207,  211,  319,  320,  207,  321,  322,  214,  212,  323,
-      212,  214,  324,  325,    0,  212,  318,  214,    0,    0,
-      212,  213,  213,  213,    0,  213,  215,  214,  213,    0,
-
-      215,  318,  327,  213,  214,  221,  215,  221,  214,  215,
-      325,  216,  221,  318,  214,  216,  215,  221,  213,  213,
-      213,  216,  213,  215,  214,  213,  216,  215,  318,  327,
-      213,  216,  221,  215,  221,  328,  215,    0,  216,  221,
-        0,  329,  216,  215,  221,    0,    0,    0,  216,  330,
-        0,    0,    0,  216,  331,    0,  332,  333,  216,  217,
-        0,  217,  328,    0,  217,  334,  335,  218,  329,  218,
-      217,    0,  217,  218,  218,    0,  330,  217,  219,  218,
-      219,  331,  217,  332,  333,  219,  217,  219,  217,  336,
-      219,  217,  334,  335,  218,  337,  218,  217,  220,  217,
-
-      218,  218,  220,  337,  217,  219,  218,  219,  220,  217,
-      338,  339,  219,  340,  219,  223,  336,  219,  220,    0,
-        0,  341,  337,  227,  223,  220,  223,  227,    0,  220,
-      337,  223,  225,  227,  225,  220,  223,  338,  339,  225,
-      340,  342,  223,  227,  225,  220,  222,  222,  341,    0,
-      227,  223,  343,  223,  227,  222,    0,  222,  223,  225,
-      227,  225,  222,  223,  344,  345,  225,  222,  342,  346,
-      227,  225,  347,  222,  222,  348,  226,  349,  226,  343,
-        0,    0,  222,  226,  222,    0,    0,    0,  226,  222,
-        0,  344,  345,    0,  222,  224,  346,  224,    0,  347,
-
-        0,  224,  348,  226,  349,  226,  350,  224,  224,  229,
-      226,  352,  224,  229,  228,  226,  228,  224,    0,  229,
-      228,  228,  224,  353,  224,  230,  228,  230,  224,  229,
-        0,  355,  230,  350,  224,  224,  229,  230,  352,  224,
-      229,  228,  356,  228,  224,  231,  229,  228,  228,  231,
-      353,    0,  230,  228,  230,  231,  229,  232,  355,  230,
-      357,  232,  358,  351,  230,  231,  360,  232,  233,  356,
-      233,  361,  231,  351,  362,  233,  231,  232,  233,  234,
-      233,  234,  231,    0,  232,    0,  234,  357,  232,  358,
-      351,  234,  231,  360,  232,  233,  363,  233,  361,  364,
-
-      351,  362,  233,    0,  232,  233,  234,  233,  234,  236,
-      235,  236,  235,  234,  366,  359,  236,  235,  234,  235,
-      237,  236,  235,  363,  237,  359,  364,    0,    0,    0,
-      237,    0,    0,    0,    0,  367,  236,  235,  236,  235,
-      237,  366,  359,  236,  235,  368,  235,  237,  236,  235,
-      238,  237,  359,  369,  238,  241,  240,  237,  240,  241,
-      238,  238,  367,  240,  370,  241,  371,  237,  240,  372,
-      238,    0,  368,    0,  242,  241,    0,  238,  242,    0,
-      369,  238,  241,  240,  242,  240,  241,  238,  238,    0,
-      240,  370,  241,  371,  242,  240,  372,  238,  239,  243,
-
-      243,  242,  241,  243,  373,  242,  239,  374,  239,  243,
-      246,  242,  246,  239,  239,    0,  246,  246,  239,  243,
-        0,  242,  246,  373,    0,  239,  243,  243,    0,    0,
-      243,  373,    0,  239,  374,  239,  243,  246,  257,  246,
-      239,  239,  257,  246,  246,  239,  243,  244,  257,  246,
-      373,  244,  247,  244,  247,  244,  260,  244,  257,  247,
-      260,  376,  377,    0,  247,  257,  260,  244,    0,  257,
-        0,    0,  378,    0,  244,  257,  260,  375,  244,  247,
-      244,  247,  244,  260,  244,  257,  247,  260,  376,  377,
-      375,  247,    0,  260,  244,  245,  379,  245,  248,  378,
-
-      248,  380,  381,  260,  375,  248,  245,  249,  245,  249,
-      248,  382,  383,  245,  249,  249,  384,  375,  245,  249,
-        0,  385,  245,  379,  245,  248,  386,  248,  380,  381,
-        0,    0,  248,  245,  249,  245,  249,  248,  382,  383,
-      245,  249,  249,  384,    0,  245,  249,  250,  385,  250,
-      251,    0,  251,  386,  250,  250,    0,  251,  250,  250,
-      252,    0,  251,  254,  387,  254,  389,    0,  390,    0,
-      254,  252,    0,  252,  250,  254,  250,  251,  252,  251,
-        0,  250,  250,  252,  251,  250,  250,  252,  253,  251,
-      254,  387,  254,  389,  253,  390,  253,  254,  252,  255,
-
-      252,  253,  254,    0,  391,  252,  253,  255,    0,  255,
-      252,    0,    0,  392,  255,  253,  393,  394,    0,  255,
-      395,  253,    0,  253,    0,  396,  255,  397,  253,    0,
-      256,  391,  256,  253,  255,  258,  255,  256,  256,  258,
-      392,  255,  256,  393,  394,  258,  255,  395,  258,  261,
-        0,  261,  396,  398,  397,  258,  261,  256,  399,  256,
-        0,  261,  258,  259,  256,  256,  258,  259,  401,  256,
-      403,  259,  258,    0,  263,  258,  261,  259,  261,  263,
-      398,  263,  258,  261,  405,  399,  263,  259,  261,    0,
-      259,  263,    0,    0,  259,  401,    0,  403,  259,    0,
-
-      402,  263,    0,    0,  259,  264,  263,  264,  263,  402,
-        0,  405,  264,  263,  259,  262,  264,  264,  263,  265,
-      262,  406,  407,  265,    0,  265,  262,  402,  262,  404,
-      265,  404,  264,  262,  264,  265,  402,  267,  262,  264,
-      408,  267,  262,  264,  264,  267,  265,  262,  406,  407,
-      265,  267,  265,  262,    0,  262,  404,  265,  404,  268,
-      262,  267,  265,  268,  267,  262,  266,  408,  267,  268,
-      409,  410,  267,  411,  413,  266,    0,  266,  267,  268,
-        0,  269,  266,  266,    0,  269,  268,  266,  267,  269,
-      268,    0,    0,  266,    0,  269,  268,  409,  410,  412,
-
-      411,  413,  266,  412,  266,  269,  268,  270,  269,  266,
-      266,  270,  269,  414,  266,  271,  269,  270,  272,  271,
-      270,  272,  269,  271,  544,  272,  412,  270,  545,  271,
-      412,  272,  269,    0,  270,    0,  546,  547,  270,  271,
-      414,  272,  271,  548,  270,  272,  271,  270,  272,  274,
-      271,  544,  272,  274,  270,  545,  271,    0,  272,  274,
-      273,  273,  273,  546,  547,  549,  271,  273,  272,  274,
-      548,  275,  273,  276,  550,  275,  274,  276,    0,  275,
-      274,  275,  551,  276,  276,    0,  274,  273,  273,  273,
-        0,  275,  549,  276,  273,    0,  274,  552,  275,  273,
-
-      276,  550,  275,  280,  276,  277,  275,  280,  275,  551,
-      276,  276,  277,  280,  554,  557,  279,  279,  275,  277,
-      276,  279,  277,  280,  552,  277,    0,  279,    0,    0,
-      280,  558,  277,    0,  280,    0,    0,  279,    0,  277,
-      280,  554,  557,  279,  279,  559,  277,  560,  279,  277,
-      280,    0,  277,  278,  279,  281,  278,  281,  558,  562,
-      278,  281,  281,  278,  279,  282,  278,  281,    0,  282,
-      563,  564,  559,    0,  560,  282,  278,    0,  282,  565,
-      278,  567,  281,  278,  281,  282,  562,  278,  281,  281,
-      278,  283,  282,  278,  281,  283,  282,  563,  564,    0,
-
-      284,  283,  282,  278,  284,  282,  565,  568,  567,  285,
-      284,  283,  282,  285,  422,  284,  422,  285,  283,  569,
-      284,  422,  283,  285,  570,  571,  422,  284,  283,  572,
-      573,  284,  574,  285,  568,    0,  285,  284,  283,    0,
-      285,  422,  284,  422,  285,    0,  569,  284,  422,    0,
-      285,  570,  571,  422,    0,    0,  572,  573,    0,  574,
-      285,  289,  289,  289,  289,  289,  289,  289,  289,  289,
-      289,  417,  417,  417,  417,  417,  417,  417,  417,  417,
-      417,  418,  419,  420,  421,  418,  419,  420,  421,  575,
-      578,  418,  419,  420,  421,    0,  579,  580,    0,  581,
-
-        0,  418,  419,  420,  421,    0,    0,    0,  418,  419,
-      420,  421,  418,  419,  420,  421,  575,  578,  418,  419,
-      420,  421,  424,  579,  580,  423,  581,  423,  418,  419,
-      420,  421,  423,  424,  425,  424,  425,  423,  426,    0,
-      424,  425,  426,    0,  582,  424,  425,    0,  426,  424,
-      583,    0,  423,  584,  423,  585,    0,    0,  426,  423,
-      424,  425,  424,  425,  423,  426,  427,  424,  425,  426,
-      427,  582,  424,  425,  428,  426,  427,  583,  428,  429,
-      584,  587,  585,  429,  428,  426,  427,    0,  430,  429,
-      430,  588,  428,  427,  428,  430,  589,  427,  590,  429,
-
-      430,  428,  431,  427,  431,  428,  429,  593,  587,  431,
-      429,  428,  594,  427,  431,  430,  429,  430,  588,  428,
-      433,  428,  430,  589,  433,  590,  429,  430,    0,  431,
-      433,  431,    0,  433,  593,    0,  431,    0,    0,  594,
-      433,  431,  432,    0,  432,  434,  596,  433,  432,  434,
-      598,  433,  599,    0,  432,  434,  600,  433,  435,  432,
-      433,  434,  435,    0,  432,  434,  435,  433,  435,  432,
-      437,  432,  434,  596,  437,  432,  434,  598,  435,  599,
-      437,  432,  434,  600,    0,  435,  432,    0,  434,  435,
-      437,  432,  434,  435,  436,  435,    0,  437,  436,    0,
-
-      601,  437,  438,  602,  436,  435,  438,  437,  603,  436,
-      438,  439,    0,  439,  436,    0,  438,  437,  439,  606,
-        0,  436,    0,  439,    0,  436,  438,  601,  604,  438,
-      602,  436,  610,  438,  612,  603,  436,  438,  439,  604,
-      439,  436,  440,  438,  440,  439,  606,  441,  440,  440,
-      439,  441,  613,  438,  440,  604,  442,  441,  442,  610,
-      615,  612,  617,  442,  618,    0,  604,  441,  442,  440,
-      443,  440,  443,    0,  441,  440,  440,  443,  441,  613,
-        0,  440,  443,  442,  441,  442,    0,  615,  444,  617,
-      442,  618,  444,  619,  441,  442,    0,  443,  444,  443,
-
-      616,  616,  445,  446,  443,  621,  445,  446,  444,  443,
-      445,    0,  622,  446,  623,  444,  445,  624,  446,  444,
-      619,    0,  626,  446,    0,  444,  445,  616,  616,  445,
-      446,    0,  621,  445,  446,  444,  447,  445,  447,  622,
-      446,  623,  447,  445,  624,  446,  627,  448,  447,  626,
-      446,  448,    0,  445,  629,    0,  449,  448,  447,    0,
-      449,  630,  631,  447,  632,  447,  449,  448,    0,  447,
-        0,  449,    0,  627,  448,  447,  449,    0,  448,  450,
-        0,  629,  450,  449,  448,  447,  450,  449,  630,  631,
-        0,  632,  450,  449,  448,  452,  634,  451,  449,  452,
-
-      453,  451,  450,  449,  453,  452,  450,  451,  451,  450,
-      453,  635,  636,  450,    0,  452,  637,  451,    0,  450,
-      453,  638,  452,  634,  451,  640,  452,  453,  451,  450,
-      641,  453,  452,    0,  451,  451,  454,  453,  635,  636,
-      454,  455,  452,  637,  451,  455,  454,  453,  638,  455,
-      456,    0,  640,    0,  456,  455,  454,  641,  642,  458,
-      456,  458,  459,  454,  459,  455,  458,  454,  455,  459,
-      456,  458,  455,  454,  459,    0,  455,  456,  457,    0,
-      457,  456,  455,  454,  457,  642,  458,  456,  458,  459,
-      457,  459,  455,  458,  643,  646,  459,  456,  458,    0,
-
-      457,  459,  460,  647,  460,  457,  462,  457,  460,  460,
-      462,  457,  648,  461,  460,  461,  462,  457,  649,  650,
-      461,  643,  646,  653,  463,  461,  462,  457,  463,  460,
-      647,  460,  463,  462,    0,  460,  460,  462,  463,  648,
-      461,  460,  461,  462,  654,  649,  650,  461,  463,  656,
-      653,  463,  461,  462,  464,  463,  464,  657,  658,  463,
-      465,  464,    0,  659,  465,  463,  464,  660,  465,  466,
-      465,  654,  661,  466,    0,  463,  656,  466,  662,  466,
-      465,  464,  663,  464,  657,  658,    0,  465,  464,  466,
-      659,  465,    0,  464,  660,  465,  466,  465,    0,  661,
-
-      466,  467,  468,  467,  466,  662,  466,  465,  467,  663,
-        0,  664,  468,  467,  468,  666,  466,    0,  668,  468,
-        0,    0,  670,    0,  468,  469,    0,  469,  467,  468,
-      467,    0,  469,    0,  469,  467,    0,  469,  664,  468,
-      467,  468,  666,  471,  470,  668,  468,  471,  470,  670,
-      470,  468,  469,  471,  469,  470,  802,    0,  472,  469,
-      470,  469,  472,  471,  469,    0,  804,    0,  472,    0,
-      471,  470,  806,  472,  471,  470,  807,  470,  472,    0,
-      471,  808,  470,  802,  473,  472,  809,  470,  473,  472,
-      471,    0,  474,  804,  473,  472,  474,  473,  474,  806,
-
-      472,    0,  474,  807,  473,  472,  475,    0,  808,    0,
-      475,  473,  474,  809,  810,  473,  475,    0,  476,  474,
-      811,  473,  476,  474,  473,  474,  475,    0,  476,  474,
-      477,  473,  478,  475,  477,  812,  478,  475,  476,  474,
-      477,  810,  478,  475,  479,  476,  813,  811,  479,  476,
-      477,    0,  478,  475,  479,  476,  480,  477,    0,  478,
-      480,  477,  812,  478,  479,  476,  480,  477,  814,  478,
-      816,  479,  480,  813,  817,  479,  480,  477,  481,  478,
-      481,  479,  482,  480,  482,  481,    0,  480,  818,  482,
-      481,  479,    0,  480,  482,  814,    0,  816,  819,  480,
-
-      484,  817,    0,  480,  484,  481,  483,  481,  483,  482,
-      484,  482,  481,  483,  483,  818,  482,  481,  483,  485,
-      484,  482,  488,  485,  488,  819,  488,  484,  820,  485,
-        0,  484,  488,  483,    0,  483,  821,  484,  823,  485,
-      483,  483,  488,  486,  486,  483,  485,  484,  486,  488,
-      485,  488,  824,  488,  486,  820,  485,  491,  489,  488,
-      489,  491,  489,  821,  486,  823,  485,  491,  489,  488,
-      486,  486,  491,    0,  825,  486,    0,  491,  489,  824,
-      826,  486,    0,  827,  491,  489,    0,  489,  491,  489,
-      828,  486,  487,  490,  491,  489,  487,  490,    0,  491,
-
-      487,  825,  487,  490,  491,  489,  487,  826,  829,  490,
-      827,    0,  830,  490,    0,    0,  487,  828,  492,  487,
-      490,  493,  492,  487,  490,  493,  831,  487,  492,  487,
-      490,  493,  832,  487,  492,  829,  490,  833,  492,  830,
-      490,  493,  494,  487,  836,  492,  494,    0,  493,  492,
-      494,  837,  493,  831,    0,  492,  494,  838,  493,  832,
-      495,  492,  495,    0,  833,  492,  494,  495,  493,  494,
-      839,  836,  495,  494,  496,    0,  496,  494,  837,    0,
-      496,  496,  840,  494,  838,    0,  496,  495,  497,  495,
-      497,  841,  498,  494,  495,  497,  498,  839,    0,  495,
-
-      497,  496,  498,  496,    0,  844,  499,  496,  496,  840,
-      499,  847,  498,  496,    0,  497,  499,  497,  841,  498,
-        0,  500,  497,  498,  848,  500,  499,  497,  502,  498,
-      502,  500,  844,  499,  500,  502,    0,  499,  847,  498,
-      502,  500,    0,  499,  850,  853,    0,  506,  500,  506,
-        0,  848,  500,  499,  506,  502,    0,  502,  500,  506,
-      856,  500,  502,  504,  504,  504,    0,  502,  500,  501,
-      504,  850,  853,  501,  506,  504,  506,  501,  857,    0,
-      858,  506,  849,  501,  859,  849,  506,  856,  501,  860,
-      504,  504,  504,  501,    0,  861,  501,  504,  864,  865,
-
-      501,  505,  504,    0,  501,  857,  505,  858,  505,  849,
-      501,  859,  849,  505,  866,  501,  860,  867,  505,  507,
-      501,  503,  861,  507,  868,  864,  865,    0,  505,  507,
-      503,    0,  503,  505,  503,  505,  870,  503,  871,  507,
-      505,  866,  503,    0,  867,  505,  507,    0,  503,  872,
-      507,  868,  874,    0,  508,    0,  507,  503,  508,  503,
-        0,  503,  508,  870,  503,  871,  507,  509,  508,  503,
-      510,  509,  875,  510,  510,    0,  872,  509,  508,  874,
-      510,  508,  509,    0,  511,  508,  511,  509,    0,  508,
-      510,  511,  876,    0,  509,  508,  511,  510,  509,  875,
-
-      510,  510,  513,    0,  509,  508,  513,  510,  512,  509,
-      512,  511,  513,  511,  509,  512,  877,  510,  511,  876,
-      512,  514,  513,  511,  515,  514,  516,  879,  515,  513,
-      516,  514,  880,  513,  515,  512,  516,  512,  520,  513,
-      520,  514,  512,  877,  515,  520,  516,  512,  514,  513,
-      520,  515,  514,  516,  879,  515,  517,  516,  514,  880,
-      517,  515,  881,  516,  882,  520,  517,  520,  514,  517,
-      518,  515,  520,  516,  518,  519,  517,  520,  883,  519,
-      518,  884,  885,  517,  886,  519,  519,  517,  518,  881,
-      518,  882,  521,  517,  521,  519,  517,  518,  887,  521,
-
-      521,  518,  519,  517,  521,  883,  519,  518,  884,  885,
-        0,  886,  519,  519,    0,  518,  522,  518,  522,  521,
-      889,  521,  519,  522,  522,  887,  521,  521,  522,  890,
-      523,  521,  523,  891,  524,  893,  524,  523,  524,  894,
-      895,  524,  523,  522,  998,  522,  524,  889,    0,    0,
-      522,  522,    0,    0,    0,  522,  890,  523,    0,  523,
-      891,  524,  893,  524,  523,  524,  894,  895,  524,  523,
-      525,  998,  525,  524,  526,  527,  526,  525,  525,  527,
-      528,  526,  525, 1000,  528,  527,  526,    0, 1002,    0,
-      528, 1003, 1004, 1005,    0,  527,    0,  525, 1007,  525,
-
-      528,  526,  527,  526,  525,  525,  527,  528,  526,  525,
-     1000,  528,  527,  526,  529, 1002,  529,  528, 1003, 1004,
-     1005,  529,  527,  530,  531, 1007,  529,  528,  531,    0,
-      530, 1009,  530,    0,  531, 1010, 1011,  530, 1012,    0,
-     1013,  529,  530,  529,  531, 1015, 1017,    0,  529,    0,
-      530,  531,    0,  529, 1019,  531,  532,  530, 1009,  530,
-      532,  531, 1010, 1011,  530, 1012,  532, 1013,  532,  530,
-      533,  531, 1015, 1017,  533,    0,  532,  535,  534,  535,
-      533, 1019,  534,  532,  535,    0,  534,  532, 1022,  535,
-      533,    0,  534,  532,    0,  532,    0,  533,    0,    0,
-
-        0,  533,  534,  532,  535,  534,  535,  533,    0,  534,
-     1024,  535,  537,  534, 1025, 1022,  535,  533,  536,  534,
-      536,  537, 1026,  537,  538,  536,  538,  536,  537,  534,
-      536,  538,    0,  537,    0,  538,  538, 1024, 1027,  537,
-        0, 1025, 1034,    0,    0,  536,    0,  536,  537, 1026,
-      537,  538,  536,  538,  536,  537, 1035,  536,  538,  539,
-      537,  539,  538,  538, 1036, 1027,  539,  539,  540, 1034,
-      540,  539, 1039,  541,  540,  540,    0,  541,    0,  541,
-      540, 1041,    0, 1035,  541,    0,  539,    0,  539,  541,
-     1043, 1036,    0,  539,  539,  540,    0,  540,  539, 1039,
-
-      541,  540,  540,  542,  541,  542,  541,  540, 1041,  542,
-      542,  541,  672, 1045,  672,  542,  541, 1043,  672,  672,
-        0,  673, 1046,  673,  672,    0,    0,  673,  673,    0,
-      542, 1047,  542,  673,    0,    0,  542,  542,    0,  672,
-     1045,  672,  542,  674,    0,  672,  672,  674,  673, 1046,
-      673,  672,  675,  674,  673,  673,  675, 1048, 1047,  677,
-      673,  677,  675,  674, 1049,  676,  677, 1050, 1052,  676,
-      674,  677,  675, 1053,  674,  676,    0,  678,  676,  675,
-      674,  678,    0,  675, 1048,  676,  677,  678,  677,  675,
-      674, 1049,  676,  677, 1050, 1052,  676,  678,  677,  675,
-
-     1053, 1054,  676,  680,  678,  676,    0,  680,  678,  679,
-        0,  679,  676,  680,  678,  681,  679, 1055,    0,  681,
-        0,  679,    0,  680,  678,  681, 1057, 1059, 1054, 1061,
-      680, 1062,    0,  682,  680,  681,  679,  682,  679, 1063,
-      680,  682,  681,  679, 1055,  683,  681,  682,  679,  683,
-      680, 1064,  681, 1057, 1059,  683, 1061,  682, 1062,  684,
-      682, 1065,  681,  684,  682,  683, 1063,  685,  682,  684,
-        0,  685,  683, 1070,  682,  685,  683, 1071, 1064,  684,
-        0,  685,  683, 1152,  682,  686,  684, 1156, 1065,  686,
-      684,  685,  683,  686,  685,  686,  684,  687,  685, 1157,
-
-     1070,  687,  685, 1160, 1071,  686,  684,  687,  685,    0,
-     1152,  689,  686,    0, 1156,  689,  686,  687,  685,    0,
-      686,  689,  686,  688,  687,  690, 1157,  688,  687,  690,
-     1160,  689,  686,  688,  687,  690,  688, 1161,  689,  691,
-      690,  691,  689,  688,  687,  690,  691, 1162,  689,  692,
-      688,  691,  690,  692,  688,    0,  690,    0,  689,  692,
-      688,  694,  690,  688, 1161,  694,  691,  690,  691,  692,
-      688,  694,  690,  691, 1162,  693,  692,    0,  691,  693,
-      692,  694,  695,    0,  695,  693,  692,  702,  694,  695,
-      693,  702,  694, 1166,  695,  693,  692,  702,  694,    0,
-
-     1169,    0,  693,  696,  696,  696,  693,  702,  694,  695,
-      696,  695,  693, 1170,  702,  696,  695,  693,  702,    0,
-     1166,  695,  693, 1173,  702, 1174,  697, 1169,  697, 1175,
-      696,  696,  696,  697,  702,  697, 1176,  696,  697,  698,
-     1170,  698,  696, 1179,    0, 1180,  698,  698, 1181,    0,
-     1173,  698, 1174,  697,    0,  697, 1175,    0,  699,    0,
-      697, 1184,  697, 1176, 1186,  697,  698, 1187,  698,  699,
-     1179,  699, 1180,  698,  698, 1181,  699,  700,  698,  700,
-        0,  699, 1188,  700,  700,  699,  701, 1189, 1184,  700,
-     1190, 1186,    0,    0, 1187,  701,  699,  701,  699,    0,
-
-     1240, 1243,  701,  699,  700, 1247,  700,  701,  699, 1188,
-      700,  700,    0,  701, 1189, 1248,  700, 1190,  703,  704,
-      703,  704,  701, 1251,  701,  703,  704, 1240, 1243,  701,
-      703,  704, 1247, 1252,  701, 1241, 1241,  705,    0,  705,
-     1253, 1254, 1248,    0,  705,  703,  704,  703,  704,  705,
-     1251, 1258,  703,  704,    0,  706, 1259,  703,  704, 1260,
-     1252, 1262,    0,  706,  705,  706,  705, 1253, 1254, 1289,
-      706,  705, 1290, 1241, 1293,  706,  705,  707, 1258,  707,
-        0,  707,  706, 1259,  707,    0, 1260,    0, 1262,  707,
-      706,  708,  706,  708,    0,  708, 1289,  706,  708, 1290,
-
-     1241, 1293,  706,  708,  707,  709,  707,  709,  707, 1296,
-        0,  707,  709, 1299,  709,    0,  707,  709,  708,  710,
-      708,  710,  708,    0,  711,  708,  710,  710,    0, 1303,
-      708,  710,  709,    0,  709,  711, 1296,  711,    0,  709,
-     1299,  709,  711, 1317,  709,  713,  710,  711,  710,  713,
-      712,  711,    0,  710,  710,  713, 1303, 1321,  710, 1316,
-     1316,  712,  711,  712,  711,  713,    0,    0,  712,  711,
-     1317,  714,  713,  712,  711,  714,  713,  712,    0,  715,
-     1324,  714,  713,  715, 1321, 1330,    0, 1334,  712,  715,
-      712,  714,  713,  716,  715,  712,    0,  716,  714,  715,
-
-      712, 1316,  714,  716,    0,  717,  715, 1324,  714,  717,
-      715, 1338, 1330,  716, 1334,  717,  715, 1340,  714,  718,
-      716,  715,    0,  718,  716,  717,  715,  718, 1316, 1342,
-      716,  719,  717,  718,    0,  719,  717, 1344, 1338, 1346,
-      716,  719,  717,  718, 1340,  720,  718, 1348,    0,  720,
-      718,  719,  717,  721,  718,  720, 1342,  721,  719,    0,
-      718,  721,  719, 1350, 1344,  720, 1346,  721,  719,    0,
-      718, 1352,  720,    0, 1348,  722,  720,  721,  719,  722,
-      721, 1354,  720,  723,  721,  722,  722,  723,  721,  724,
-     1350,  724,  720,  723,  721,  722,  724,    0, 1352, 1323,
-
-     1323,  724,  722,  723,  721,    0,  722, 1356, 1354,    0,
-      723,  727,  722,  722,  723,  727,  724,  725,  724,  725,
-      723,  727,  722,  724,  725,  726,    0,  726,  724,  725,
-      723,  727,  726,  729, 1356,  729,    0,  726,  727,    0,
-      729, 1323,  727,    0,  725,  729,  725,    0,  727,    0,
-        0,  725,  726,  728,  726,    0,  725,  728,  727,  726,
-      729,    0,  729,  728,  726,    0,  728,  729, 1323,  730,
-        0,  730,  729,  728,    0,  730,  730,    0,    0,    0,
-      728,  730, 1265, 1265,  728,  731,    0,  731,    0,    0,
-      728,  731,  731,  728,    0,    0,  730,  731,  730,  733,
-
-      728,  733,  730,  730,    0,    0,  733,    0,  730,    0,
-        0,  733,  731,    0,  731,    0,    0,    0,  731,  731,
-     1265,    0,    0,    0,  731,  732,  733,  734,  733,  734,
-      732,    0,  732,  733,  734,    0,  732,  732,  733,  734,
-        0,  735,  732,  735,    0,    0,    0, 1265,  735,    0,
-        0,    0,  732,  735,  734,    0,  734,  732,    0,  732,
-      736,  734,  736,  732,  732,    0,  734,  736,  735,  732,
-      735,  737,  736,  737,  738,  735,  738,    0,  737,    0,
-      735,  738,  738,  737,    0,    0,  738,  736,    0,  736,
-      739,    0,  739,    0,  736,    0,    0,  739,  737,  736,
-
-      737,  738,  739,  738,  740,  737,  740,    0,  738,  738,
-      737,  740,    0,  738,    0,    0,  740,  739,    0,  739,
-        0,    0,  741,    0,  739,    0,  741,    0,    0,  739,
-      742,  740,  741,  740,  742,  743,    0,    0,  740,  743,
-      742,    0,  741,  740,  744,  743,  744,    0,    0,  741,
-      742,  744,  744,  741,  745,  743,  744,  742,  745,  741,
-      745,  742,  743,    0,    0,  745,  743,  742,    0,  741,
-      745,  744,  743,  744,    0,    0,    0,  742,  744,  744,
-        0,  745,  743,  744,  746,  745,  746,  745,    0,  747,
-      746,  746,  745,  747,  748,    0,  746,  745,  748,  747,
-
-      749,    0,  749,  769,  748,  769,  749,    0,    0,  747,
-      769,  746,  749,  746,  748,  769,  747,  746,  746,    0,
-      747,  748,  749,  746,  750,  748,  747,  749,  750,  749,
-      769,  748,  769,  749,  750,    0,  747,  769,    0,  749,
-        0,  748,  769,  751,  750,    0,    0,  751,    0,  749,
-        0,  750,    0,  751,    0,  750,  751,  774,    0,  774,
-        0,  750,  752,  751,  774,    0,  752,    0,    0,  774,
-      751,  750,  752,    0,  751,  752,    0,  753,    0,    0,
-      751,  753,  752,  751,  774,    0,  774,  753,    0,  752,
-      751,  774,    0,  752,    0,    0,  774,  753,    0,  752,
-
-        0,    0,  752,  754,  753,    0,  755,  754,  753,  752,
-      755,  754,    0,  754,  753,  756,  755,    0,    0,  756,
-        0,    0,    0,  754,  753,  756,  755,    0,    0,    0,
-      754,    0,    0,  755,  754,  756,    0,  755,  754,    0,
-      754,  757,  756,  755,    0,  757,  756,    0,    0,    0,
-      754,  757,  756,  755,    0,  758,  759,    0,    0,  758,
-      759,  757,  756,  758,  759,    0,    0,    0,  757,  758,
-      759,    0,  757,    0,    0,    0,    0,    0,  757,  758,
-      759,    0,  758,  759,    0,  760,  758,  759,  757,  760,
-      758,  759,    0,    0,  761,  760,  758,  759,  761,    0,
-
-        0,    0,    0,    0,  761,  760,  758,  759,    0,    0,
-        0,    0,  760,  762,  761,    0,  760,  762,    0,    0,
-        0,  761,  760,  762,    0,  761,  762,    0,    0,    0,
-        0,  761,  760,  762,    0,  763,    0,    0,  764,  763,
-      762,  761,  764,  763,  762,  763,    0,    0,  764,    0,
-      762,  764,    0,  762,    0,  763,    0,    0,  764,    0,
-      762,    0,  763,    0,  765,  764,  763,  767,  765,  764,
-      763,  767,  763,  766,  765,  764,  766,  767,  764,  765,
-      766,    0,  763,    0,  765,  764,  766,  767,    0,  768,
-        0,  765,    0,  768,  767,  765,  766,  768,  767,  768,
-
-      766,  765,    0,  766,  767,    0,  765,  766,    0,  768,
-        0,  765,    0,  766,  767,  771,  768,    0,  770,  771,
-      768,    0,    0,  766,  768,  771,  768,  770,  772,  770,
-        0,    0,  772,  773,  770,  771,  768,  773,  772,  770,
-        0,    0,  771,  773,    0,  770,  771,  775,  772,    0,
-        0,  775,  771,  773,  770,  772,  770,  775,    0,  772,
-      773,  770,  771,    0,  773,  772,  770,  775,    0,  776,
-      773,    0,  777,  776,  775,  772,  777,  778,  775,  776,
-      773,  778,  777,    0,  775,    0,    0,  778,    0,  776,
-        0,  779,  777,    0,  775,  779,  776,  778,    0,  777,
-
-      776,  779,    0,  777,  778,    0,  776,    0,  778,  777,
-        0,  779,    0,  780,  778,    0,  776,  780,  779,  777,
-        0,    0,  779,  780,  778,  781,    0,  781,  779,  782,
-        0,  782,  781,  780,    0,    0,  782,  781,  779,    0,
-      780,  782,    0,    0,  780,    0,    0,    0,    0,    0,
-      780,    0,  781,    0,  781,  783,  782,  783,  782,  781,
-      780,    0,  783,  782,  781,  784,    0,  783,  782,    0,
-        0,  785,    0,  785,  784,  791,  784,    0,  785,  791,
-      785,  784,  783,  785,  783,  791,  784,    0,    0,  783,
-        0,    0,  784,    0,  783,  791,    0,  786,  785,  786,
-
-      785,  784,  791,  784,  786,  785,  791,  785,  784,  786,
-      785,    0,  791,  784,    0,    0,  787,    0,  787,  788,
-        0,    0,  791,  787,  786,  787,  786,  789,  787,  789,
-      788,  786,  788,    0,  789,  789,  786,  788,    0,  789,
-        0,    0,  788,  787,    0,  787,  788,    0,    0,    0,
-      787,    0,  787,  790,  789,  787,  789,  788,  790,  788,
-      790,  789,  789,  793,  788,  790,  789,  793,  792,  788,
-      790,  792,  792,  793,    0,    0,    0,    0,  792,    0,
-      790,    0,    0,  793,    0,  790,    0,  790,  792,    0,
-      793,    0,  790,    0,  793,  792,    0,  790,  792,  792,
-
-      793,    0,  794,  795,  796,  792,  794,  795,  796,    0,
-      793,    0,  794,  795,  796,  792,  797,    0,  794,    0,
-      797,    0,  794,  795,  796,  798,  797,  798,    0,  794,
-      795,  796,  798,  794,  795,  796,  797,  798,    0,  794,
-      795,  796,    0,  797,    0,  794,    0,  797,    0,  794,
-      795,  796,  798,  797,  798,  899,    0,  899,  900,  798,
-      900,    0,  899,  797,  798,  900,  901,  899,  901,  902,
-      900,  902,    0,  901,    0,    0,  902,    0,  901,    0,
-      901,  902,  899,    0,  899,  900,    0,  900,    0,  899,
-        0,    0,  900,  901,  899,  901,  902,  900,  902,    0,
-
-      901,    0,  903,  902,    0,  901,  903,  901,  902,    0,
-      904,  905,  903,    0,  904,  905,    0,    0,    0,    0,
-      904,  905,  903,    0,    0,    0,    0,    0,    0,  903,
-      904,  905,    0,  903,    0,    0,  906,  904,  905,  903,
-      906,  904,  905,    0,    0,    0,  906,  904,  905,  903,
-        0,  906,    0,    0,  908,  908,  906,  904,  905,  908,
-      907,    0,    0,  906,  907,  908,    0,  906,  907,    0,
-        0,    0,    0,  906,  907,  908,    0,    0,  906,    0,
-        0,  908,  908,  906,  907,    0,  908,  907,  909,    0,
-      909,  907,  908,    0,  909,  907,  910,  911,  910,  911,
-
-      909,  907,  908,  910,  911,  911,    0,    0,  910,  911,
-      909,  907,    0,    0,    0,  909,    0,  909,  912,    0,
-        0,  909,  912,  910,  911,  910,  911,  909,  912,    0,
-      910,  911,  911,    0,    0,  910,  911,  909,  912,    0,
-      913,  915,  914,  915,  913,  912,  914,    0,  915,  912,
-      913,    0,  914,  915,  916,  912,    0,    0,  916,    0,
-      913,    0,  914,    0,  916,  912,    0,  913,  915,  914,
-      915,  913,  917,  914,  916,  915,  917,  913,    0,  914,
-      915,  916,  917,    0,    0,  916,  918,  913,    0,  914,
-      918,  916,  917,    0,  918,  919,    0,  919,    0,  917,
-
-      918,  916,  919,  917,    0,    0,    0,  919,  920,  917,
-      918,    0,  920,  918,    0,    0,  921,  918,  920,  917,
-      921,  918,  919,    0,  919,    0,  921,  918,  920,  919,
-        0,    0,    0,    0,  919,  920,  921,  918,  922,  920,
-        0,    0,  922,  921,    0,  920,  923,  921,  922,    0,
-      923,    0,  924,  921,  924,  920,  923,    0,  922,  924,
-        0,  923,    0,  921,  924,  922,  923,    0,    0,  922,
-      925,    0,  926,  923,  925,  922,  926,  923,    0,  924,
-      925,  924,  926,  923,    0,  922,  924,    0,  923,    0,
-      925,  924,  926,  923,  927,    0,  928,  925,  927,  926,
-
-      928,  925,    0,  926,  927,    0,  928,  925,    0,  926,
-        0,  928,    0,    0,  927,    0,  928,  925,    0,  926,
-      929,  927,    0,  928,  929,  927,    0,  928,    0,    0,
-      929,  927,  930,  928,  930,  929,    0,    0,  928,  930,
-      929,  927,    0,  928,  930,  931,  932,  929,  932,  931,
-      933,  929,  932,    0,  933,  931,    0,  929,  932,  930,
-      933,  930,  929,    0,    0,  931,  930,  929,  932,    0,
-      933,  930,  931,  932,  934,  932,  931,  933,  934,  932,
-        0,  933,  931,    0,  934,  932,  935,  933,    0,  936,
-      935,  936,  931,  936,  934,  932,  935,  933,    0,  936,
-
-      938,  934,  938,    0,  935,  934,  935,  938,    0,  936,
-        0,  934,  938,  935,    0,  937,  936,  935,  936,  937,
-      936,  934,    0,  935,    0,  937,  936,  938,    0,  938,
-      937,  935,    0,  935,  938,  937,  936,    0,  939,  938,
-      939,  941,  937,  941,  940,  939,  937,    0,  941,  940,
-      939,  940,  937,  941,    0,    0,  940,  937,    0,    0,
-        0,  940,  937,    0,    0,  939,    0,  939,  941,    0,
-      941,  940,  939,    0,    0,  941,  940,  939,  940,  942,
-      941,  942,  943,  940,  943,  944,  942,  944,  940,  943,
-      943,  942,  944,  945,  943,  945,    0,  944,    0,    0,
-
-      945,    0,    0,    0,    0,  945,  942,    0,  942,  943,
-        0,  943,  944,  942,  944,    0,  943,  943,  942,  944,
-      945,  943,  945,  946,  944,  946,    0,  945,    0,  947,
-      946,  946,  945,  947,  948,  946,  948,    0,    0,  947,
-        0,  948,    0,    0,  948,    0,  948,    0,    0,  947,
-      946,    0,  946,    0,    0,    0,  947,  946,  946,    0,
-      947,  948,  946,  948,    0,  949,  947,  949,  948,    0,
-        0,  948,  949,  948,    0,    0,  947,  949,  950,  951,
-      950,  951,    0,    0,    0,  950,  951,    0,    0,    0,
-      950,  951,  949,    0,  949,    0,    0,    0,    0,  949,
-
-        0,  952,    0,    0,  949,  950,  951,  950,  951,  952,
-        0,  952,  950,  951,    0,    0,  952,  950,  951,    0,
-      953,  952,  953,  954,    0,  954,    0,  953,  952,    0,
-      954,    0,  953,    0,    0,  954,  952,    0,  952,    0,
-        0,  955,    0,  952,    0,  955,    0,  953,  952,  953,
-      954,  955,  954,  956,  953,  956,  957,  954,    0,  953,
-      956,  955,  954,    0,    0,  956,    0,  957,  955,  957,
-        0,    0,  955,    0,  957,    0,    0,    0,  955,  957,
-      956,    0,  956,  957,    0,    0,    0,  956,  955,    0,
-        0,  958,  956,  958,  957,    0,  957,    0,  958,  958,
-
-      960,  957,  960,  958,    0,  959,  957,  960,  960,  959,
-        0,  959,  960,    0,    0,    0,  959,    0,  958,    0,
-      958,  959,    0,    0,    0,  958,  958,  960,    0,  960,
-      958,    0,  959,    0,  960,  960,  959,    0,  959,  960,
-      961,    0,  961,  959,  962,  963,  962,  961,  959,  963,
-        0,  962,  961,    0,    0,  963,  962,    0,    0,    0,
-      964,    0,    0,    0,  964,  963,    0,  961,    0,  961,
-      964,  962,  963,  962,  961,  964,  963,    0,  962,  961,
-      964,    0,  963,  962,  965,  965,  966,  964,    0,  965,
-      966,  964,  963,    0,    0,  965,  966,  964,    0,  966,
-
-        0,    0,  964,    0,    0,  965,  966,  964,    0,    0,
-        0,  965,  965,  966,  967,  968,  965,  966,  967,  968,
-        0,    0,  965,  966,  967,  968,  966,  967,    0,    0,
-        0,    0,  965,  966,  967,  968,    0,    0,    0,  969,
-      970,  967,  968,  969,  970,  967,  968,    0,    0,  969,
-      970,  967,  968,  971,  967,    0,    0,  971,    0,  969,
-      970,  967,  968,  971,  973,  972,  969,  970,  973,  972,
-      969,  970,  973,  971,    0,  972,  969,  970,  973,    0,
-      971,    0,    0,    0,  971,  972,  969,  970,  973,  974,
-      971,  973,  972,  974,  976,  973,  972,  974,  976,  973,
-
-      971,    0,  972,  974,  976,  973,  975,  975,    0,  976,
-        0,  975,  972,  974,  976,  973,  974,  975,    0,  977,
-      974,  976,  978,  977,  974,  976,  978,  975,    0,  977,
-      974,  976,  978,  975,  975,    0,  976,    0,  975,  977,
-      974,  976,  978,    0,  975,    0,  977,  979,  979,  978,
-      977,    0,  979,  978,  975,    0,  977,  980,  979,  978,
-      981,  980,  981,    0,    0,  980,  977,  981,  979,  978,
-        0,  980,  981,    0,  979,  979,    0,    0,    0,  979,
-        0,  980,    0,    0,  980,  979,    0,  981,  980,  981,
-        0,    0,  980,    0,  981,  979,    0,    0,  980,  981,
-
-      982,    0,  982,  983,    0,  983,  982,  982,  980,    0,
-      983,  983,  982,  984,    0,  983,  986,    0,  986,    0,
-        0,    0,    0,  986,  984,    0,  984,  982,  986,  982,
-      983,  984,  983,  982,  982,    0,  984,  983,  983,  982,
-      984,  985,  983,  986,    0,  986,    0,    0,    0,    0,
-      986,  984,  985,  984,  985,  986,    0,    0,  984,  985,
-      987,    0,  987,  984,  985,  988,    0,  987,  985,  988,
-      990,    0,  987,    0,  990,  988,    0,  989,  989,  985,
-      990,  985,  989,    0,    0,  988,  985,  987,  989,  987,
-      990,  985,  988,    0,  987,    0,  988,  990,  989,  987,
-
-        0,  990,  988,    0,  989,  989,  991,  990,    0,  989,
-      991,  992,  988,  992,    0,  989,  991,  990,  992,    0,
-        0,  993,    0,  992,    0,  989,  991,    0,    0,    0,
-        0,    0,  993,  991,  993,    0,    0,  991,  992,  993,
-      992,    0,    0,  991,  993,  992,    0,  994,  993,    0,
-      992,    0,    0,  991,    0,  995,    0,  995,  994,  993,
-      994,  993,  995,    0,    0,  994,  993,  995,    0,    0,
-      994,  993,    0,    0,  994,    0,  996,    0,  996,    0,
-        0,    0,  995,  996,  995,  994, 1073,  994,  996,  995,
-     1073, 1074,  994,    0,  995, 1074, 1073,  994,    0,    0,
-
-     1075, 1074, 1075,  996,    0,  996, 1073, 1075,    0,    0,
-      996, 1074, 1075, 1073, 1076,  996, 1076, 1073, 1074,    0,
-        0, 1076, 1074, 1073,    0,    0, 1076, 1075, 1074, 1075,
-     1077,    0, 1077, 1073, 1075,    0, 1078, 1077, 1074, 1075,
-     1078, 1076, 1077, 1076,    0, 1079, 1078,    0, 1076, 1079,
-        0,    0,    0, 1076,    0, 1079, 1078, 1077,    0, 1077,
-     1079,    0,    0, 1078, 1077, 1079,    0, 1078, 1080, 1077,
-     1080,    0, 1079, 1078,    0, 1080, 1079, 1081,    0, 1081,
-     1080,    0, 1079, 1078, 1081,    0, 1082, 1079, 1082, 1081,
-        0,    0, 1079, 1082,    0, 1080,    0, 1080, 1082,    0,
-
-        0,    0, 1080,    0, 1081,    0, 1081, 1080,    0,    0,
-     1083, 1081, 1083, 1082,    0, 1082, 1081, 1083,    0, 1084,
-     1082, 1084, 1083,    0,    0, 1082, 1084, 1084, 1085, 1085,
-     1085, 1084,    0,    0,    0, 1085,    0, 1083,    0, 1083,
-     1085,    0,    0,    0, 1083,    0, 1084,    0, 1084, 1083,
-     1086,    0,    0, 1084, 1084, 1085, 1085, 1085, 1084, 1086,
-        0, 1086, 1085, 1087,    0, 1087, 1086, 1085,    0,    0,
-     1087, 1086, 1088,    0, 1088, 1087,    0, 1086,    0, 1088,
-     1088,    0,    0,    0, 1088,    0, 1086,    0, 1086,    0,
-     1087,    0, 1087, 1086,    0,    0,    0, 1087, 1086, 1088,
-
-        0, 1088, 1087, 1089, 1090, 1089, 1088, 1088,    0,    0,
-     1089, 1088,    0,    0, 1090, 1089, 1090, 1091,    0, 1091,
-        0, 1090,    0,    0, 1091,    0, 1090,    0,    0, 1091,
-     1089, 1090, 1089,    0,    0,    0, 1092, 1089,    0,    0,
-        0, 1090, 1089, 1090, 1091, 1092, 1091, 1092, 1090,    0,
-        0, 1091, 1092, 1090,    0,    0, 1091, 1092, 1093, 1094,
-     1093, 1094,    0, 1092,    0, 1093, 1094,    0,    0,    0,
-     1093, 1094, 1092,    0, 1092,    0,    0,    0,    0, 1092,
-        0,    0,    0,    0, 1092, 1093, 1094, 1093, 1094, 1095,
-        0, 1095, 1093, 1094,    0, 1097, 1095, 1093, 1094, 1097,
-
-     1096, 1095, 1096,    0, 1098, 1097,    0, 1096, 1098,    0,
-        0,    0, 1096,    0, 1098, 1097, 1095,    0, 1095,    0,
-        0,    0, 1097, 1095, 1098,    0, 1097, 1096, 1095, 1096,
-        0, 1098, 1097,    0, 1096, 1098, 1099,    0, 1099, 1096,
-     1101, 1098, 1097, 1099, 1101, 1100,    0, 1100, 1099,    0,
-     1101, 1098, 1100, 1100, 1102,    0, 1102, 1100,    0,    0,
-     1101, 1102,    0, 1099,    0, 1099, 1102, 1101,    0,    0,
-     1099, 1101, 1100,    0, 1100, 1099,    0, 1101,    0, 1100,
-     1100, 1102,    0, 1102, 1100,    0,    0, 1101, 1102, 1103,
-     1104, 1103, 1104, 1102,    0,    0, 1103, 1104, 1105,    0,
-
-     1105, 1103, 1104,    0,    0, 1105,    0,    0,    0,    0,
-     1105,    0,    0,    0,    0,    0, 1103, 1104, 1103, 1104,
-        0,    0,    0, 1103, 1104, 1105,    0, 1105, 1103, 1104,
-        0, 1106, 1105, 1106, 1107,    0, 1107, 1105, 1106,    0,
-     1108, 1107, 1108, 1106,    0,    0, 1107, 1108,    0,    0,
-        0,    0, 1108,    0,    0,    0,    0,    0, 1106,    0,
-     1106, 1107,    0, 1107,    0, 1106,    0, 1108, 1107, 1108,
-     1106,    0,    0, 1107, 1108, 1109, 1110, 1109,    0, 1108,
-     1110, 1109, 1109,    0,    0,    0, 1110, 1109,    0,    0,
-     1112, 1111,    0,    0, 1112, 1111, 1110,    0,    0, 1111,
-
-     1112,    0, 1109, 1110, 1109, 1111,    0, 1110, 1109, 1109,
-     1112,    0,    0, 1110, 1109, 1111,    0, 1112, 1111,    0,
-     1113, 1112, 1111, 1110, 1113,    0, 1111, 1112,    0, 1114,
-     1113, 1114, 1111,    0,    0,    0, 1114, 1112,    0,    0,
-     1113, 1114, 1111, 1115,    0, 1115,    0, 1113,    0,    0,
-     1115, 1113, 1116,    0, 1116, 1115, 1114, 1113, 1114, 1116,
-        0,    0,    0, 1114, 1116,    0,    0, 1113, 1114,    0,
-     1115, 1117, 1115, 1117, 1118,    0,    0, 1115, 1117, 1116,
-        0, 1116, 1115, 1117,    0, 1118, 1116, 1118,    0,    0,
-        0, 1116, 1118,    0,    0,    0,    0, 1118, 1117,    0,
-
-     1117, 1118,    0,    0, 1119, 1117, 1119,    0,    0,    0,
-     1117, 1119, 1118, 1120, 1118, 1120, 1119,    0,    0, 1118,
-     1120, 1120,    0,    0, 1118, 1120, 1121,    0,    0,    0,
-     1121, 1119,    0, 1119,    0, 1122, 1121,    0, 1119, 1122,
-     1120,    0, 1120, 1119,    0, 1122, 1121, 1120, 1120, 1125,
-     1123, 1125, 1120, 1121, 1123, 1122, 1125, 1121,    0,    0,
-     1123, 1125, 1122, 1121, 1124,    0, 1122,    0, 1124,    0,
-     1123,    0, 1122, 1121, 1124,    0, 1125, 1123, 1125,    0,
-        0, 1123, 1122, 1125, 1124,    0,    0, 1123, 1125, 1127,
-        0, 1124, 1126,    0, 1126, 1124,    0, 1123, 1127, 1126,
-
-     1127, 1124,    0,    0, 1126, 1127,    0,    0,    0,    0,
-     1127, 1124,    0, 1128,    0,    0, 1127,    0,    0, 1126,
-        0, 1126, 1128,    0, 1128, 1127, 1126, 1127,    0, 1128,
-        0, 1126, 1127,    0, 1128,    0, 1129, 1127, 1129,    0,
-     1128,    0,    0, 1129,    0, 1130,    0, 1130, 1129, 1128,
-        0, 1128, 1130,    0,    0,    0, 1128, 1130,    0,    0,
-        0, 1128,    0, 1129, 1131, 1129, 1131,    0,    0,    0,
-     1129, 1131, 1130,    0, 1130, 1129, 1131,    0, 1132, 1130,
-     1132,    0,    0,    0, 1130, 1132,    0, 1133,    0, 1133,
-     1132, 1131,    0, 1131, 1133,    0,    0,    0, 1131, 1133,
-
-        0,    0,    0, 1131,    0, 1132, 1134, 1132, 1134,    0,
-        0,    0, 1132, 1134, 1133,    0, 1133, 1132, 1134,    0,
-     1135, 1133, 1135, 1136,    0,    0, 1133, 1135,    0,    0,
-        0,    0, 1135, 1134, 1136, 1134, 1136,    0,    0,    0,
-     1134, 1136, 1137,    0,    0, 1134, 1136, 1135,    0, 1135,
-     1136,    0,    0, 1137, 1135, 1137,    0,    0,    0, 1135,
-     1137, 1136,    0, 1136,    0, 1137,    0, 1138, 1136, 1137,
-        0,    0,    0, 1136,    0,    0, 1138, 1139, 1138, 1139,
-     1137,    0, 1137, 1138, 1139, 1139,    0, 1137, 1138, 1139,
-        0,    0, 1137,    0, 1138,    0,    0,    0,    0, 1140,
-
-        0,    0,    0, 1138, 1139, 1138, 1139, 1140,    0, 1140,
-     1138, 1139, 1139,    0, 1140, 1138, 1139,    0, 1141, 1140,
-     1141, 1142,    0, 1142,    0, 1141, 1140,    0, 1142,    0,
-     1141,    0,    0, 1142, 1140,    0, 1140, 1143,    0, 1143,
-        0, 1140,    0,    0, 1143, 1141, 1140, 1141, 1142, 1143,
-     1142, 1144, 1141, 1144,    0, 1142,    0, 1141, 1144,    0,
-     1142,    0,    0, 1144, 1143,    0, 1143, 1145,    0, 1145,
-     1146, 1143, 1146, 1145, 1145,    0, 1143, 1146, 1144, 1145,
-     1144, 1194, 1146, 1194,    0, 1144,    0,    0, 1194,    0,
-     1144,    0,    0, 1194, 1145,    0, 1145, 1146,    0, 1146,
-
-     1145, 1145,    0,    0, 1146, 1195, 1145, 1195, 1194, 1146,
-     1194, 1196, 1195, 1196, 1197, 1194, 1197, 1195, 1196,    0,
-     1194, 1197,    0, 1196,    0,    0, 1197, 1198,    0,    0,
-        0, 1198, 1195,    0, 1195,    0,    0, 1198, 1196, 1195,
-     1196, 1197, 1199, 1197, 1195, 1196, 1199, 1198, 1197,    0,
-     1196, 1200, 1199, 1197, 1198, 1200, 1201, 1201, 1198,    0,
-        0, 1200, 1199,    0, 1198,    0, 1202,    0,    0, 1199,
-     1202, 1200,    0, 1199, 1198,    0, 1202,    0, 1200, 1199,
-        0, 1201, 1200,    0,    0, 1201, 1202,    0, 1200, 1199,
-        0, 1201, 1203, 1202,    0, 1204, 1203, 1202, 1200, 1204,
-
-     1203, 1201,    0, 1202,    0, 1204, 1203,    0, 1201,    0,
-     1205,    0, 1201, 1202, 1205, 1204, 1203,    0, 1201, 1203,
-     1205,    0, 1204, 1203,    0, 1206, 1204, 1203, 1201, 1206,
-     1205,    0, 1204, 1203, 1207, 1206,    0, 1205, 1207,    0,
-        0, 1205, 1204, 1203, 1207, 1206, 1212, 1205, 1212, 1207,
-        0,    0, 1206, 1212, 1207,    0, 1206, 1205, 1212, 1209,
-        0, 1207, 1206, 1209, 1208, 1207, 1208,    0, 1208, 1209,
-        0, 1207, 1206, 1212, 1208, 1212, 1207,    0, 1210, 1209,
-     1212, 1207, 1210,    0, 1208, 1212, 1209, 1213, 1210, 1213,
-     1209, 1208,    0, 1208, 1213, 1208, 1209,    0, 1210, 1213,
-
-     1211, 1208,    0,    0, 1211, 1210, 1209,    0,    0, 1210,
-     1211, 1208,    0,    0, 1213, 1210, 1213, 1214,    0, 1214,
-     1211, 1213,    0,    0, 1214, 1210, 1213, 1211, 1216, 1214,
-     1216, 1211, 1215,    0,    0, 1216,    0, 1211,    0,    0,
-     1216, 1215,    0, 1215, 1214,    0, 1214, 1211, 1215,    0,
-        0, 1214,    0, 1215,    0, 1216, 1214, 1216,    0, 1215,
-        0,    0, 1216,    0, 1217,    0, 1217, 1216, 1215,    0,
-     1215, 1217, 1218,    0, 1218, 1215, 1217, 1220,    0, 1218,
-     1215, 1220, 1221, 1219, 1218, 1219, 1221, 1220,    0, 1219,
-     1219, 1217, 1221, 1217,    0, 1219,    0, 1220, 1217, 1218,
-
-        0, 1218, 1221, 1217, 1220,    0, 1218,    0, 1220, 1221,
-     1219, 1218, 1219, 1221, 1220,    0, 1219, 1219, 1222, 1221,
-     1222, 1223, 1219, 1223, 1220, 1222,    0,    0, 1223, 1221,
-     1222,    0, 1224, 1223, 1224,    0,    0,    0,    0, 1224,
-        0,    0, 1225,    0, 1224, 1222,    0, 1222, 1223,    0,
-     1223, 1225, 1222, 1225,    0, 1223,    0, 1222, 1225, 1224,
-     1223, 1224,    0, 1225,    0, 1226, 1224, 1226,    0, 1225,
-        0, 1224, 1226, 1226,    0,    0,    0, 1226, 1225,    0,
-     1225,    0,    0, 1227, 1227, 1225, 1227,    0,    0,    0,
-     1225, 1227, 1226,    0, 1226, 1228, 1227, 1228,    0, 1226,
-
-     1226,    0, 1228,    0, 1226,    0,    0, 1228,    0,    0,
-     1227, 1227,    0, 1227, 1229,    0, 1229,    0, 1227,    0,
-        0, 1229, 1228, 1227, 1228, 1230, 1229, 1230, 1231, 1228,
-     1231,    0, 1230, 1230, 1228, 1231,    0, 1230,    0,    0,
-     1231, 1229,    0, 1229, 1232,    0, 1232,    0, 1229,    0,
-     1232, 1232, 1230, 1229, 1230, 1231, 1232, 1231,    0, 1230,
-     1230,    0, 1231,    0, 1230,    0,    0, 1231, 1233, 1233,
-     1233, 1232,    0, 1232, 1234, 1233, 1234, 1232, 1232,    0,
-     1233, 1234, 1234, 1232, 1235,    0, 1234,    0, 1235,    0,
-        0,    0,    0,    0, 1235, 1233, 1233, 1233,    0,    0,
-
-        0, 1234, 1233, 1234, 1235,    0, 1236, 1233, 1234, 1234,
-     1236, 1235,    0, 1234, 1237, 1235, 1236,    0, 1237, 1238,
-        0, 1235,    0, 1238, 1237,    0, 1236,    0,    0, 1238,
-        0, 1235, 1266, 1236, 1237,    0, 1266, 1236,    0, 1238,
-        0, 1237, 1266, 1236, 1264, 1237, 1238,    0, 1264,    0,
-     1238, 1237, 1266, 1236, 1264,    0, 1238, 1264, 1267, 1266,
-        0, 1237, 1267, 1266, 1264,    0, 1238,    0, 1267, 1266,
-     1268, 1264, 1269, 1267, 1268, 1264, 1269,    0, 1267, 1266,
-     1268, 1264, 1269,    0, 1264, 1267,    0,    0,    0, 1267,
-     1268, 1264, 1269,    0, 1270, 1267,    0, 1268, 1270, 1269,
-
-     1267, 1268,    0, 1269, 1270, 1267, 1271, 1268, 1271, 1269,
-     1271,    0,    0,    0, 1270,    0, 1271, 1268,    0, 1269,
-        0, 1270,    0,    0, 1272, 1270, 1271,    0, 1272,    0,
-        0, 1270, 1273, 1271, 1272, 1271, 1273, 1271,    0, 1272,
-        0, 1270, 1273, 1271, 1272,    0,    0,    0,    0,    0,
-     1274, 1272, 1273, 1271, 1274, 1272,    0,    0,    0, 1273,
-     1274, 1272,    0, 1273,    0,    0, 1272,    0,    0, 1273,
-     1274, 1272, 1275,    0,    0,    0, 1275, 1274,    0, 1273,
-        0, 1274, 1275, 1277, 1276, 1275, 1276, 1274, 1277,    0,
-     1277, 1276, 1275,    0, 1278, 1277, 1276, 1274, 1278, 1275,
-
-     1277,    0,    0, 1275, 1278,    0,    0,    0,    0, 1275,
-     1277, 1276, 1275, 1276, 1278, 1277, 1279, 1277, 1276, 1275,
-     1279, 1278, 1277, 1276, 1280, 1278, 1279, 1277, 1280, 1281,
-        0, 1278,    0, 1281, 1280,    0, 1279,    0, 1282, 1281,
-        0, 1278, 1282, 1279, 1280,    0,    0, 1279, 1282, 1281,
-        0, 1280,    0, 1279,    0, 1280, 1281,    0, 1282,    0,
-     1281, 1280,    0, 1279,    0, 1282, 1281,    0, 1283, 1282,
-     1284, 1280, 1283, 1285, 1284, 1282, 1281, 1285, 1283, 1283,
-     1284, 1286, 1286, 1285,    0, 1282, 1286,    0, 1283,    0,
-     1284,    0, 1286, 1285,    0, 1283,    0, 1284,    0, 1283,
-
-     1285, 1284, 1286,    0, 1285, 1283, 1283, 1284, 1286, 1286,
-     1285, 1302, 1302, 1286, 1304, 1283,    0, 1284, 1304, 1286,
-     1285,    0, 1305, 1306, 1304,    0, 1305, 1306,    0, 1286,
-        0,    0, 1305, 1306, 1304,    0, 1302,    0,    0,    0,
-     1302, 1304, 1305, 1306,    0, 1304, 1302,    0,    0, 1305,
-     1306, 1304,    0, 1305, 1306,    0, 1302,    0,    0, 1305,
-     1306, 1304,    0, 1302, 1307,    0, 1307, 1302,    0, 1305,
-     1306, 1307, 1308, 1302, 1308, 1309, 1307, 1309, 1310, 1308,
-     1310,    0, 1309, 1302, 1308, 1310,    0, 1309,    0,    0,
-     1310, 1307,    0, 1307,    0,    0,    0,    0, 1307, 1308,
-
-        0, 1308, 1309, 1307, 1309, 1310, 1308, 1310, 1311, 1309,
-     1311, 1308, 1310,    0, 1309, 1311, 1312, 1310, 1312,    0,
-     1311, 1313,    0, 1312,    0, 1313, 1314,    0, 1312, 1325,
-     1314, 1313,    0, 1325, 1326, 1311, 1314, 1311, 1326, 1325,
-        0, 1313, 1311, 1312, 1326, 1312, 1314, 1311, 1313, 1325,
-     1312,    0, 1313, 1314, 1326, 1312, 1325, 1314, 1313,    0,
-     1325, 1326,    0, 1314,    0, 1326, 1325,    0, 1313,    0,
-     1327, 1326,    0, 1314, 1327, 1328, 1325, 1328,    0,    0,
-     1327, 1326, 1328,    0, 1336,    0, 1336, 1328,    0,    0,
-     1327, 1336,    0,    0,    0,    0, 1336, 1327,    0,    0,
-
-        0, 1327, 1328,    0, 1328,    0,    0, 1327,    0, 1328,
-        0, 1336,    0, 1336, 1328,    0,    0, 1327, 1336,    0,
-        0,    0,    0, 1336, 1368, 1368, 1368, 1368, 1368, 1369,
-        0,    0, 1369, 1369, 1371, 1371, 1371,    0, 1371, 1372,
-        0, 1372, 1372, 1372, 1373,    0, 1373, 1373, 1373, 1374,
-        0, 1374, 1374, 1374, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367, 1367,
-     1367
+        5,    5,    5,    5,    5,    5,    9,    9,   10,   10,
+       13,   13,   13,   13,   13,   13,   13,   13,   13,   13,
+       16,   17,   17,   17,   17,   17,   17,   17,   17,   17,
+       17,   16,   18,   18,   18,   18,   18,   18,   18,   18,
+       18,   18,   18,   20,   20,   23,   24,   23,   29,   30,
+
+       24,   25,   32,   23,   29,   23,   24,   30,   25,   23,
+       23,   33,   43,   30,   43,   25,   24,   43,   25, 1380,
+       46,   25,   23,   24,   23,   29,   30,   24,   25,   32,
+       23,   29,   23,   24,   30,   25,   23,   23,   33,   43,
+       30,   43,   25,   24,   43,   25,   26,   46,   25,   27,
+       26,   27,   51,   51,   26,   34,   27,  105,   35,   34,
+       26,   27,   35,   26,   58,   34,   52,   52,   35,   45,
+       45,   62,   62,   26, 1374,   58,   27,   26,   27, 1373,
+       36,   26,   34,   27,  105,   35,   34,   26,   27,   35,
+       26,   28,   34,   38,   36,   35,   45,   45,  106,   28,
+
+       36,   36,   28,  109,   38,   28,   31,   36,   28, 1372,
+       38,   28,   31,   31,   31,   44,   90,   90,   28,   31,
+       38,   36, 1371,   44, 1369,  106,   28,   36,   36,   28,
+      109,   38,   28,   31, 1367,   28,   37,   38,   28,   31,
+       31,   31,   44,  110,   37,   40,   31,  107,   37,   40,
+       44,   37,   37,   40,   85,  107,   85,  112,   85,   40,
+     1365,   85, 1363,   37,  108, 1361,   85,  108, 1359,  113,
+      110,   37,   40, 1357,  107,   37,   40, 1355,   37,   37,
+       40,   85,  107,   85,  112,   85,   40,   41,   85,   41,
+      116,  108,   41,   85,  108,   41,  113,   41,  119,   41,
+
+       41,   55,   55,   55,   55,   55,   55,   55,   55,   55,
+       55,  194,  194, 1353,   41, 1351,   41,  116, 1349,   41,
+      111,  111,   41,  115,   41,  119,   41,   41,   42,  118,
+      115,   71,   42,   71,  111,   42,   42,   71,   71,  118,
+      122,  122,   42,   71,  123,   42, 1347,  111,  111, 1343,
+      115, 1165, 1165, 1298, 1298,   42,  118,  115,   71,   42,
+       71,  111,   42,   42,   71,   71,  118,  122,  122,   42,
+       71,  123,   42,   59,   59,   59,   59,   59,   59,   59,
+       59,   59,   59,   60,   60,   60,   60,   60,   60,   60,
+       60,   60,   60,   60,   61,   61, 1339,   61,   61,   61,
+
+       61,   61,   61,   61,   61,   61,   61,   61,   61,   61,
+       61,   61,   61,   61,   61,   61,   61,   61,   72,   74,
+       75,   76,   72,   74,   75,   76,   72,  124,  125,   74,
+       75,   76,   72,  117,  117,  117,  127,  117,  120,   74,
+       75,   76,   72,  120,   61,   72,   74,   75,   76,   72,
+       74,   75,   76,   72,  124,  125,   74,   75,   76,   72,
+      117,  117,  117,  127,  117,  120,   74,   75,   76,   72,
+      120,   61,   65,   65, 1332,   65,   65,   65,   65,   65,
+       65,   65,   93,   93,   93,   93,   93,   93,   93,   93,
+       93,   93,   65,   65,   65,   65,   77,  129,   81,   65,
+
+       77,   65,   81,  126,  126,  130,   77,   65,   81,   65,
+      131,  132,  133,   65,   65,  134,   77,  132,   81,  135,
+      136,  138, 1325,   77,  129,   81,   65,   77,   65,   81,
+      126,  126,  130,   77,   65,   81,   65,  131,  132,  133,
+       65,   65,  134,   77,  132,   81,  135,  136,  138,   65,
+       66,   66, 1311,   66,   66,   66,   66,   66,   66,   66,
+       82, 1297, 1273,  139,   82,  141, 1249,  142,   82, 1203,
+       66,   66,   66,   66,   82,   86, 1157,  137,   66,   86,
+      137,  144,   66,   86,   82,  145, 1082,   82,   66,   86,
+      139,   82,  141,   87,  142,   82,   87,   87,   66,   86,
+
+     1007,   82,   86,   87,  137,   66,   86,  137,  144,   66,
+       86,   82,  145,   87,  908,   66,   86,  146,  809,  681,
+       87,  553,  425,   87,   87,   66,   86,   66,   67,   88,
+       87,  143,   67,   88,  147,   67,   67,  150,  151,   88,
+       87,  143,   67,  152,  146,   67,  143,  143,   67,   88,
+      153,  155,   67,  296,  199,   67,   88,  196,  143,   67,
+       88,  147,   67,   67,  150,  151,   88,   95,  143,   67,
+      152,   92,   67,  143,  143,   67,   88,  153,  155,   67,
+       68,  121,  156,  121,   68,  128,  121,  128,   68,  157,
+      159,  128,  121,  148,   68,  148,  160,   68,  128,  121,
+
+      154,  161,  128,  154,   68,   89,  162,   68,  121,  156,
+      121,   68,  128,  121,  128,   68,  157,  159,  128,  121,
+      148,   68,  148,  160,   68,  128,  121,  154,  161,  128,
+      154,   68,   69,  162,  163,  149,   69,  149,  165,   69,
+      164,   69,   69,  167,  164,   64,   69,  169,  149,  172,
+       63,   69,   69,   54,   53,   49,  173,  174,   47,   69,
+       22,  163,  149,   69,  149,  165,   69,  164,   69,   69,
+      167,  164,  166,   69,  169,  149,  172,  166,   69,   69,
+       70,  168,  171,  173,  174,  166,  170,   70,   70,  175,
+      166,   70,  168,  176,   70,  170,  171,   70,  178,  166,
+
+       70,   21,  179,  170,  166,  180,   11,   70,  168,  171,
+        7,  181,  166,  170,   70,   70,  175,  166,   70,  168,
+      176,   70,  170,  171,   70,  178,  177,   70,   73,  179,
+      170,  181,  180,  182,   73,   73,   73,  177,  181,  183,
+      182,   73,  184,  182,  185,  187,   73,    4,  188,  189,
+      185,  300,  186,  177,    3,   73,  302,    0,  181,  303,
+      182,   73,   73,   73,  177,  186,  183,  182,   73,  184,
+      182,  185,  187,   73,   78,  188,  189,  185,  300,  186,
+      208,   78,  305,  302,  208,    0,  303,    0,   78,  307,
+      208,   78,  186,    0,   78,   78,    0,    0,  308,  309,
+
+      208,   78,  310,    0,  311,  312,  314,  208,   78,  305,
+        0,  208,  211,    0,  211,   78,  307,  208,   78,  211,
+      211,   78,   78,   79,  211,  308,  309,  208,   79,  310,
+       79,  311,  312,  314,  315,  316,   79,   79,  210,  211,
+       79,  211,  210,   79,   79,    0,  211,  211,  210,  317,
+       79,  211,    0,  210,  318,   79,    0,   79,  210,    0,
+      319,  315,  316,   79,   79,  210,  320,   79,  321,  210,
+       79,   79,   80,  209,  209,  210,  317,    0,  209,   80,
+      210,  318,    0,   80,  209,  210,   80,  319,  322,   80,
+      323,  324,   80,  320,  209,  321,  325,  326,    0,   80,
+
+      209,  209,  213,    0,  213,  209,   80,  328,  213,  213,
+       80,  209,  329,   80,  213,  322,   80,  323,  324,   80,
+       83,  209,   83,  325,  326,   83,   83,    0,   83,  213,
+       83,  213,   83,   83,  328,  213,  213,    0,  330,  329,
+      331,  213,   83,    0,    0,  214,    0,   83,    0,   83,
+        0,    0,   83,   83,  214,   83,  214,   83,    0,   83,
+       83,  214,  313,  332,  313,  330,  214,  331,  216,   83,
+       84,  327,  214,  216,   84,  216,  333,   84,   84,  313,
+      216,  214,  334,  214,   84,  216,  327,   84,  214,  313,
+      332,  313,  336,  214,   84,  216,    0,   84,  327,    0,
+
+      216,   84,  216,  333,   84,   84,  313,  216,    0,  334,
+        0,   84,  216,  327,   84,    0,    0,    0,    0,  336,
+        0,   84,   96,   96,   96,   96,   96,   96,   96,   96,
+       96,   96,   97,   97,   97,   97,   97,   97,   97,   97,
+       97,   97,   98,   98,   98,   98,   98,   98,   98,   98,
+       98,   98,   98,  197,  197,  197,  197,  197,  197,  197,
+      197,  197,  197,  200,  200,  200,  200,  200,  200,  200,
+      200,  200,  200,  201,  201,  201,  201,  201,  201,  201,
+      201,  201,  201,  202,  202,  202,  202,  202,  202,  202,
+      202,  202,  202,  202,  203,  203,  337,  203,  203,  203,
+
+      203,  203,  203,  203,    0,    0,  338,  339,  217,  218,
+      340,  341,  217,  218,  203,  203,  203,  203,  217,  218,
+      219,  222,  219,  337,    0,  222,  342,  219,  217,  218,
+        0,  222,  219,  338,  339,  217,  218,  340,  341,  217,
+      218,  222,    0,    0,    0,  217,  218,  219,  222,  219,
+        0,  220,  222,  342,  219,  217,  218,  223,  222,  219,
+      343,  223,  220,    0,  220,  344,  345,  223,  222,  220,
+      223,  203,  212,  346,  220,  212,  347,  223,  220,  348,
+      349,  346,  350,  212,  223,  212,  351,  343,  223,  220,
+      212,  220,  344,  345,  223,  212,  220,  223,    0,  212,
+
+      346,  220,  212,  347,  223,    0,  348,  349,  346,  350,
+      212,    0,  212,  351,    0,  224,  352,  212,  353,  224,
+      354,  355,  212,  215,  215,  224,  226,  356,  226,  215,
+      224,  215,  226,  226,  357,  224,  215,  215,  226,  358,
+      359,  215,  224,  352,    0,  353,  224,  354,  355,    0,
+      215,  215,  224,  226,  356,  226,  215,  224,  215,  226,
+      226,  357,  224,  215,  215,  226,  358,  359,  215,  221,
+      221,  221,    0,  221,    0,    0,  221,    0,  361,  362,
+      364,  221,  297,  297,  297,  297,  297,  297,  297,  297,
+      297,  297,  227,    0,  227,    0,  221,  221,  221,  227,
+
+      221,  227,  360,  221,  227,  361,  362,  364,  221,  225,
+      365,  225,  360,  228,  225,  366,  367,  228,  369,  227,
+      225,  227,  225,  228,  368,  370,  227,  225,  227,  360,
+      371,  227,  225,  228,  368,  372,  225,  365,  225,  360,
+      228,  225,  366,  367,  228,  369,  229,  225,  229,  225,
+      228,  368,  370,  229,  225,  231,  373,  371,  229,  225,
+      228,  368,  372,  375,  231,  233,  231,  233,    0,  376,
+        0,  231,  233,  229,  377,  229,  231,  233,  378,  379,
+      229,  380,  231,  373,  381,  229,  230,  230,  383,    0,
+      375,  231,  233,  231,  233,  230,  376,  230,  231,  233,
+
+      385,  377,  230,  231,  233,  378,  379,  230,  380,    0,
+        0,  381,  382,  230,  230,  383,  234,  386,  234,    0,
+        0,    0,  230,  234,  230,    0,  387,  385,  234,  230,
+        0,  382,    0,  388,  230,  232,  235,  232,    0,  382,
+      235,  232,  389,  234,  386,  234,  235,  232,  232,  390,
+      234,    0,  232,  387,    0,  234,  235,  232,  382,  236,
+      388,  236,  232,  235,  232,  236,  236,  235,  232,  389,
+        0,  236,  391,  235,  232,  232,  390,  237,  238,  232,
+      238,  237,  392,  235,  232,  238,  236,  237,  236,    0,
+      238,  239,  236,  236,    0,  239,  240,  237,  236,  391,
+
+      240,  239,    0,  393,  237,  238,  240,  238,  237,  392,
+      394,  239,  238,  242,  237,  242,  240,  238,  239,  241,
+      242,  241,  239,  240,  237,  242,  241,  240,  239,  241,
+      393,  241,  243,  240,  243,    0,  395,  394,  239,  243,
+      242,  243,  242,  240,  243,  396,  241,  242,  241,    0,
+      245,  384,  242,  241,  245,  244,  241,  244,  241,  243,
+      245,  243,  244,  395,  384,  246,  243,  244,  243,  246,
+      245,  243,  396,    0,  398,  246,  246,  245,  384,  399,
+      400,  245,  244,  401,  244,  246,    0,  245,  248,  244,
+      248,  384,  246,    0,  244,  248,  246,  245,  402,    0,
+
+      248,  398,  246,  246,  249,    0,  399,  400,  249,    0,
+      401,  403,  246,  247,  249,  248,  250,  248,  404,    0,
+      250,  247,  248,  247,  249,  402,  250,  248,  247,  247,
+        0,  249,  285,  247,    0,  249,  250,    0,  403,  285,
+      247,  249,    0,  250,  405,  404,  285,  250,  247,  285,
+      247,  249,  285,  250,  406,  247,  247,  251,  251,  285,
+      247,  251,  254,  250,  254,    0,  285,  251,  254,  254,
+        0,  405,  407,  285,  254,    0,  285,  251,    0,  285,
+      408,  406,    0,  265,  251,  251,    0,  265,  251,  254,
+      255,  254,  255,  265,  251,  254,  254,  255,    0,  407,
+
+        0,  254,  255,  265,  251,  252,    0,  408,  410,  252,
+      265,  252,  411,  252,  265,  252,    0,  255,  412,  255,
+      265,  411,  414,  268,  255,  252,    0,  268,    0,  255,
+      265,    0,  252,  268,  415,  410,  252,    0,  252,  411,
+      252,    0,  252,  268,    0,  412,    0,  416,  411,  414,
+      268,  417,  252,  253,  268,  253,  256,  413,  256,  413,
+      268,  415,  418,  256,  253,  257,  253,  257,  256,  419,
+      268,  253,  257,  257,  416,  420,  253,  257,  417,  422,
+      253,    0,  253,  256,  413,  256,  413,  423,    0,  418,
+      256,  253,  257,  253,  257,  256,  419,  554,  253,  257,
+
+      257,    0,  420,  253,  257,  258,  422,  258,  259,    0,
+      259,  555,  258,  258,  423,  259,  258,  258,  260,    0,
+      259,  262,  421,  262,  554,    0,  421,    0,  262,  260,
+        0,  260,  258,  262,  258,  259,  260,  259,  555,  258,
+      258,  260,  259,  258,  258,  260,  261,  259,  262,  421,
+      262,  556,  261,  421,  261,  262,  260,  263,  260,  261,
+      262,    0,  557,  260,  261,  263,    0,  263,  260,    0,
+        0,  558,  263,  261,  559,  560,    0,  263,  556,  261,
+        0,  261,    0,  561,  263,  562,  261,    0,  264,  557,
+      264,  261,  263,  266,  263,  264,  264,  266,  558,  263,
+
+      264,  559,  560,  266,  263,    0,  266,  269,    0,  269,
+      561,  564,  562,  266,  269,  264,  567,  264,    0,  269,
+      266,  267,  264,  264,  266,  267,  568,  264,  569,  267,
+      266,  570,  271,  266,  269,  267,  269,  271,  564,  271,
+      266,  269,  572,  567,  271,  267,  269,    0,  267,  271,
+        0,    0,  267,  568,    0,  569,  267,    0,  570,  271,
+      573,    0,  267,  272,  271,  272,  271,  574,    0,  572,
+      272,  271,  267,  270,  272,  272,  271,  273,  270,  575,
+      577,  273,    0,  273,  270,  578,  270,  573,  273,  579,
+      272,  270,  272,  273,  574,  275,  270,  272,  580,  275,
+
+      270,  272,  272,  275,  273,  270,  575,  577,  273,  275,
+      273,  270,  578,  270,    0,  273,  579,  276,  270,  275,
+      273,  276,  275,  270,  274,  580,  275,  276,  581,  582,
+      275,  583,  584,  274,  585,  274,  275,  276,    0,  277,
+      274,  274,    0,  277,  276,  274,  275,  277,  276,    0,
+        0,  274,    0,  277,  276,  581,  582,  588,  583,  584,
+      274,  585,  274,  277,  276,  278,  277,  274,  274,  278,
+      277,  589,  274,  279,  277,  278,  280,  279,  278,  280,
+      277,  279,  590,  280,  588,  278,  591,  279,  592,  280,
+      277,    0,  278,    0,  593,  594,  278,  279,  589,  280,
+
+      279,  595,  278,  280,  279,  278,  280,  282,  279,  590,
+      280,  282,  278,  591,  279,  592,  280,  282,  281,  281,
+      281,  593,  594,  597,  279,  281,  280,  282,  595,  283,
+      281,  284,  598,  283,  282,  284,  599,  283,  282,  283,
+      600,  284,  284,    0,  282,  281,  281,  281,  603,  283,
+      597,  284,  281,    0,  282,    0,  283,  281,  284,  598,
+      283,  604,  284,  599,  283,    0,  283,  600,  284,  284,
+      288,  606,  287,  287,  288,  603,  283,  287,  284,  286,
+      288,  608,  286,  287,  609,  610,  286,    0,  604,  286,
+      288,    0,  286,  287,    0,    0,    0,  288,  606,  287,
+
+      287,  288,  286,  611,  287,    0,  286,  288,  608,  286,
+      287,  609,  610,  286,  291,    0,  286,  288,  291,  286,
+      287,  289,  290,  289,  291,  612,  290,  289,  289,  286,
+      611,  613,  290,  289,  291,  290,    0,  616,  620,  622,
+        0,  291,  290,  623,    0,  291,    0,    0,  289,  290,
+      289,  291,  612,  290,  289,  289,    0,    0,  613,  290,
+      289,  291,  290,  292,  616,  620,  622,  292,  293,  290,
+      623,  428,  293,  292,  614,  428,  293,  432,  292,  432,
+      625,  428,  293,  292,  432,  614,  626,  626,  627,  432,
+      292,  428,  293,    0,  292,  293,    0,    0,  428,  293,
+
+      292,  614,  428,  293,  432,  292,  432,  625,  428,  293,
+      292,  432,  614,  626,  626,  627,  432,    0,  428,  293,
+      426,  426,  426,  426,  426,  426,  426,  426,  426,  426,
+      427,  427,  628,  427,  427,  427,  427,  427,  427,  427,
+        0,    0,  629,  631,  429,  430,  632,  633,  429,  430,
+      427,  427,  427,  427,  429,  430,  433,  431,  433,  628,
+        0,  431,  634,  433,  429,  430,    0,  431,  433,  629,
+      631,  429,  430,  632,  633,  429,  430,  431,    0,    0,
+        0,  429,  430,  433,  431,  433,    0,  434,  431,  634,
+      433,  429,  430,  436,  431,  433,    0,  436,  434,  435,
+
+      434,  435,    0,  436,  431,  434,  435,  427,    0,  636,
+      434,  435,    0,  436,  434,  637,    0,  639,  640,  437,
+      436,  641,    0,  437,  436,  434,  435,  434,  435,  437,
+      436,  438,  434,  435,  642,  438,  636,  434,  435,  437,
+      436,  438,  637,  439,  639,  640,  437,  439,  641,  438,
+      437,  438,  440,  439,  440,  644,  437,  645,  438,  440,
+        0,  642,  438,  439,  440,  441,  437,  441,  438,    0,
+      439,  646,  441,  647,  439,  648,  438,  441,  438,  440,
+      439,  440,  644,  443,  645,    0,  440,  443,  650,  651,
+      439,  440,  441,  443,  441,    0,  443,    0,  646,  441,
+
+      647,    0,  648,  443,  441,  442,    0,  442,  444,  652,
+      443,  442,  444,  653,  443,  650,  651,  442,  444,  656,
+      443,  445,  442,  443,  444,  445,    0,  442,  444,  445,
+      443,  445,  442,  447,  442,  444,  652,  447,  442,  444,
+      653,  445,    0,  447,  442,  444,  656,    0,  445,  442,
+        0,  444,  445,  447,  442,  444,  445,  446,  445,    0,
+      447,  446,    0,  657,  447,  448,  658,  446,  445,  448,
+      447,  659,  446,  448,  449,  660,  449,  446,    0,  448,
+      447,  449,  663,    0,  446,    0,  449,    0,  446,  448,
+      657,  664,  448,  658,  446,  666,  448,  667,  659,  446,
+
+      448,  449,  660,  449,  446,  450,  448,  450,  449,  663,
+      451,  450,  450,  449,  451,  668,  448,  450,  664,  452,
+      451,  452,  666,  669,  667,  670,  452,  671,    0,  672,
+      451,  452,  450,  453,  450,  453,  673,  451,  450,  450,
+      453,  451,  668,    0,  450,  453,  452,  451,  452,    0,
+      669,  454,  670,  452,  671,  454,  672,  451,  452,    0,
+      453,  454,  453,  673,  674,  455,  456,  453,  676,  455,
+      456,  454,  453,  455,    0,  678,  456,  680,  454,  455,
+      812,  456,  454,    0,    0,  814,  456,    0,  454,  455,
+      816,  674,  455,  456,    0,  676,  455,  456,  454,  457,
+
+      455,  457,  678,  456,  680,  457,  455,  812,  456,  817,
+      458,  457,  814,  456,  458,    0,  455,  816,    0,  459,
+      458,  457,    0,  459,  818,  819,  457,  820,  457,  459,
+      458,    0,  457,    0,  459,    0,  817,  458,  457,  459,
+        0,  458,  460,    0,    0,  460,  459,  458,  457,  460,
+      459,  818,  819,    0,  820,  460,  459,  458,  462,  821,
+      461,  459,  462,  463,  461,  460,  459,  463,  462,  460,
+      461,  461,  460,  463,  822,  823,  460,    0,  462,  824,
+      461,    0,  460,  463,  826,  462,  821,  461,  827,  462,
+      463,  461,  460,  828,  463,  462,    0,  461,  461,  464,
+
+      463,  822,  823,  464,  465,  462,  824,  461,  465,  464,
+      463,  826,  465,  466,    0,  827,    0,  466,  465,  464,
+      828,  829,  468,  466,  468,  469,  464,  469,  465,  468,
+      464,  465,  469,  466,  468,  465,  464,  469,    0,  465,
+      466,  467,    0,  467,  466,  465,  464,  467,  829,  468,
+      466,  468,  469,  467,  469,  465,  468,  830,  831,  469,
+      466,  468,    0,  467,  469,  470,  833,  470,  467,  472,
+      467,  470,  470,  472,  467,  834,  471,  470,  471,  472,
+      467,  835,  836,  471,  830,  831,  837,  473,  471,  472,
+      467,  473,  470,  833,  470,  473,  472,    0,  470,  470,
+
+      472,  473,  834,  471,  470,  471,  472,  838,  835,  836,
+      471,  473,  839,  837,  473,  471,  472,  474,  473,  474,
+      840,  841,  473,  475,  474,    0,  842,  475,  473,  474,
+      843,  475,  476,  475,  838,  846,  476,    0,  473,  839,
+      476,  847,  476,  475,  474,  848,  474,  840,  841,    0,
+      475,  474,  476,  842,  475,    0,  474,  843,  475,  476,
+      475,    0,  846,  476,  477,  478,  477,  476,  847,  476,
+      475,  477,  848,    0,  849,  478,  477,  478,  850,  476,
+        0,  851,  478,    0,    0,  854,    0,  478,  479,    0,
+      479,  477,  478,  477,    0,  479,    0,  479,  477,    0,
+
+      479,  849,  478,  477,  478,  850,  481,  480,  851,  478,
+      481,  480,  854,  480,  478,  479,  481,  479,  480,  857,
+        0,  482,  479,  480,  479,  482,  481,  479,    0,  858,
+        0,  482,    0,  481,  480,  860,  482,  481,  480,  863,
+      480,  482,    0,  481,  866,  480,  857,  483,  482,  867,
+      480,  483,  482,  481,    0,  484,  858,  483,  482,  484,
+      483,  484,  860,  482,    0,  484,  863,  483,  482,  485,
+        0,  866,    0,  485,  483,  484,  867,  868,  483,  485,
+        0,  486,  484,  869,  483,  486,  484,  483,  484,  485,
+        0,  486,  484,  487,  483,  488,  485,  487,  870,  488,
+
+      485,  486,  484,  487,  868,  488,  485,  489,  486,  871,
+      869,  489,  486,  487,    0,  488,  485,  489,  486,  490,
+      487,    0,  488,  490,  487,  870,  488,  489,  486,  490,
+      487,  874,  488,  875,  489,  490,  871,    0,  489,  490,
+      487,  491,  488,  491,  489,  492,  490,  492,  491,    0,
+      490,  876,  492,  491,  489,    0,  490,  492,  874,    0,
+      875,  859,  490,  494,  859,    0,  490,  494,  491,  493,
+      491,  493,  492,  494,  492,  491,  493,  493,  876,  492,
+      491,  493,  495,  494,  492,  498,  495,  498,  859,  498,
+      494,  859,  495,    0,  494,  498,  493,    0,  493,  877,
+
+      494,  878,  495,  493,  493,  498,  496,  496,  493,  495,
+      494,  496,  498,  495,  498,  880,  498,  496,  881,  495,
+      501,  499,  498,  499,  501,  499,  877,  496,  878,  495,
+      501,  499,  498,  496,  496,  501,    0,  882,  496,    0,
+      501,  499,  880,  884,  496,  881,  885,  501,  499,    0,
+      499,  501,  499,  886,  496,  497,  500,  501,  499,  497,
+      500,    0,  501,  497,  882,  497,  500,  501,  499,  497,
+      884,  887,  500,  885,    0,  889,  500,    0,    0,  497,
+      886,  502,  497,  500,  503,  502,  497,  500,  503,  890,
+      497,  502,  497,  500,  503,  891,  497,  502,  887,  500,
+
+      892,  502,  889,  500,  503,  504,  497,  893,  502,  504,
+        0,  503,  502,  504,  894,  503,  890,    0,  502,  504,
+      895,  503,  891,  505,  502,  505,    0,  892,  502,  504,
+      505,  503,  504,  896,  893,  505,  504,  506,    0,  506,
+      504,  894,    0,  506,  506,  897,  504,  895,    0,  506,
+      505,  507,  505,  507,  899,  508,  504,  505,  507,  508,
+      896,    0,  505,  507,  506,  508,  506,    0,  900,  509,
+      506,  506,  897,  509,  901,  508,  506,    0,  507,  509,
+      507,  899,  508,    0,  510,  507,  508,  903,  510,  509,
+      507,  512,  508,  512,  510,  900,  509,  510,  512,    0,
+
+      509,  901,  508,  512,  510,    0,  509,  904,  905,    0,
+      516,  510,  516,    0,  903,  510,  509,  516,  512,    0,
+      512,  510,  516, 1008,  510,  512,  514,  514,  514,    0,
+      512,  510,  511,  514,  904,  905,  511,  516,  514,  516,
+      511, 1010,    0, 1012,  516, 1013,  511, 1014, 1015,  516,
+     1008,  511, 1017,  514,  514,  514,  511,    0, 1019,  511,
+      514, 1020, 1021,  511,  515,  514,    0,  511, 1010,  515,
+     1012,  515, 1013,  511, 1014, 1015,  515, 1022,  511, 1017,
+     1023,  515,  517,  511,  513, 1019,  517, 1025, 1020, 1021,
+        0,  515,  517,  513,    0,  513,  515,  513,  515, 1027,
+
+      513, 1029,  517,  515, 1022,  513,    0, 1023,  515,  517,
+        0,  513, 1032,  517, 1025, 1034,    0,  518,    0,  517,
+      513,  518,  513,    0,  513,  518, 1027,  513, 1029,  517,
+      519,  518,  513,  520,  519, 1035,  520,  520,    0, 1032,
+      519,  518, 1034,  520,  518,  519,    0,  521,  518,  521,
+      519,    0,  518,  520,  521, 1036,    0,  519,  518,  521,
+      520,  519, 1035,  520,  520,  523,    0,  519,  518,  523,
+      520,  522,  519,  522,  521,  523,  521,  519,  522, 1037,
+      520,  521, 1036,  522,  524,  523,  521,  525,  524,  526,
+     1044,  525,  523,  526,  524, 1045,  523,  525,  522,  526,
+
+      522,  530,  523,  530,  524,  522, 1037,  525,  530,  526,
+      522,  524,  523,  530,  525,  524,  526, 1044,  525,  527,
+      526,  524, 1045,  527,  525, 1046,  526, 1049,  530,  527,
+      530,  524,  527,  528,  525,  530,  526,  528,  529,  527,
+      530, 1051,  529,  528, 1053, 1055,  527, 1056,  529,  529,
+      527,  528, 1046,  528, 1049,  531,  527,  531,  529,  527,
+      528, 1057,  531,  531,  528,  529,  527,  531, 1051,  529,
+      528, 1053, 1055,    0, 1056,  529,  529,    0,  528,  532,
+      528,  532,  531, 1058,  531,  529,  532,  532, 1057,  531,
+      531,  532, 1059,  533,  531,  533, 1060,  534, 1062,  534,
+
+      533,  534, 1063, 1064,  534,  533,  532, 1065,  532,  534,
+     1058,    0,    0,  532,  532,    0,    0,    0,  532, 1059,
+      533,    0,  533, 1060,  534, 1062,  534,  533,  534, 1063,
+     1064,  534,  533,  535, 1065,  535,  534,  536,  537,  536,
+      535,  535,  537,  538,  536,  535, 1067,  538,  537,  536,
+        0, 1069,    0,  538, 1071, 1072, 1073,    0,  537,    0,
+      535, 1074,  535,  538,  536,  537,  536,  535,  535,  537,
+      538,  536,  535, 1067,  538,  537,  536,  539, 1069,  539,
+      538, 1071, 1072, 1073,  539,  537,  540,  541, 1074,  539,
+      538,  541,    0,  540, 1075,  540,    0,  541, 1080, 1081,
+
+      540, 1162,    0, 1166,  539,  540,  539,  541, 1167, 1170,
+        0,  539,    0,  540,  541,    0,  539, 1171,  541,  542,
+      540, 1075,  540,  542,  541, 1080, 1081,  540, 1162,  542,
+     1166,  542,  540,  543,  541, 1167, 1170,  543,    0,  542,
+      545,  544,  545,  543, 1171,  544,  542,  545,    0,  544,
+      542, 1172,  545,  543,    0,  544,  542,    0,  542,    0,
+      543,    0,    0,    0,  543,  544,  542,  545,  544,  545,
+      543,    0,  544, 1176,  545,  547,  544, 1179, 1172,  545,
+      543,  546,  544,  546,  547, 1180,  547,  548,  546,  548,
+      546,  547,  544,  546,  548,    0,  547,    0,  548,  548,
+
+     1176, 1183,  547,    0, 1179, 1184,    0,    0,  546,    0,
+      546,  547, 1180,  547,  548,  546,  548,  546,  547, 1185,
+      546,  548,  549,  547,  549,  548,  548, 1186, 1183,  549,
+      549,  550, 1184,  550,  549, 1189,  551,  550,  550,    0,
+      551,    0,  551,  550, 1190,    0, 1185,  551,    0,  549,
+        0,  549,  551, 1191, 1186,    0,  549,  549,  550,    0,
+      550,  549, 1189,  551,  550,  550,  552,  551,  552,  551,
+      550, 1190,  552,  552,  551,  682, 1194,  682,  552,  551,
+     1191,  682,  682,    0,  683, 1196,  683,  682,    0,    0,
+      683,  683,    0,  552, 1197,  552,  683,    0,    0,  552,
+
+      552,    0,  682, 1194,  682,  552,  684,    0,  682,  682,
+      684,  683, 1196,  683,  682,  685,  684,  683,  683,  685,
+     1198, 1197,  687,  683,  687,  685,  684, 1199,  686,  687,
+     1200, 1250,  686,  684,  687,  685, 1253,  684,  686,    0,
+      688,  686,  685,  684,  688,    0,  685, 1198,  686,  687,
+      688,  687,  685,  684, 1199,  686,  687, 1200, 1250,  686,
+      688,  687,  685, 1253, 1257,  686,  690,  688,  686,    0,
+      690,  688,  689,    0,  689,  686,  690,  688,  691,  689,
+     1258,    0,  691,    0,  689,    0,  690,  688,  691, 1261,
+     1262, 1257, 1263,  690, 1264,    0,  692,  690,  691,  689,
+
+      692,  689, 1268,  690,  692,  691,  689, 1258,  693,  691,
+      692,  689,  693,  690, 1269,  691, 1261, 1262,  693, 1263,
+      692, 1264,  694,  692, 1270,  691,  694,  692,  693, 1268,
+      695,  692,  694,    0,  695,  693, 1272,  692,  695,  693,
+     1299, 1269,  694,    0,  695,  693, 1300,  692,  696,  694,
+     1303, 1270,  696,  694,  695,  693,  696,  695,  696,  694,
+      697,  695, 1306, 1272,  697,  695, 1309, 1299,  696,  694,
+      697,  695,    0, 1300,  699,  696,    0, 1303,  699,  696,
+      697,  695,    0,  696,  699,  696,  698,  697,  700, 1306,
+      698,  697,  700, 1309,  699,  696,  698,  697,  700,  698,
+
+     1313,  699,  701,  700,  701,  699,  698,  697,  700,  701,
+     1327,  699,  702,  698,  701,  700,  702,  698,    0,  700,
+        0,  699,  702,  698,  704,  700,  698, 1313,  704,  701,
+      700,  701,  702,  698,  704,  700,  701, 1327,  703,  702,
+        0,  701,  703,  702,  704,  705,    0,  705,  703,  702,
+      712,  704,  705,  703,  712,  704,    0,  705,  703,  702,
+      712,  704,    0, 1251, 1251,  703,  706,  706,  706,  703,
+      712,  704,  705,  706,  705,  703,    0,  712,  706,  705,
+      703,  712, 1326, 1326,  705,  703, 1331,  712, 1334,  707,
+     1340,  707, 1344,  706,  706,  706,  707,  712,  707,    0,
+
+      706,  707,  708, 1251,  708,  706, 1333, 1333, 1348,  708,
+      708, 1275, 1275, 1331,  708, 1334,  707, 1340,  707, 1344,
+        0,  709,    0,  707,    0,  707, 1326, 1350,  707,  708,
+     1251,  708,  709,    0,  709, 1348,  708,  708,    0,  709,
+      710,  708,  710,    0,  709, 1352,  710,  710,  709,  711,
+     1333, 1275,  710, 1326, 1350,    0,    0,    0,  711,  709,
+      711,  709,    0, 1354, 1356,  711,  709,  710, 1358,  710,
+      711,  709, 1352,  710,  710,    0,  711, 1333, 1275,  710,
+        0,  713,  714,  713,  714,  711, 1360,  711,  713,  714,
+     1354, 1356,  711,  713,  714, 1358, 1362,  711, 1364,    0,
+
+      715,    0,  715, 1366,    0,    0,    0,  715,  713,  714,
+      713,  714,  715, 1360,    0,  713,  714,    0,  716,    0,
+      713,  714,    0, 1362,    0, 1364,  716,  715,  716,  715,
+     1366,    0,    0,  716,  715,    0,    0,    0,  716,  715,
+      717,    0,  717,    0,  717,  716,    0,  717,    0,    0,
+        0,    0,  717,  716,  718,  716,  718,    0,  718,    0,
+      716,  718,    0,    0,    0,  716,  718,  717,  719,  717,
+      719,  717,    0,    0,  717,  719,    0,  719,    0,  717,
+      719,  718,  720,  718,  720,  718,    0,  721,  718,  720,
+      720,    0,    0,  718,  720,  719,    0,  719,  721,    0,
+
+      721,    0,  719,    0,  719,  721,    0,  719,  723,  720,
+      721,  720,  723,  722,  721,    0,  720,  720,  723,    0,
+        0,  720,    0,    0,  722,  721,  722,  721,  723,    0,
+        0,  722,  721,    0,  724,  723,  722,  721,  724,  723,
+      722,    0,  725,    0,  724,  723,  725,    0,    0,    0,
+        0,  722,  725,  722,  724,  723,  726,  725,  722,    0,
+      726,  724,  725,  722,    0,  724,  726,    0,  727,  725,
+        0,  724,  727,  725,    0,    0,  726,    0,  727,  725,
+        0,  724,  728,  726,  725,    0,  728,  726,  727,  725,
+      728,    0,    0,  726,  729,  727,  728,    0,  729,  727,
+
+        0,    0,    0,  726,  729,  727,  728,    0,  730,  728,
+        0,    0,  730,  728,  729,  727,  731,  728,  730,    0,
+      731,  729,    0,  728,  731,  729,    0,    0,  730,    0,
+      731,  729,    0,  728,    0,  730,    0,    0,  732,  730,
+      731,  729,  732,  731,    0,  730,  733,  731,  732,  732,
+      733,  731,  734,    0,  734,  730,  733,  731,  732,  734,
+        0,    0,    0,    0,  734,  732,  733,  731,    0,  732,
+        0,    0,    0,  733,  737,  732,  732,  733,  737,  734,
+      735,  734,  735,  733,  737,  732,  734,  735,  736,    0,
+      736,  734,  735,  733,  737,  736,  739,    0,  739,    0,
+
+      736,  737,    0,  739,    0,  737,    0,  735,  739,  735,
+        0,  737,    0,    0,  735,  736,  738,  736,    0,  735,
+      738,  737,  736,  739,    0,  739,  738,  736,    0,  738,
+      739,    0,  740,    0,  740,  739,  738,    0,  740,  740,
+        0,    0,    0,  738,  740,    0,    0,  738,  741,    0,
+      741,    0,    0,  738,  741,  741,  738,    0,    0,  740,
+      741,  740,  743,  738,  743,  740,  740,    0,    0,  743,
+        0,  740,    0,    0,  743,  741,    0,  741,    0,    0,
+        0,  741,  741,    0,    0,    0,    0,  741,  742,  743,
+      744,  743,  744,  742,    0,  742,  743,  744,    0,  742,
+
+      742,  743,  744,    0,  745,  742,  745,    0,    0,    0,
+        0,  745,    0,    0,    0,  742,  745,  744,    0,  744,
+      742,    0,  742,  746,  744,  746,  742,  742,    0,  744,
+      746,  745,  742,  745,  747,  746,  747,  748,  745,  748,
+        0,  747,    0,  745,  748,  748,  747,    0,    0,  748,
+      746,    0,  746,  749,    0,  749,    0,  746,    0,    0,
+      749,  747,  746,  747,  748,  749,  748,  750,  747,  750,
+        0,  748,  748,  747,  750,    0,  748,    0,    0,  750,
+      749,    0,  749,    0,    0,  751,    0,  749,    0,  751,
+        0,    0,  749,  752,  750,  751,  750,  752,  753,    0,
+
+        0,  750,  753,  752,    0,  751,  750,  754,  753,  754,
+        0,    0,  751,  752,  754,  754,  751,  755,  753,  754,
+      752,  755,  751,  755,  752,  753,    0,    0,  755,  753,
+      752,    0,  751,  755,  754,  753,  754,    0,    0,    0,
+      752,  754,  754,    0,  755,  753,  754,  756,  755,  756,
+      755,    0,  757,  756,  756,  755,  757,  758,    0,  756,
+      755,  758,  757,  759,    0,  759,  779,  758,  779,  759,
+        0,    0,  757,  779,  756,  759,  756,  758,  779,  757,
+      756,  756,    0,  757,  758,  759,  756,  760,  758,  757,
+      759,  760,  759,  779,  758,  779,  759,  760,    0,  757,
+
+      779,    0,  759,    0,  758,  779,  761,  760,    0,    0,
+      761,    0,  759,    0,  760,    0,  761,    0,  760,  761,
+      784,    0,  784,    0,  760,  762,  761,  784,    0,  762,
+        0,    0,  784,  761,  760,  762,    0,  761,  762,    0,
+      763,    0,    0,  761,  763,  762,  761,  784,    0,  784,
+      763,    0,  762,  761,  784,    0,  762,    0,    0,  784,
+      763,    0,  762,    0,    0,  762,  764,  763,    0,  765,
+      764,  763,  762,  765,  764,    0,  764,  763,  766,  765,
+        0,    0,  766,    0,    0,    0,  764,  763,  766,  765,
+        0,    0,    0,  764,    0,    0,  765,  764,  766,    0,
+
+      765,  764,    0,  764,  767,  766,  765,    0,  767,  766,
+        0,    0,    0,  764,  767,  766,  765,    0,  768,  769,
+        0,    0,  768,  769,  767,  766,  768,  769,    0,    0,
+        0,  767,  768,  769,    0,  767,    0,    0,    0,    0,
+        0,  767,  768,  769,    0,  768,  769,    0,  770,  768,
+      769,  767,  770,  768,  769,    0,    0,  771,  770,  768,
+      769,  771,    0,    0,    0,    0,    0,  771,  770,  768,
+      769,    0,    0,    0,    0,  770,  772,  771,    0,  770,
+      772,    0,    0,    0,  771,  770,  772,    0,  771,  772,
+        0,    0,    0,    0,  771,  770,  772,    0,  773,    0,
+
+        0,  774,  773,  772,  771,  774,  773,  772,  773,    0,
+        0,  774,    0,  772,  774,    0,  772,    0,  773,    0,
+        0,  774,    0,  772,    0,  773,    0,  775,  774,  773,
+      777,  775,  774,  773,  777,  773,  776,  775,  774,  776,
+      777,  774,  775,  776,    0,  773,    0,  775,  774,  776,
+      777,    0,  778,    0,  775,    0,  778,  777,  775,  776,
+      778,  777,  778,  776,  775,    0,  776,  777,    0,  775,
+      776,    0,  778,    0,  775,    0,  776,  777,  781,  778,
+        0,  780,  781,  778,    0,    0,  776,  778,  781,  778,
+      780,  782,  780,    0,    0,  782,  783,  780,  781,  778,
+
+      783,  782,  780,    0,    0,  781,  783,    0,  780,  781,
+      785,  782,    0,    0,  785,  781,  783,  780,  782,  780,
+      785,    0,  782,  783,  780,  781,    0,  783,  782,  780,
+      785,    0,  786,  783,    0,  787,  786,  785,  782,  787,
+      788,  785,  786,  783,  788,  787,    0,  785,    0,    0,
+      788,    0,  786,    0,  789,  787,    0,  785,  789,  786,
+      788,    0,  787,  786,  789,    0,  787,  788,    0,  786,
+        0,  788,  787,    0,  789,    0,  790,  788,    0,  786,
+      790,  789,  787,    0,    0,  789,  790,  788,  791,    0,
+      791,  789,  792,    0,  792,  791,  790,    0,    0,  792,
+
+      791,  789,    0,  790,  792,    0,    0,  790,    0,    0,
+        0,    0,    0,  790,    0,  791,    0,  791,  793,  792,
+      793,  792,  791,  790,    0,  793,  792,  791,  794,    0,
+      793,  792,    0,    0,  795,    0,  795,  794,  801,  794,
+        0,  795,  801,  795,  794,  793,  795,  793,  801,  794,
+        0,    0,  793,    0,    0,  794,    0,  793,  801,    0,
+      796,  795,  796,  795,  794,  801,  794,  796,  795,  801,
+      795,  794,  796,  795,    0,  801,  794,    0,    0,  797,
+        0,  797,  798,    0,    0,  801,  797,  796,  797,  796,
+      799,  797,  799,  798,  796,  798,    0,  799,  799,  796,
+
+      798,    0,  799,    0,    0,  798,  797,    0,  797,  798,
+        0,    0,    0,  797,    0,  797,  800,  799,  797,  799,
+      798,  800,  798,  800,  799,  799,  803,  798,  800,  799,
+      803,  802,  798,  800,  802,  802,  803,    0,    0,    0,
+        0,  802,    0,  800,    0,    0,  803,    0,  800,    0,
+      800,  802,    0,  803,    0,  800,    0,  803,  802,    0,
+      800,  802,  802,  803,    0,  804,  805,  806,  802,  804,
+      805,  806,    0,  803,    0,  804,  805,  806,  802,  807,
+        0,  804,    0,  807,    0,  804,  805,  806,  808,  807,
+      808,    0,  804,  805,  806,  808,  804,  805,  806,  807,
+
+      808,    0,  804,  805,  806,    0,  807,    0,  804,    0,
+      807,    0,  804,  805,  806,  808,  807,  808,  909,    0,
+      909,  910,  808,  910,    0,  909,  807,  808,  910,  911,
+      909,  911,  912,  910,  912,    0,  911,    0,    0,  912,
+        0,  911,    0,  911,  912,  909,    0,  909,  910,    0,
+      910,    0,  909,    0,    0,  910,  911,  909,  911,  912,
+      910,  912,    0,  911,    0,  913,  912,    0,  911,  913,
+      911,  912,    0,  914,  915,  913,    0,  914,  915,    0,
+        0,    0,    0,  914,  915,  913,    0,    0,    0,    0,
+        0,    0,  913,  914,  915,    0,  913,    0,    0,  916,
+
+      914,  915,  913,  916,  914,  915,    0,    0,    0,  916,
+      914,  915,  913,    0,  916,    0,    0,  918,  918,  916,
+      914,  915,  918,  917,    0,    0,  916,  917,  918,    0,
+      916,  917,    0,    0,    0,    0,  916,  917,  918,    0,
+        0,  916,    0,    0,  918,  918,  916,  917,    0,  918,
+      917,  919,    0,  919,  917,  918,    0,  919,  917,  920,
+      921,  920,  921,  919,  917,  918,  920,  921,  921,    0,
+        0,  920,  921,  919,  917,    0,    0,    0,  919,    0,
+      919,  922,    0,    0,  919,  922,  920,  921,  920,  921,
+      919,  922,    0,  920,  921,  921,    0,    0,  920,  921,
+
+      919,  922,    0,  923,  925,  924,  925,  923,  922,  924,
+        0,  925,  922,  923,    0,  924,  925,  926,  922,    0,
+        0,  926,    0,  923,    0,  924,    0,  926,  922,    0,
+      923,  925,  924,  925,  923,  927,  924,  926,  925,  927,
+      923,    0,  924,  925,  926,  927,    0,    0,  926,  928,
+      923,    0,  924,  928,  926,  927,    0,  928,  929,    0,
+      929,    0,  927,  928,  926,  929,  927,    0,    0,    0,
+      929,  930,  927,  928,    0,  930,  928,    0,    0,  931,
+      928,  930,  927,  931,  928,  929,    0,  929,    0,  931,
+      928,  930,  929,    0,    0,    0,    0,  929,  930,  931,
+
+      928,  932,  930,    0,    0,  932,  931,    0,  930,  933,
+      931,  932,    0,  933,    0,  934,  931,  934,  930,  933,
+        0,  932,  934,    0,  933,    0,  931,  934,  932,  933,
+        0,    0,  932,  935,    0,  936,  933,  935,  932,  936,
+      933,    0,  934,  935,  934,  936,  933,    0,  932,  934,
+        0,  933,    0,  935,  934,  936,  933,  937,    0,  938,
+      935,  937,  936,  938,  935,    0,  936,  937,    0,  938,
+      935,    0,  936,    0,  938,    0,    0,  937,    0,  938,
+      935,    0,  936,  939,  937,    0,  938,  939,  937,    0,
+      938,    0,    0,  939,  937,  940,  938,  940,  939,    0,
+
+        0,  938,  940,  939,  937,    0,  938,  940,  941,  942,
+      939,  942,  941,  943,  939,  942,    0,  943,  941,    0,
+      939,  942,  940,  943,  940,  939,    0,    0,  941,  940,
+      939,  942,    0,  943,  940,  941,  942,  944,  942,  941,
+      943,  944,  942,    0,  943,  941,    0,  944,  942,  945,
+      943,    0,  946,  945,  946,  941,  946,  944,  942,  945,
+      943,    0,  946,  948,  944,  948,    0,  945,  944,  945,
+      948,    0,  946,    0,  944,  948,  945,    0,  947,  946,
+      945,  946,  947,  946,  944,    0,  945,    0,  947,  946,
+      948,    0,  948,  947,  945,    0,  945,  948,  947,  946,
+
+        0,  949,  948,  949,  951,  947,  951,  950,  949,  947,
+        0,  951,  950,  949,  950,  947,  951,    0,    0,  950,
+      947,    0,    0,    0,  950,  947,    0,    0,  949,    0,
+      949,  951,    0,  951,  950,  949,    0,    0,  951,  950,
+      949,  950,  952,  951,  952,  953,  950,  953,  954,  952,
+      954,  950,  953,  953,  952,  954,  955,  953,  955,    0,
+      954,    0,    0,  955,    0,    0,    0,    0,  955,  952,
+        0,  952,  953,    0,  953,  954,  952,  954,    0,  953,
+      953,  952,  954,  955,  953,  955,  956,  954,  956,    0,
+      955,    0,  957,  956,  956,  955,  957,  958,  956,  958,
+
+        0,    0,  957,    0,  958,    0,    0,  958,    0,  958,
+        0,    0,  957,  956,    0,  956,    0,    0,    0,  957,
+      956,  956,    0,  957,  958,  956,  958,    0,  959,  957,
+      959,  958,    0,    0,  958,  959,  958,    0,    0,  957,
+      959,  960,  961,  960,  961,    0,    0,    0,  960,  961,
+        0,    0,    0,  960,  961,  959,    0,  959,    0,    0,
+        0,    0,  959,    0,  962,    0,    0,  959,  960,  961,
+      960,  961,  962,    0,  962,  960,  961,    0,    0,  962,
+      960,  961,    0,  963,  962,  963,  964,    0,  964,    0,
+      963,  962,    0,  964,    0,  963,    0,    0,  964,  962,
+
+        0,  962,    0,    0,  965,    0,  962,    0,  965,    0,
+      963,  962,  963,  964,  965,  964,  966,  963,  966,  967,
+      964,    0,  963,  966,  965,  964,    0,    0,  966,    0,
+      967,  965,  967,    0,    0,  965,    0,  967,    0,    0,
+        0,  965,  967,  966,    0,  966,  967,    0,    0,    0,
+      966,  965,    0,    0,  968,  966,  968,  967,    0,  967,
+        0,  968,  968,  970,  967,  970,  968,    0,  969,  967,
+      970,  970,  969,    0,  969,  970,    0,    0,    0,  969,
+        0,  968,    0,  968,  969,    0,    0,    0,  968,  968,
+      970,    0,  970,  968,    0,  969,    0,  970,  970,  969,
+
+        0,  969,  970,  971,    0,  971,  969,  972,  973,  972,
+      971,  969,  973,    0,  972,  971,    0,    0,  973,  972,
+        0,    0,    0,  974,    0,    0,    0,  974,  973,    0,
+      971,    0,  971,  974,  972,  973,  972,  971,  974,  973,
+        0,  972,  971,  974,    0,  973,  972,  975,  975,  976,
+      974,    0,  975,  976,  974,  973,    0,    0,  975,  976,
+      974,    0,  976,    0,    0,  974,    0,    0,  975,  976,
+      974,    0,    0,    0,  975,  975,  976,  977,  978,  975,
+      976,  977,  978,    0,    0,  975,  976,  977,  978,  976,
+      977,    0,    0,    0,    0,  975,  976,  977,  978,    0,
+
+        0,    0,  979,  980,  977,  978,  979,  980,  977,  978,
+        0,    0,  979,  980,  977,  978,  981,  977,    0,    0,
+      981,    0,  979,  980,  977,  978,  981,  983,  982,  979,
+      980,  983,  982,  979,  980,  983,  981,    0,  982,  979,
+      980,  983,    0,  981,    0,    0,    0,  981,  982,  979,
+      980,  983,  984,  981,  983,  982,  984,  986,  983,  982,
+      984,  986,  983,  981,    0,  982,  984,  986,  983,  985,
+      985,    0,  986,    0,  985,  982,  984,  986,  983,  984,
+      985,    0,  987,  984,  986,  988,  987,  984,  986,  988,
+      985,    0,  987,  984,  986,  988,  985,  985,    0,  986,
+
+        0,  985,  987,  984,  986,  988,    0,  985,    0,  987,
+      989,  989,  988,  987,    0,  989,  988,  985,    0,  987,
+      990,  989,  988,  991,  990,  991,    0,    0,  990,  987,
+      991,  989,  988,    0,  990,  991,    0,  989,  989,    0,
+        0,    0,  989,    0,  990,    0,    0,  990,  989,    0,
+      991,  990,  991,    0,    0,  990,    0,  991,  989,    0,
+        0,  990,  991,  992,    0,  992,  993,    0,  993,  992,
+      992,  990,    0,  993,  993,  992,  994,    0,  993,  996,
+        0,  996,    0,    0,    0,    0,  996,  994,    0,  994,
+      992,  996,  992,  993,  994,  993,  992,  992,    0,  994,
+
+      993,  993,  992,  994,  995,  993,  996,    0,  996,    0,
+        0,    0,    0,  996,  994,  995,  994,  995,  996,    0,
+        0,  994,  995,  997,    0,  997,  994,  995,  998,    0,
+      997,  995,  998, 1000,    0,  997,    0, 1000,  998,    0,
+      999,  999,  995, 1000,  995,  999,    0,    0,  998,  995,
+      997,  999,  997, 1000,  995,  998,    0,  997,    0,  998,
+     1000,  999,  997,    0, 1000,  998,    0,  999,  999, 1001,
+     1000,    0,  999, 1001, 1002,  998, 1002,    0,  999, 1001,
+     1000, 1002,    0,    0, 1003,    0, 1002,    0,  999, 1001,
+        0,    0,    0,    0,    0, 1003, 1001, 1003,    0,    0,
+
+     1001, 1002, 1003, 1002,    0,    0, 1001, 1003, 1002,    0,
+     1004, 1003,    0, 1002,    0,    0, 1001,    0, 1005,    0,
+     1005, 1004, 1003, 1004, 1003, 1005,    0,    0, 1004, 1003,
+     1005,    0,    0, 1004, 1003,    0,    0, 1004,    0, 1006,
+        0, 1006,    0,    0,    0, 1005, 1006, 1005, 1004, 1083,
+     1004, 1006, 1005, 1083, 1084, 1004,    0, 1005, 1084, 1083,
+     1004,    0,    0, 1085, 1084, 1085, 1006,    0, 1006, 1083,
+     1085,    0,    0, 1006, 1084, 1085, 1083, 1086, 1006, 1086,
+     1083, 1084,    0,    0, 1086, 1084, 1083,    0,    0, 1086,
+     1085, 1084, 1085, 1087,    0, 1087, 1083, 1085,    0, 1088,
+
+     1087, 1084, 1085, 1088, 1086, 1087, 1086,    0, 1089, 1088,
+        0, 1086, 1089,    0,    0,    0, 1086,    0, 1089, 1088,
+     1087,    0, 1087, 1089,    0,    0, 1088, 1087, 1089,    0,
+     1088, 1090, 1087, 1090,    0, 1089, 1088,    0, 1090, 1089,
+     1091,    0, 1091, 1090,    0, 1089, 1088, 1091,    0, 1092,
+     1089, 1092, 1091,    0,    0, 1089, 1092,    0, 1090,    0,
+     1090, 1092,    0,    0,    0, 1090,    0, 1091,    0, 1091,
+     1090,    0,    0, 1093, 1091, 1093, 1092,    0, 1092, 1091,
+     1093,    0, 1094, 1092, 1094, 1093,    0,    0, 1092, 1094,
+     1094, 1095, 1095, 1095, 1094,    0,    0,    0, 1095,    0,
+
+     1093,    0, 1093, 1095,    0,    0,    0, 1093,    0, 1094,
+        0, 1094, 1093, 1096,    0,    0, 1094, 1094, 1095, 1095,
+     1095, 1094, 1096,    0, 1096, 1095, 1097,    0, 1097, 1096,
+     1095,    0,    0, 1097, 1096, 1098,    0, 1098, 1097,    0,
+     1096,    0, 1098, 1098,    0,    0,    0, 1098,    0, 1096,
+        0, 1096,    0, 1097,    0, 1097, 1096,    0,    0,    0,
+     1097, 1096, 1098,    0, 1098, 1097, 1099, 1100, 1099, 1098,
+     1098,    0,    0, 1099, 1098,    0,    0, 1100, 1099, 1100,
+     1101,    0, 1101,    0, 1100,    0,    0, 1101,    0, 1100,
+        0,    0, 1101, 1099, 1100, 1099,    0,    0,    0, 1102,
+
+     1099,    0,    0,    0, 1100, 1099, 1100, 1101, 1102, 1101,
+     1102, 1100,    0,    0, 1101, 1102, 1100,    0,    0, 1101,
+     1102, 1103, 1104, 1103, 1104,    0, 1102,    0, 1103, 1104,
+        0,    0,    0, 1103, 1104, 1102,    0, 1102,    0,    0,
+        0,    0, 1102,    0,    0,    0,    0, 1102, 1103, 1104,
+     1103, 1104, 1105,    0, 1105, 1103, 1104,    0, 1107, 1105,
+     1103, 1104, 1107, 1106, 1105, 1106,    0, 1108, 1107,    0,
+     1106, 1108,    0,    0,    0, 1106,    0, 1108, 1107, 1105,
+        0, 1105,    0,    0,    0, 1107, 1105, 1108,    0, 1107,
+     1106, 1105, 1106,    0, 1108, 1107,    0, 1106, 1108, 1109,
+
+        0, 1109, 1106, 1111, 1108, 1107, 1109, 1111, 1110,    0,
+     1110, 1109,    0, 1111, 1108, 1110, 1110, 1112,    0, 1112,
+     1110,    0,    0, 1111, 1112,    0, 1109,    0, 1109, 1112,
+     1111,    0,    0, 1109, 1111, 1110,    0, 1110, 1109,    0,
+     1111,    0, 1110, 1110, 1112,    0, 1112, 1110,    0,    0,
+     1111, 1112, 1113, 1114, 1113, 1114, 1112,    0,    0, 1113,
+     1114, 1115,    0, 1115, 1113, 1114,    0,    0, 1115,    0,
+        0,    0,    0, 1115,    0,    0,    0,    0,    0, 1113,
+     1114, 1113, 1114,    0,    0,    0, 1113, 1114, 1115,    0,
+     1115, 1113, 1114,    0, 1116, 1115, 1116, 1117,    0, 1117,
+
+     1115, 1116,    0, 1118, 1117, 1118, 1116,    0,    0, 1117,
+     1118,    0,    0,    0,    0, 1118,    0,    0,    0,    0,
+        0, 1116,    0, 1116, 1117,    0, 1117,    0, 1116,    0,
+     1118, 1117, 1118, 1116,    0,    0, 1117, 1118, 1119, 1120,
+     1119,    0, 1118, 1120, 1119, 1119,    0,    0,    0, 1120,
+     1119,    0,    0, 1122, 1121,    0,    0, 1122, 1121, 1120,
+        0,    0, 1121, 1122,    0, 1119, 1120, 1119, 1121,    0,
+     1120, 1119, 1119, 1122,    0,    0, 1120, 1119, 1121,    0,
+     1122, 1121,    0, 1123, 1122, 1121, 1120, 1123,    0, 1121,
+     1122,    0, 1124, 1123, 1124, 1121,    0,    0,    0, 1124,
+
+     1122,    0,    0, 1123, 1124, 1121, 1125,    0, 1125,    0,
+     1123,    0,    0, 1125, 1123, 1126,    0, 1126, 1125, 1124,
+     1123, 1124, 1126,    0,    0,    0, 1124, 1126,    0,    0,
+     1123, 1124,    0, 1125, 1127, 1125, 1127, 1128,    0,    0,
+     1125, 1127, 1126,    0, 1126, 1125, 1127,    0, 1128, 1126,
+     1128,    0,    0,    0, 1126, 1128,    0,    0,    0,    0,
+     1128, 1127,    0, 1127, 1128,    0,    0, 1129, 1127, 1129,
+        0,    0,    0, 1127, 1129, 1128, 1130, 1128, 1130, 1129,
+        0,    0, 1128, 1130, 1130,    0,    0, 1128, 1130, 1131,
+        0,    0,    0, 1131, 1129,    0, 1129,    0, 1132, 1131,
+
+        0, 1129, 1132, 1130,    0, 1130, 1129,    0, 1132, 1131,
+     1130, 1130, 1135, 1133, 1135, 1130, 1131, 1133, 1132, 1135,
+     1131,    0,    0, 1133, 1135, 1132, 1131, 1134,    0, 1132,
+        0, 1134,    0, 1133,    0, 1132, 1131, 1134,    0, 1135,
+     1133, 1135,    0,    0, 1133, 1132, 1135, 1134,    0,    0,
+     1133, 1135, 1137,    0, 1134, 1136,    0, 1136, 1134,    0,
+     1133, 1137, 1136, 1137, 1134,    0,    0, 1136, 1137,    0,
+        0,    0,    0, 1137, 1134,    0, 1138,    0,    0, 1137,
+        0,    0, 1136,    0, 1136, 1138,    0, 1138, 1137, 1136,
+     1137,    0, 1138,    0, 1136, 1137,    0, 1138,    0, 1139,
+
+     1137, 1139,    0, 1138,    0,    0, 1139,    0, 1140,    0,
+     1140, 1139, 1138,    0, 1138, 1140,    0,    0,    0, 1138,
+     1140,    0,    0,    0, 1138,    0, 1139, 1141, 1139, 1141,
+        0,    0,    0, 1139, 1141, 1140,    0, 1140, 1139, 1141,
+        0, 1142, 1140, 1142,    0,    0,    0, 1140, 1142,    0,
+     1143,    0, 1143, 1142, 1141,    0, 1141, 1143,    0,    0,
+        0, 1141, 1143,    0,    0,    0, 1141,    0, 1142, 1144,
+     1142, 1144,    0,    0,    0, 1142, 1144, 1143,    0, 1143,
+     1142, 1144,    0, 1145, 1143, 1145, 1146,    0,    0, 1143,
+     1145,    0,    0,    0,    0, 1145, 1144, 1146, 1144, 1146,
+
+        0,    0,    0, 1144, 1146, 1147,    0,    0, 1144, 1146,
+     1145,    0, 1145, 1146,    0,    0, 1147, 1145, 1147,    0,
+        0,    0, 1145, 1147, 1146,    0, 1146,    0, 1147,    0,
+     1148, 1146, 1147,    0,    0,    0, 1146,    0,    0, 1148,
+     1149, 1148, 1149, 1147,    0, 1147, 1148, 1149, 1149,    0,
+     1147, 1148, 1149,    0,    0, 1147,    0, 1148,    0,    0,
+        0,    0, 1150,    0,    0,    0, 1148, 1149, 1148, 1149,
+     1150,    0, 1150, 1148, 1149, 1149,    0, 1150, 1148, 1149,
+        0, 1151, 1150, 1151, 1152,    0, 1152,    0, 1151, 1150,
+        0, 1152,    0, 1151,    0,    0, 1152, 1150,    0, 1150,
+
+     1153,    0, 1153,    0, 1150,    0,    0, 1153, 1151, 1150,
+     1151, 1152, 1153, 1152, 1154, 1151, 1154,    0, 1152,    0,
+     1151, 1154,    0, 1152,    0,    0, 1154, 1153,    0, 1153,
+     1155,    0, 1155, 1156, 1153, 1156, 1155, 1155,    0, 1153,
+     1156, 1154, 1155, 1154, 1204, 1156, 1204,    0, 1154,    0,
+        0, 1204,    0, 1154,    0,    0, 1204, 1155,    0, 1155,
+     1156,    0, 1156, 1155, 1155,    0,    0, 1156, 1205, 1155,
+     1205, 1204, 1156, 1204, 1206, 1205, 1206, 1207, 1204, 1207,
+     1205, 1206,    0, 1204, 1207,    0, 1206,    0,    0, 1207,
+     1208,    0, 1211, 1211, 1208, 1205,    0, 1205,    0,    0,
+
+     1208, 1206, 1205, 1206, 1207, 1209, 1207, 1205, 1206, 1209,
+     1208, 1207,    0, 1206, 1210, 1209, 1207, 1208, 1210, 1211,
+        0, 1208,    0, 1211, 1210, 1209,    0, 1208,    0, 1211,
+        0,    0, 1209,    0, 1210,    0, 1209, 1208,    0, 1211,
+     1213, 1210, 1209, 1212, 1213, 1210, 1211, 1212, 1213,    0,
+     1211, 1210, 1209, 1212, 1213,    0, 1211,    0, 1214,    0,
+        0, 1210, 1214, 1212, 1213,    0, 1211, 1213, 1214,    0,
+     1212, 1213, 1215, 1216, 1212, 1213, 1215, 1216, 1214,    0,
+     1212, 1213, 1215, 1216,    0, 1214,    0,    0,    0, 1214,
+     1212, 1213, 1215, 1216,    0, 1214,    0, 1217, 1219, 1215,
+
+     1216, 1217, 1219, 1215, 1216, 1214,    0, 1217, 1219, 1215,
+     1216, 1218, 1217, 1218,    0, 1218,    0, 1217, 1219, 1215,
+     1216, 1218,    0, 1220, 1217, 1219, 1221, 1220, 1217, 1219,
+     1221, 1218,    0, 1220, 1217, 1219, 1221,    0, 1218, 1217,
+     1218,    0, 1218, 1220, 1217, 1219, 1221,    0, 1218, 1222,
+     1220, 1222,    0, 1221, 1220,    0, 1222, 1221, 1218,    0,
+     1220, 1222, 1223, 1221, 1223, 1224,    0, 1224,    0, 1223,
+     1220,    0, 1224, 1221, 1223,    0, 1222, 1224, 1222,    0,
+        0,    0,    0, 1222, 1225,    0,    0,    0, 1222, 1223,
+        0, 1223, 1224, 1225, 1224, 1225, 1223,    0,    0, 1224,
+
+     1225, 1223,    0,    0, 1224, 1225, 1226, 1227, 1226, 1227,
+        0, 1225,    0, 1226, 1227,    0,    0,    0, 1226, 1227,
+     1225,    0, 1225,    0,    0,    0,    0, 1225,    0,    0,
+        0,    0, 1225, 1226, 1227, 1226, 1227, 1228,    0, 1228,
+     1226, 1227,    0, 1230, 1228, 1226, 1227, 1230, 1229, 1228,
+     1229,    0, 1231, 1230, 1229, 1229, 1231,    0,    0,    0,
+     1229,    0, 1231, 1230, 1228,    0, 1228,    0,    0,    0,
+     1230, 1228, 1231,    0, 1230, 1229, 1228, 1229,    0, 1231,
+     1230, 1229, 1229, 1231, 1232,    0, 1232, 1229,    0, 1231,
+     1230, 1232,    0, 1233,    0, 1233, 1232,    0,    0, 1231,
+
+     1233,    0, 1234,    0, 1234, 1233,    0,    0,    0, 1234,
+        0, 1232,    0, 1232, 1234,    0,    0, 1235, 1232,    0,
+     1233,    0, 1233, 1232,    0,    0, 1235, 1233, 1235, 1234,
+        0, 1234, 1233, 1235,    0, 1236, 1234, 1236, 1235,    0,
+        0, 1234, 1236, 1236, 1235,    0,    0, 1236, 1237, 1237,
+        0, 1237,    0, 1235,    0, 1235, 1237,    0,    0,    0,
+     1235, 1237, 1236,    0, 1236, 1235,    0,    0,    0, 1236,
+     1236,    0,    0,    0, 1236, 1237, 1237, 1238, 1237, 1238,
+     1239,    0, 1239, 1237, 1238,    0,    0, 1239, 1237, 1238,
+        0, 1240, 1239, 1240,    0,    0,    0,    0, 1240, 1240,
+
+        0,    0,    0, 1240, 1238,    0, 1238, 1239,    0, 1239,
+     1241, 1238, 1241,    0, 1239,    0, 1238, 1241, 1240, 1239,
+     1240, 1242, 1241, 1242,    0, 1240, 1240, 1242, 1242,    0,
+     1240,    0,    0, 1242, 1243, 1243, 1243, 1241,    0, 1241,
+        0, 1243,    0,    0, 1241, 1244, 1243, 1244, 1242, 1241,
+     1242,    0, 1244, 1244, 1242, 1242,    0, 1244,    0,    0,
+     1242, 1243, 1243, 1243,    0, 1245, 1246, 1247, 1243, 1245,
+     1246, 1247, 1244, 1243, 1244, 1245, 1246, 1247,    0, 1244,
+     1244,    0,    0,    0, 1244, 1245, 1246, 1247,    0,    0,
+        0, 1248, 1245, 1246, 1247, 1248, 1245, 1246, 1247,    0,
+
+        0, 1248, 1245, 1246, 1247, 1276, 1274,    0,    0, 1276,
+     1274, 1248, 1245, 1246, 1247, 1276, 1274,    0, 1248, 1274,
+     1277,    0, 1248,    0, 1277, 1276, 1274,    0, 1248,    0,
+     1277,    0, 1276, 1274,    0, 1277, 1276, 1274, 1248,    0,
+     1277,    0, 1276, 1274, 1278, 1279, 1274, 1277, 1278, 1279,
+        0, 1277, 1276, 1274, 1278, 1279,    0, 1277,    0, 1280,
+        0,    0, 1277, 1280, 1278, 1279,    0, 1277,    0, 1280,
+        0, 1278, 1279,    0, 1282, 1278, 1279,    0, 1282, 1280,
+        0, 1278, 1279, 1281, 1282, 1281, 1280, 1281,    0, 1282,
+     1280, 1278, 1279, 1281, 1282,    0, 1280, 1286, 1283, 1286,
+
+        0, 1282, 1283, 1281, 1286, 1282, 1280,    0, 1283, 1286,
+     1281, 1282, 1281, 1284, 1281,    0, 1282, 1284, 1283,    0,
+     1281, 1282,    0, 1284, 1286, 1283, 1286,    0, 1285, 1283,
+     1281, 1286, 1285, 1284,    0, 1283, 1286,    0, 1285,    0,
+     1284, 1285,    0,    0, 1284, 1283, 1287,    0, 1285,    0,
+     1284, 1287, 1288, 1287,    0, 1285, 1288, 1289, 1287, 1285,
+     1284, 1289, 1288, 1287,    0, 1285, 1290, 1289, 1285,    0,
+     1290,    0, 1288, 1287,    0, 1285, 1290, 1289, 1287, 1288,
+     1287,    0,    0, 1288, 1289, 1287, 1290,    0, 1289, 1288,
+     1287, 1291, 1292, 1290, 1289, 1291, 1292, 1290,    0, 1288,
+
+        0, 1291, 1292, 1290, 1289, 1293,    0,    0,    0, 1293,
+     1294, 1291, 1292, 1290, 1294, 1293, 1293,    0, 1291, 1292,
+     1294,    0, 1291, 1292,    0, 1293,    0,    0, 1291, 1292,
+     1294,    0, 1293,    0,    0,    0, 1293, 1294, 1291, 1292,
+     1295, 1294, 1293, 1293, 1295,    0,    0, 1294, 1296, 1296,
+     1295,    0, 1293, 1296, 1312, 1312,    0, 1294,    0, 1296,
+     1295,    0, 1314,    0,    0,    0, 1314, 1295,    0, 1296,
+        0, 1295, 1314,    0,    0, 1296, 1296, 1295,    0,    0,
+     1296, 1312, 1314,    0, 1315, 1312, 1296, 1295, 1315, 1314,
+     1317, 1312, 1317, 1314, 1315,    0, 1296, 1317, 1318, 1314,
+
+     1318, 1312, 1317, 1316, 1315, 1318,    0, 1316, 1312, 1314,
+     1318, 1315, 1312, 1316,    0, 1315,    0, 1317, 1312, 1317,
+        0, 1315,    0, 1316, 1317, 1318,    0, 1318, 1312, 1317,
+     1316, 1315, 1318,    0, 1316,    0, 1319, 1318, 1319, 1320,
+     1316, 1320, 1321, 1319, 1321, 1322, 1320, 1322, 1319, 1321,
+     1316, 1320, 1322,    0, 1321,    0,    0, 1322,    0,    0,
+        0,    0,    0, 1319,    0, 1319, 1320,    0, 1320, 1321,
+     1319, 1321, 1322, 1320, 1322, 1319, 1321,    0, 1320, 1322,
+        0, 1321, 1323, 1324, 1322, 1335, 1323, 1324,    0, 1335,
+        0,    0, 1323, 1324,    0, 1335,    0, 1336,    0,    0,
+
+        0, 1336, 1323, 1324,    0, 1335,    0, 1336,    0, 1323,
+     1324, 1337, 1335, 1323, 1324, 1337, 1335, 1336,    0, 1323,
+     1324, 1337, 1335,    0, 1336,    0,    0,    0, 1336, 1323,
+     1324, 1337, 1335, 1338, 1336, 1338,    0,    0, 1337, 1346,
+     1338, 1346, 1337,    0, 1336, 1338, 1346,    0, 1337,    0,
+        0, 1346,    0,    0,    0,    0,    0,    0, 1337,    0,
+     1338,    0, 1338,    0,    0,    0, 1346, 1338, 1346,    0,
+        0,    0, 1338, 1346,    0,    0,    0,    0, 1346, 1378,
+     1378, 1378, 1378, 1378, 1378, 1379,    0,    0, 1379, 1379,
+     1379, 1381, 1381, 1382, 1382, 1382,    0, 1382, 1382, 1383,
+
+        0, 1383, 1383, 1383, 1383, 1384,    0, 1384, 1384, 1384,
+     1384, 1385,    0, 1385, 1385, 1385, 1385, 1386,    0, 1386,
+     1386, 1386, 1386, 1387, 1387, 1388,    0, 1388, 1388, 1388,
+     1388, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377,
+
+     1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377, 1377
     } ;
 
 /* The intent behind this definition is that it'll catch
@@ -2888,6 +3155,7 @@ static yyconst flex_int16_t yy_chk[9032] =
 
 static thread_local std::stringstream strbuf;
 
+#line 3158 "flex_lexer.cpp"
 
 /***************************
  ** Section 2: Rules
@@ -2901,7 +3169,7 @@ static thread_local std::stringstream strbuf;
 /***************************
  ** Section 3: Rules
  ***************************/
-#line 2905 "flex_lexer.cpp"
+#line 3172 "flex_lexer.cpp"
 
 #define INITIAL 0
 #define singlequotedstring 1
@@ -2957,7 +3225,7 @@ struct yyguts_t
 
     }; /* end struct yyguts_t */
 
-static int yy_init_globals (yyscan_t yyscanner );
+static int yy_init_globals ( yyscan_t yyscanner );
 
     /* This must go here because YYSTYPE and YYLTYPE are included
      * from bison output in section 1.*/
@@ -2965,50 +3233,50 @@ static int yy_init_globals (yyscan_t yyscanner );
     
     #    define yylloc yyg->yylloc_r
     
-int hsql_lex_init (yyscan_t* scanner);
+int yylex_init (yyscan_t* scanner);
 
-int hsql_lex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int hsql_lex_destroy (yyscan_t yyscanner );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int hsql_get_debug (yyscan_t yyscanner );
+int yyget_debug ( yyscan_t yyscanner );
 
-void hsql_set_debug (int debug_flag ,yyscan_t yyscanner );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE hsql_get_extra (yyscan_t yyscanner );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void hsql_set_extra (YY_EXTRA_TYPE user_defined ,yyscan_t yyscanner );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *hsql_get_in (yyscan_t yyscanner );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void hsql_set_in  (FILE * _in_str ,yyscan_t yyscanner );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *hsql_get_out (yyscan_t yyscanner );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void hsql_set_out  (FILE * _out_str ,yyscan_t yyscanner );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			int hsql_get_leng (yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *hsql_get_text (yyscan_t yyscanner );
+char *yyget_text ( yyscan_t yyscanner );
 
-int hsql_get_lineno (yyscan_t yyscanner );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void hsql_set_lineno (int _line_number ,yyscan_t yyscanner );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-int hsql_get_column  (yyscan_t yyscanner );
+int yyget_column  ( yyscan_t yyscanner );
 
-void hsql_set_column (int _column_no ,yyscan_t yyscanner );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
 
-YYSTYPE * hsql_get_lval (yyscan_t yyscanner );
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
 
-void hsql_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
 
-       YYLTYPE *hsql_get_lloc (yyscan_t yyscanner );
+       YYLTYPE *yyget_lloc ( yyscan_t yyscanner );
     
-        void hsql_set_lloc (YYLTYPE * yylloc_param ,yyscan_t yyscanner );
+        void yyset_lloc ( YYLTYPE * yylloc_param , yyscan_t yyscanner );
     
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -3016,9 +3284,9 @@ void hsql_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int hsql_wrap (yyscan_t yyscanner );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int hsql_wrap (yyscan_t yyscanner );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
 #endif
 
@@ -3027,19 +3295,18 @@ extern int hsql_wrap (yyscan_t yyscanner );
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int ,yyscan_t yyscanner);
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (yyscan_t yyscanner );
+static int yyinput ( yyscan_t yyscanner );
 #else
-static int input (yyscan_t yyscanner );
+static int input ( yyscan_t yyscanner );
 #endif
 
 #endif
@@ -3124,10 +3391,10 @@ static int input (yyscan_t yyscanner );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int hsql_lex \
-               (YYSTYPE * yylval_param,YYLTYPE * yylloc_param ,yyscan_t yyscanner);
+extern int yylex \
+               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner);
 
-#define YY_DECL int hsql_lex \
+#define YY_DECL int yylex \
                (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner)
 #endif /* !YY_DECL */
 
@@ -3177,19 +3444,19 @@ YY_DECL
 			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			hsql_ensure_buffer_stack (yyscanner);
+			yyensure_buffer_stack (yyscanner);
 			YY_CURRENT_BUFFER_LVALUE =
-				hsql__create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
+				yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 		}
 
-		hsql__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 		}
 
 	{
 #line 57 "flex_lexer.l"
 
 
-#line 3193 "flex_lexer.cpp"
+#line 3459 "flex_lexer.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -3216,13 +3483,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 1368 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+				if ( yy_current_state >= 1378 )
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_current_state != 1367 );
+		while ( yy_current_state != 1377 );
 		yy_cp = yyg->yy_last_accepting_cpos;
 		yy_current_state = yyg->yy_last_accepting_state;
 
@@ -4130,13 +4397,29 @@ TOKEN(CONCAT)
 case 177:
 YY_RULE_SETUP
 #line 241 "flex_lexer.l"
-{ return yytext[0]; }
+{
+  yylval->ival = atoll(yytext + 1);
+  return SQL_DOLLAR_PARAM;
+}
 	YY_BREAK
 case 178:
-#line 244 "flex_lexer.l"
+YY_RULE_SETUP
+#line 246 "flex_lexer.l"
+{
+  yylval->sval = strdup(yytext + 1);
+  return SQL_NAMED_PARAM;
+}
+	YY_BREAK
 case 179:
 YY_RULE_SETUP
-#line 244 "flex_lexer.l"
+#line 251 "flex_lexer.l"
+{ return yytext[0]; }
+	YY_BREAK
+case 180:
+#line 254 "flex_lexer.l"
+case 181:
+YY_RULE_SETUP
+#line 254 "flex_lexer.l"
 {
   yylval->fval = atof(yytext);
   return SQL_FLOATVAL;
@@ -4147,17 +4430,17 @@ YY_RULE_SETUP
    * positive equivalent. We thus match for LLONG_MIN specifically. This is not an issue for floats, where
    *   numeric_limits<double>::lowest() == -numeric_limits<double>::max();
    */
-case 180:
+case 182:
 YY_RULE_SETUP
-#line 254 "flex_lexer.l"
+#line 264 "flex_lexer.l"
 {
   yylval->ival = LLONG_MIN;
   return SQL_INTVAL;
 }
 	YY_BREAK
-case 181:
+case 183:
 YY_RULE_SETUP
-#line 259 "flex_lexer.l"
+#line 269 "flex_lexer.l"
 {
   errno = 0;
   yylval->ival = strtoll(yytext, nullptr, 0);
@@ -4168,59 +4451,59 @@ YY_RULE_SETUP
   return SQL_INTVAL;
 }
 	YY_BREAK
-case 182:
+case 184:
 YY_RULE_SETUP
-#line 269 "flex_lexer.l"
+#line 279 "flex_lexer.l"
 {
   // Crop the leading and trailing quote char
   yylval->sval = hsql::substr(yytext, 1, strlen(yytext)-1);
   return SQL_IDENTIFIER;
 }
 	YY_BREAK
-case 183:
+case 185:
 YY_RULE_SETUP
-#line 275 "flex_lexer.l"
+#line 285 "flex_lexer.l"
 {
   yylval->sval = strdup(yytext);
   return SQL_IDENTIFIER;
 }
 	YY_BREAK
-case 184:
-YY_RULE_SETUP
-#line 280 "flex_lexer.l"
-{ BEGIN singlequotedstring; strbuf.clear(); strbuf.str(""); }  // Clear strbuf manually, see #170
-	YY_BREAK
-case 185:
-YY_RULE_SETUP
-#line 281 "flex_lexer.l"
-{ strbuf << '\''; }
-	YY_BREAK
 case 186:
-/* rule 186 can match eol */
 YY_RULE_SETUP
-#line 282 "flex_lexer.l"
-{ strbuf << yytext; }
+#line 290 "flex_lexer.l"
+{ BEGIN singlequotedstring; strbuf.clear(); strbuf.str(""); }  // Clear strbuf manually, see #170
 	YY_BREAK
 case 187:
 YY_RULE_SETUP
-#line 283 "flex_lexer.l"
-{ BEGIN 0; yylval->sval = strdup(strbuf.str().c_str()); return SQL_STRING; }
-	YY_BREAK
-case YY_STATE_EOF(singlequotedstring):
-#line 284 "flex_lexer.l"
-{ fprintf(stderr, "[SQL-Lexer-Error] Unterminated string\n"); return 0; }
+#line 291 "flex_lexer.l"
+{ strbuf << '\''; }
 	YY_BREAK
 case 188:
+/* rule 188 can match eol */
 YY_RULE_SETUP
-#line 286 "flex_lexer.l"
-{ fprintf(stderr, "[SQL-Lexer-Error] Unknown Character: %c\n", yytext[0]); return 0; }
+#line 292 "flex_lexer.l"
+{ strbuf << yytext; }
 	YY_BREAK
 case 189:
 YY_RULE_SETUP
-#line 288 "flex_lexer.l"
+#line 293 "flex_lexer.l"
+{ BEGIN 0; yylval->sval = strdup(strbuf.str().c_str()); return SQL_STRING; }
+	YY_BREAK
+case YY_STATE_EOF(singlequotedstring):
+#line 294 "flex_lexer.l"
+{ fprintf(stderr, "[SQL-Lexer-Error] Unterminated string\n"); return 0; }
+	YY_BREAK
+case 190:
+YY_RULE_SETUP
+#line 296 "flex_lexer.l"
+{ fprintf(stderr, "[SQL-Lexer-Error] Unknown Character: %c\n", yytext[0]); return 0; }
+	YY_BREAK
+case 191:
+YY_RULE_SETUP
+#line 298 "flex_lexer.l"
 ECHO;
 	YY_BREAK
-#line 4224 "flex_lexer.cpp"
+#line 4506 "flex_lexer.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(COMMENT):
 	yyterminate();
@@ -4239,7 +4522,7 @@ case YY_STATE_EOF(COMMENT):
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
 			 * just pointed yyin at a new source and called
-			 * hsql_lex().  If so, then we have to assure
+			 * yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
@@ -4300,7 +4583,7 @@ case YY_STATE_EOF(COMMENT):
 				{
 				yyg->yy_did_buffer_switch_on_eof = 0;
 
-				if ( hsql_wrap(yyscanner ) )
+				if ( yywrap( yyscanner ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -4354,7 +4637,7 @@ case YY_STATE_EOF(COMMENT):
 	} /* end of action switch */
 		} /* end of scanning one token */
 	} /* end of user's declarations */
-} /* end of hsql_lex */
+} /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -4368,7 +4651,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = yyg->yytext_ptr;
-	yy_size_t number_to_move, i;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( yyg->yy_c_buf_p > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars + 1] )
@@ -4397,7 +4680,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (yy_size_t) (yyg->yy_c_buf_p - yyg->yytext_ptr) - 1;
+	number_to_move = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -4433,7 +4716,8 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					hsql_realloc((void *) b->yy_ch_buf,(yy_size_t) (b->yy_buf_size + 2) ,yyscanner );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 				}
 			else
 				/* Can't grow it, we don't own it. */
@@ -4465,7 +4749,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			hsql_restart(yyin  ,yyscanner);
+			yyrestart( yyin  , yyscanner);
 			}
 
 		else
@@ -4479,12 +4763,15 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) hsql_realloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,(yy_size_t) new_size ,yyscanner );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	yyg->yy_n_chars += number_to_move;
@@ -4517,10 +4804,10 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 1368 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+			if ( yy_current_state >= 1378 )
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -4546,11 +4833,11 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 1368 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+		if ( yy_current_state >= 1378 )
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
-	yy_is_jam = (yy_current_state == 1367);
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+	yy_is_jam = (yy_current_state == 1377);
 
 	(void)yyg;
 	return yy_is_jam ? 0 : yy_current_state;
@@ -4585,7 +4872,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			int offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -4602,13 +4889,13 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 					 */
 
 					/* Reset buffer status. */
-					hsql_restart(yyin ,yyscanner);
+					yyrestart( yyin , yyscanner);
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( hsql_wrap(yyscanner ) )
+					if ( yywrap( yyscanner ) )
 						return 0;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
@@ -4640,34 +4927,34 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void hsql_restart  (FILE * input_file , yyscan_t yyscanner)
+    void yyrestart  (FILE * input_file , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if ( ! YY_CURRENT_BUFFER ){
-        hsql_ensure_buffer_stack (yyscanner);
+        yyensure_buffer_stack (yyscanner);
 		YY_CURRENT_BUFFER_LVALUE =
-            hsql__create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 	}
 
-	hsql__init_buffer(YY_CURRENT_BUFFER,input_file ,yyscanner);
-	hsql__load_buffer_state(yyscanner );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file , yyscanner);
+	yy_load_buffer_state( yyscanner );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * @param yyscanner The scanner object.
  */
-    void hsql__switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		hsql_pop_buffer_state();
-	 *		hsql_push_buffer_state(new_buffer);
+	 *		yypop_buffer_state();
+	 *		yypush_buffer_state(new_buffer);
      */
-	hsql_ensure_buffer_stack (yyscanner);
+	yyensure_buffer_stack (yyscanner);
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -4680,17 +4967,17 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	hsql__load_buffer_state(yyscanner );
+	yy_load_buffer_state( yyscanner );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (hsql_wrap()) processing, but the only time this flag
-	 * is looked at is after hsql_wrap() is called, so it's safe
+	 * EOF (yywrap()) processing, but the only time this flag
+	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
-static void hsql__load_buffer_state  (yyscan_t yyscanner)
+static void yy_load_buffer_state  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
@@ -4705,35 +4992,35 @@ static void hsql__load_buffer_state  (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE hsql__create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) hsql_alloc(sizeof( struct yy_buffer_state ) ,yyscanner );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in hsql__create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) hsql_alloc((yy_size_t) (b->yy_buf_size + 2) ,yyscanner );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in hsql__create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	hsql__init_buffer(b,file ,yyscanner);
+	yy_init_buffer( b, file , yyscanner);
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with hsql__create_buffer()
+ * @param b a buffer created with yy_create_buffer()
  * @param yyscanner The scanner object.
  */
-    void hsql__delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
+    void yy_delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
@@ -4744,28 +5031,28 @@ static void hsql__load_buffer_state  (yyscan_t yyscanner)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		hsql_free((void *) b->yy_ch_buf ,yyscanner );
+		yyfree( (void *) b->yy_ch_buf , yyscanner );
 
-	hsql_free((void *) b ,yyscanner );
+	yyfree( (void *) b , yyscanner );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a hsql_restart() or at EOF.
+ * such as during a yyrestart() or at EOF.
  */
-    static void hsql__init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
 
 {
 	int oerrno = errno;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	hsql__flush_buffer(b ,yyscanner);
+	yy_flush_buffer( b , yyscanner);
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then hsql__init_buffer was _probably_
-     * called from hsql_restart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then yy_init_buffer was _probably_
+     * called from yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -4782,7 +5069,7 @@ static void hsql__load_buffer_state  (yyscan_t yyscanner)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * @param yyscanner The scanner object.
  */
-    void hsql__flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
+    void yy_flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if ( ! b )
@@ -4803,7 +5090,7 @@ static void hsql__load_buffer_state  (yyscan_t yyscanner)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		hsql__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -4812,15 +5099,15 @@ static void hsql__load_buffer_state  (yyscan_t yyscanner)
  *  @param new_buffer The new state.
  *  @param yyscanner The scanner object.
  */
-void hsql_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if (new_buffer == NULL)
 		return;
 
-	hsql_ensure_buffer_stack(yyscanner);
+	yyensure_buffer_stack(yyscanner);
 
-	/* This block is copied from hsql__switch_to_buffer. */
+	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -4834,8 +5121,8 @@ void hsql_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 		yyg->yy_buffer_stack_top++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from hsql__switch_to_buffer. */
-	hsql__load_buffer_state(yyscanner );
+	/* copied from yy_switch_to_buffer. */
+	yy_load_buffer_state( yyscanner );
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
@@ -4843,19 +5130,19 @@ void hsql_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
  *  The next element becomes the new top.
  *  @param yyscanner The scanner object.
  */
-void hsql_pop_buffer_state (yyscan_t yyscanner)
+void yypop_buffer_state (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if (!YY_CURRENT_BUFFER)
 		return;
 
-	hsql__delete_buffer(YY_CURRENT_BUFFER ,yyscanner);
+	yy_delete_buffer(YY_CURRENT_BUFFER , yyscanner);
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if (yyg->yy_buffer_stack_top > 0)
 		--yyg->yy_buffer_stack_top;
 
 	if (YY_CURRENT_BUFFER) {
-		hsql__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 		yyg->yy_did_buffer_switch_on_eof = 1;
 	}
 }
@@ -4863,9 +5150,9 @@ void hsql_pop_buffer_state (yyscan_t yyscanner)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void hsql_ensure_buffer_stack (yyscan_t yyscanner)
+static void yyensure_buffer_stack (yyscan_t yyscanner)
 {
-	int num_to_alloc;
+	yy_size_t num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if (!yyg->yy_buffer_stack) {
@@ -4875,14 +5162,14 @@ static void hsql_ensure_buffer_stack (yyscan_t yyscanner)
 		 * immediate realloc on the next call.
          */
       num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		yyg->yy_buffer_stack = (struct yy_buffer_state**)hsql_alloc
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
-			YY_FATAL_ERROR( "out of dynamic memory in hsql_ensure_buffer_stack()" );
-								  
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
+
 		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		yyg->yy_buffer_stack_max = num_to_alloc;
 		yyg->yy_buffer_stack_top = 0;
 		return;
@@ -4894,12 +5181,12 @@ static void hsql_ensure_buffer_stack (yyscan_t yyscanner)
 		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = yyg->yy_buffer_stack_max + grow_size;
-		yyg->yy_buffer_stack = (struct yy_buffer_state**)hsql_realloc
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyrealloc
 								(yyg->yy_buffer_stack,
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
-			YY_FATAL_ERROR( "out of dynamic memory in hsql_ensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset(yyg->yy_buffer_stack + yyg->yy_buffer_stack_max, 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -4911,9 +5198,9 @@ static void hsql_ensure_buffer_stack (yyscan_t yyscanner)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * @param yyscanner The scanner object.
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE hsql__scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
@@ -4923,9 +5210,9 @@ YY_BUFFER_STATE hsql__scan_buffer  (char * base, yy_size_t  size , yyscan_t yysc
 		/* They forgot to leave room for the EOB's. */
 		return NULL;
 
-	b = (YY_BUFFER_STATE) hsql_alloc(sizeof( struct yy_buffer_state ) ,yyscanner );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in hsql__scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
 	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
@@ -4937,33 +5224,33 @@ YY_BUFFER_STATE hsql__scan_buffer  (char * base, yy_size_t  size , yyscan_t yysc
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	hsql__switch_to_buffer(b ,yyscanner );
+	yy_switch_to_buffer( b , yyscanner );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to hsql_lex() will
+/** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       hsql__scan_bytes() instead.
+ *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE hsql__scan_string (yyconst char * yystr , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
 {
     
-	return hsql__scan_bytes(yystr,(int) strlen(yystr) ,yyscanner);
+	return yy_scan_bytes( yystr, (int) strlen(yystr) , yyscanner);
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to hsql_lex() will
+/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE hsql__scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
@@ -4972,18 +5259,18 @@ YY_BUFFER_STATE hsql__scan_bytes  (yyconst char * yybytes, int  _yybytes_len , y
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = (yy_size_t) (_yybytes_len + 2);
-	buf = (char *) hsql_alloc(n ,yyscanner );
+	buf = (char *) yyalloc( n , yyscanner );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in hsql__scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = hsql__scan_buffer(buf,n ,yyscanner);
+	b = yy_scan_buffer( buf, n , yyscanner);
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in hsql__scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -4997,11 +5284,11 @@ YY_BUFFER_STATE hsql__scan_bytes  (yyconst char * yybytes, int  _yybytes_len , y
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yynoreturn yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
+static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	(void) fprintf( stderr, "%s\n", msg );
+	fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -5012,7 +5299,7 @@ static void yynoreturn yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        yy_size_t yyless_macro_arg = (n); \
+        int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		yytext[yyleng] = yyg->yy_hold_char; \
 		yyg->yy_c_buf_p = yytext + yyless_macro_arg; \
@@ -5027,7 +5314,7 @@ static void yynoreturn yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
 /** Get the user-defined data for this scanner.
  * @param yyscanner The scanner object.
  */
-YY_EXTRA_TYPE hsql_get_extra  (yyscan_t yyscanner)
+YY_EXTRA_TYPE yyget_extra  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyextra;
@@ -5036,10 +5323,10 @@ YY_EXTRA_TYPE hsql_get_extra  (yyscan_t yyscanner)
 /** Get the current line number.
  * @param yyscanner The scanner object.
  */
-int hsql_get_lineno  (yyscan_t yyscanner)
+int yyget_lineno  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
     
@@ -5049,10 +5336,10 @@ int hsql_get_lineno  (yyscan_t yyscanner)
 /** Get the current column number.
  * @param yyscanner The scanner object.
  */
-int hsql_get_column  (yyscan_t yyscanner)
+int yyget_column  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
     
@@ -5062,7 +5349,7 @@ int hsql_get_column  (yyscan_t yyscanner)
 /** Get the input stream.
  * @param yyscanner The scanner object.
  */
-FILE *hsql_get_in  (yyscan_t yyscanner)
+FILE *yyget_in  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyin;
@@ -5071,7 +5358,7 @@ FILE *hsql_get_in  (yyscan_t yyscanner)
 /** Get the output stream.
  * @param yyscanner The scanner object.
  */
-FILE *hsql_get_out  (yyscan_t yyscanner)
+FILE *yyget_out  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyout;
@@ -5080,7 +5367,7 @@ FILE *hsql_get_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-int hsql_get_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -5090,7 +5377,7 @@ int hsql_get_leng  (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  */
 
-char *hsql_get_text  (yyscan_t yyscanner)
+char *yyget_text  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yytext;
@@ -5100,7 +5387,7 @@ char *hsql_get_text  (yyscan_t yyscanner)
  * @param user_defined The data to be associated with this scanner.
  * @param yyscanner The scanner object.
  */
-void hsql_set_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
+void yyset_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyextra = user_defined ;
@@ -5110,13 +5397,13 @@ void hsql_set_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
  * @param _line_number line number
  * @param yyscanner The scanner object.
  */
-void hsql_set_lineno (int  _line_number , yyscan_t yyscanner)
+void yyset_lineno (int  _line_number , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           YY_FATAL_ERROR( "hsql_set_lineno called with no buffer" );
+           YY_FATAL_ERROR( "yyset_lineno called with no buffer" );
     
     yylineno = _line_number;
 }
@@ -5125,13 +5412,13 @@ void hsql_set_lineno (int  _line_number , yyscan_t yyscanner)
  * @param _column_no column number
  * @param yyscanner The scanner object.
  */
-void hsql_set_column (int  _column_no , yyscan_t yyscanner)
+void yyset_column (int  _column_no , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           YY_FATAL_ERROR( "hsql_set_column called with no buffer" );
+           YY_FATAL_ERROR( "yyset_column called with no buffer" );
     
     yycolumn = _column_no;
 }
@@ -5140,27 +5427,27 @@ void hsql_set_column (int  _column_no , yyscan_t yyscanner)
  * input buffer.
  * @param _in_str A readable stream.
  * @param yyscanner The scanner object.
- * @see hsql__switch_to_buffer
+ * @see yy_switch_to_buffer
  */
-void hsql_set_in (FILE *  _in_str , yyscan_t yyscanner)
+void yyset_in (FILE *  _in_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyin = _in_str ;
 }
 
-void hsql_set_out (FILE *  _out_str , yyscan_t yyscanner)
+void yyset_out (FILE *  _out_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyout = _out_str ;
 }
 
-int hsql_get_debug  (yyscan_t yyscanner)
+int yyget_debug  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yy_flex_debug;
 }
 
-void hsql_set_debug (int  _bdebug , yyscan_t yyscanner)
+void yyset_debug (int  _bdebug , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yy_flex_debug = _bdebug ;
@@ -5168,25 +5455,25 @@ void hsql_set_debug (int  _bdebug , yyscan_t yyscanner)
 
 /* Accessor methods for yylval and yylloc */
 
-YYSTYPE * hsql_get_lval  (yyscan_t yyscanner)
+YYSTYPE * yyget_lval  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yylval;
 }
 
-void hsql_set_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
+void yyset_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yylval = yylval_param;
 }
 
-YYLTYPE *hsql_get_lloc  (yyscan_t yyscanner)
+YYLTYPE *yyget_lloc  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yylloc;
 }
     
-void hsql_set_lloc (YYLTYPE *  yylloc_param , yyscan_t yyscanner)
+void yyset_lloc (YYLTYPE *  yylloc_param , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yylloc = yylloc_param;
@@ -5194,20 +5481,18 @@ void hsql_set_lloc (YYLTYPE *  yylloc_param , yyscan_t yyscanner)
     
 /* User-visible API */
 
-/* hsql_lex_init is special because it creates the scanner itself, so it is
+/* yylex_init is special because it creates the scanner itself, so it is
  * the ONLY reentrant function that doesn't take the scanner as the last argument.
  * That's why we explicitly handle the declaration, instead of using our macros.
  */
-
-int hsql_lex_init(yyscan_t* ptr_yy_globals)
-
+int yylex_init(yyscan_t* ptr_yy_globals)
 {
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
         return 1;
     }
 
-    *ptr_yy_globals = (yyscan_t) hsql_alloc ( sizeof( struct yyguts_t ), NULL );
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), NULL );
 
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
@@ -5220,39 +5505,37 @@ int hsql_lex_init(yyscan_t* ptr_yy_globals)
     return yy_init_globals ( *ptr_yy_globals );
 }
 
-/* hsql_lex_init_extra has the same functionality as hsql_lex_init, but follows the
+/* yylex_init_extra has the same functionality as yylex_init, but follows the
  * convention of taking the scanner as the last argument. Note however, that
  * this is a *pointer* to a scanner, as it will be allocated by this call (and
  * is the reason, too, why this function also must handle its own declaration).
- * The user defined value in the first argument will be available to hsql_alloc in
+ * The user defined value in the first argument will be available to yyalloc in
  * the yyextra field.
  */
-
-int hsql_lex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals )
-
+int yylex_init_extra( YY_EXTRA_TYPE yy_user_defined, yyscan_t* ptr_yy_globals )
 {
     struct yyguts_t dummy_yyguts;
 
-    hsql_set_extra (yy_user_defined, &dummy_yyguts);
+    yyset_extra (yy_user_defined, &dummy_yyguts);
 
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
         return 1;
     }
-	
-    *ptr_yy_globals = (yyscan_t) hsql_alloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
-	
+
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
+
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
-    
+
     /* By setting to 0xAA, we expose bugs in
     yy_init_globals. Leave at 0x00 for releases. */
     memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
-    
-    hsql_set_extra (yy_user_defined, *ptr_yy_globals);
-    
+
+    yyset_extra (yy_user_defined, *ptr_yy_globals);
+
     return yy_init_globals ( *ptr_yy_globals );
 }
 
@@ -5260,7 +5543,7 @@ static int yy_init_globals (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from hsql_lex_destroy(), so don't allocate here.
+     * This function is called from yylex_destroy(), so don't allocate here.
      */
 
     yyg->yy_buffer_stack = NULL;
@@ -5284,37 +5567,37 @@ static int yy_init_globals (yyscan_t yyscanner)
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * hsql_lex_init()
+     * yylex_init()
      */
     return 0;
 }
 
-/* hsql_lex_destroy is for both reentrant and non-reentrant scanners. */
-int hsql_lex_destroy  (yyscan_t yyscanner)
+/* yylex_destroy is for both reentrant and non-reentrant scanners. */
+int yylex_destroy  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		hsql__delete_buffer(YY_CURRENT_BUFFER ,yyscanner );
+		yy_delete_buffer( YY_CURRENT_BUFFER , yyscanner );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		hsql_pop_buffer_state(yyscanner);
+		yypop_buffer_state(yyscanner);
 	}
 
 	/* Destroy the stack itself. */
-	hsql_free(yyg->yy_buffer_stack ,yyscanner);
+	yyfree(yyg->yy_buffer_stack , yyscanner);
 	yyg->yy_buffer_stack = NULL;
 
     /* Destroy the start condition stack. */
-        hsql_free(yyg->yy_start_stack ,yyscanner );
+        yyfree( yyg->yy_start_stack , yyscanner );
         yyg->yy_start_stack = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * hsql_lex() is called, initialization will occur. */
+     * yylex() is called, initialization will occur. */
     yy_init_globals( yyscanner);
 
     /* Destroy the main struct (reentrant only). */
-    hsql_free ( yyscanner , yyscanner );
+    yyfree ( yyscanner , yyscanner );
     yyscanner = NULL;
     return 0;
 }
@@ -5324,7 +5607,7 @@ int hsql_lex_destroy  (yyscan_t yyscanner)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n , yyscan_t yyscanner)
+static void yy_flex_strncpy (char* s1, const char * s2, int n , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -5336,7 +5619,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n , yyscan_t yysca
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
+static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -5346,14 +5629,14 @@ static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
 }
 #endif
 
-void *hsql_alloc (yy_size_t  size , yyscan_t yyscanner)
+void *yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
 	return malloc(size);
 }
 
-void *hsql_realloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
+void *yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -5368,17 +5651,16 @@ void *hsql_realloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 	return realloc(ptr, size);
 }
 
-void hsql_free (void * ptr , yyscan_t yyscanner)
+void yyfree (void * ptr , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	free( (char *) ptr );	/* see hsql_realloc() for (char *) cast */
+	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-#line 288 "flex_lexer.l"
-
+#line 298 "flex_lexer.l"
 
 /***************************
  ** Section 3: User code

--- a/src/parser/flex_lexer.cpp
+++ b/src/parser/flex_lexer.cpp
@@ -1,6 +1,6 @@
-#line 1 "flex_lexer.cpp"
+#line 2 "flex_lexer.cpp"
 
-#line 3 "flex_lexer.cpp"
+#line 4 "flex_lexer.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -3155,7 +3155,7 @@ static const flex_int16_t yy_chk[9211] =
 
 static thread_local std::stringstream strbuf;
 
-#line 3158 "flex_lexer.cpp"
+#line 3159 "flex_lexer.cpp"
 
 /***************************
  ** Section 2: Rules
@@ -3164,12 +3164,13 @@ static thread_local std::stringstream strbuf;
 /* Make reentrant */
 /* performance tweeks */
 /* other flags */
+#define YY_NO_INPUT 1
 /* %option nodefault */
 
 /***************************
  ** Section 3: Rules
  ***************************/
-#line 3172 "flex_lexer.cpp"
+#line 3174 "flex_lexer.cpp"
 
 #define INITIAL 0
 #define singlequotedstring 1
@@ -3456,7 +3457,7 @@ YY_DECL
 #line 57 "flex_lexer.l"
 
 
-#line 3459 "flex_lexer.cpp"
+#line 3461 "flex_lexer.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -4503,7 +4504,7 @@ YY_RULE_SETUP
 #line 298 "flex_lexer.l"
 ECHO;
 	YY_BREAK
-#line 4506 "flex_lexer.cpp"
+#line 4508 "flex_lexer.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(COMMENT):
 	yyterminate();

--- a/src/parser/flex_lexer.h
+++ b/src/parser/flex_lexer.h
@@ -2,9 +2,9 @@
 #define hsql_HEADER_H 1
 #define hsql_IN_HEADER 1
 
-#line 6 "flex_lexer.h"
+#line 5 "flex_lexer.h"
 
-#line 8 "flex_lexer.h"
+#line 7 "flex_lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -13,9 +13,243 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 1
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define hsql__create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer hsql__create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define hsql__delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer hsql__delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define hsql__scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer hsql__scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define hsql__scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string hsql__scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define hsql__scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes hsql__scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define hsql__init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer hsql__init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define hsql__flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer hsql__flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define hsql__load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state hsql__load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define hsql__switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer hsql__switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define hsql_push_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state hsql_push_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define hsql_pop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state hsql_pop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define hsql_ensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack hsql_ensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define hsql_lex_ALREADY_DEFINED
+#else
+#define yylex hsql_lex
+#endif
+
+#ifdef yyrestart
+#define hsql_restart_ALREADY_DEFINED
+#else
+#define yyrestart hsql_restart
+#endif
+
+#ifdef yylex_init
+#define hsql_lex_init_ALREADY_DEFINED
+#else
+#define yylex_init hsql_lex_init
+#endif
+
+#ifdef yylex_init_extra
+#define hsql_lex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra hsql_lex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define hsql_lex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy hsql_lex_destroy
+#endif
+
+#ifdef yyget_debug
+#define hsql_get_debug_ALREADY_DEFINED
+#else
+#define yyget_debug hsql_get_debug
+#endif
+
+#ifdef yyset_debug
+#define hsql_set_debug_ALREADY_DEFINED
+#else
+#define yyset_debug hsql_set_debug
+#endif
+
+#ifdef yyget_extra
+#define hsql_get_extra_ALREADY_DEFINED
+#else
+#define yyget_extra hsql_get_extra
+#endif
+
+#ifdef yyset_extra
+#define hsql_set_extra_ALREADY_DEFINED
+#else
+#define yyset_extra hsql_set_extra
+#endif
+
+#ifdef yyget_in
+#define hsql_get_in_ALREADY_DEFINED
+#else
+#define yyget_in hsql_get_in
+#endif
+
+#ifdef yyset_in
+#define hsql_set_in_ALREADY_DEFINED
+#else
+#define yyset_in hsql_set_in
+#endif
+
+#ifdef yyget_out
+#define hsql_get_out_ALREADY_DEFINED
+#else
+#define yyget_out hsql_get_out
+#endif
+
+#ifdef yyset_out
+#define hsql_set_out_ALREADY_DEFINED
+#else
+#define yyset_out hsql_set_out
+#endif
+
+#ifdef yyget_leng
+#define hsql_get_leng_ALREADY_DEFINED
+#else
+#define yyget_leng hsql_get_leng
+#endif
+
+#ifdef yyget_text
+#define hsql_get_text_ALREADY_DEFINED
+#else
+#define yyget_text hsql_get_text
+#endif
+
+#ifdef yyget_lineno
+#define hsql_get_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno hsql_get_lineno
+#endif
+
+#ifdef yyset_lineno
+#define hsql_set_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno hsql_set_lineno
+#endif
+
+#ifdef yyget_column
+#define hsql_get_column_ALREADY_DEFINED
+#else
+#define yyget_column hsql_get_column
+#endif
+
+#ifdef yyset_column
+#define hsql_set_column_ALREADY_DEFINED
+#else
+#define yyset_column hsql_set_column
+#endif
+
+#ifdef yywrap
+#define hsql_wrap_ALREADY_DEFINED
+#else
+#define yywrap hsql_wrap
+#endif
+
+#ifdef yyget_lval
+#define hsql_get_lval_ALREADY_DEFINED
+#else
+#define yyget_lval hsql_get_lval
+#endif
+
+#ifdef yyset_lval
+#define hsql_set_lval_ALREADY_DEFINED
+#else
+#define yyset_lval hsql_set_lval
+#endif
+
+#ifdef yyget_lloc
+#define hsql_get_lloc_ALREADY_DEFINED
+#else
+#define yyget_lloc hsql_get_lloc
+#endif
+
+#ifdef yyset_lloc
+#define hsql_set_lloc_ALREADY_DEFINED
+#else
+#define yyset_lloc hsql_set_lloc
+#endif
+
+#ifdef yyalloc
+#define hsql_alloc_ALREADY_DEFINED
+#else
+#define yyalloc hsql_alloc
+#endif
+
+#ifdef yyrealloc
+#define hsql_realloc_ALREADY_DEFINED
+#else
+#define yyrealloc hsql_realloc
+#endif
+
+#ifdef yyfree
+#define hsql_free_ALREADY_DEFINED
+#else
+#define yyfree hsql_free
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -88,9 +322,15 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
+
+/* begin standard C++ headers. */
 
 /* TODO: this is always defined, so inline it */
 #define yyconst const
@@ -181,7 +421,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -192,21 +432,21 @@ struct yy_buffer_state
 	};
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
-void hsql_restart (FILE *input_file ,yyscan_t yyscanner );
-void hsql__switch_to_buffer (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__create_buffer (FILE *file,int size ,yyscan_t yyscanner );
-void hsql__delete_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void hsql__flush_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void hsql_push_buffer_state (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-void hsql_pop_buffer_state (yyscan_t yyscanner );
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-YY_BUFFER_STATE hsql__scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE hsql__scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-void *hsql_alloc (yy_size_t ,yyscan_t yyscanner );
-void *hsql_realloc (void *,yy_size_t ,yyscan_t yyscanner );
-void hsql_free (void * ,yyscan_t yyscanner );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
 /* Begin user sect3 */
 
@@ -234,50 +474,50 @@ void hsql_free (void * ,yyscan_t yyscanner );
 #define YY_EXTRA_TYPE void *
 #endif
 
-int hsql_lex_init (yyscan_t* scanner);
+int yylex_init (yyscan_t* scanner);
 
-int hsql_lex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int hsql_lex_destroy (yyscan_t yyscanner );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int hsql_get_debug (yyscan_t yyscanner );
+int yyget_debug ( yyscan_t yyscanner );
 
-void hsql_set_debug (int debug_flag ,yyscan_t yyscanner );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE hsql_get_extra (yyscan_t yyscanner );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void hsql_set_extra (YY_EXTRA_TYPE user_defined ,yyscan_t yyscanner );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *hsql_get_in (yyscan_t yyscanner );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void hsql_set_in  (FILE * _in_str ,yyscan_t yyscanner );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *hsql_get_out (yyscan_t yyscanner );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void hsql_set_out  (FILE * _out_str ,yyscan_t yyscanner );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			int hsql_get_leng (yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *hsql_get_text (yyscan_t yyscanner );
+char *yyget_text ( yyscan_t yyscanner );
 
-int hsql_get_lineno (yyscan_t yyscanner );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void hsql_set_lineno (int _line_number ,yyscan_t yyscanner );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-int hsql_get_column  (yyscan_t yyscanner );
+int yyget_column  ( yyscan_t yyscanner );
 
-void hsql_set_column (int _column_no ,yyscan_t yyscanner );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
 
-YYSTYPE * hsql_get_lval (yyscan_t yyscanner );
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
 
-void hsql_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
 
-       YYLTYPE *hsql_get_lloc (yyscan_t yyscanner );
+       YYLTYPE *yyget_lloc ( yyscan_t yyscanner );
     
-        void hsql_set_lloc (YYLTYPE * yylloc_param ,yyscan_t yyscanner );
+        void yyset_lloc ( YYLTYPE * yylloc_param , yyscan_t yyscanner );
     
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -285,18 +525,18 @@ void hsql_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int hsql_wrap (yyscan_t yyscanner );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int hsql_wrap (yyscan_t yyscanner );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int ,yyscan_t yyscanner);
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
@@ -324,10 +564,10 @@ static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int hsql_lex \
-               (YYSTYPE * yylval_param,YYLTYPE * yylloc_param ,yyscan_t yyscanner);
+extern int yylex \
+               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner);
 
-#define YY_DECL int hsql_lex \
+#define YY_DECL int yylex \
                (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner)
 #endif /* !YY_DECL */
 
@@ -345,9 +585,154 @@ extern int hsql_lex \
 #undef YY_DECL
 #endif
 
-#line 288 "flex_lexer.l"
+#ifndef hsql__create_buffer_ALREADY_DEFINED
+#undef yy_create_buffer
+#endif
+#ifndef hsql__delete_buffer_ALREADY_DEFINED
+#undef yy_delete_buffer
+#endif
+#ifndef hsql__scan_buffer_ALREADY_DEFINED
+#undef yy_scan_buffer
+#endif
+#ifndef hsql__scan_string_ALREADY_DEFINED
+#undef yy_scan_string
+#endif
+#ifndef hsql__scan_bytes_ALREADY_DEFINED
+#undef yy_scan_bytes
+#endif
+#ifndef hsql__init_buffer_ALREADY_DEFINED
+#undef yy_init_buffer
+#endif
+#ifndef hsql__flush_buffer_ALREADY_DEFINED
+#undef yy_flush_buffer
+#endif
+#ifndef hsql__load_buffer_state_ALREADY_DEFINED
+#undef yy_load_buffer_state
+#endif
+#ifndef hsql__switch_to_buffer_ALREADY_DEFINED
+#undef yy_switch_to_buffer
+#endif
+#ifndef hsql_push_buffer_state_ALREADY_DEFINED
+#undef yypush_buffer_state
+#endif
+#ifndef hsql_pop_buffer_state_ALREADY_DEFINED
+#undef yypop_buffer_state
+#endif
+#ifndef hsql_ensure_buffer_stack_ALREADY_DEFINED
+#undef yyensure_buffer_stack
+#endif
+#ifndef hsql_lex_ALREADY_DEFINED
+#undef yylex
+#endif
+#ifndef hsql_restart_ALREADY_DEFINED
+#undef yyrestart
+#endif
+#ifndef hsql_lex_init_ALREADY_DEFINED
+#undef yylex_init
+#endif
+#ifndef hsql_lex_init_extra_ALREADY_DEFINED
+#undef yylex_init_extra
+#endif
+#ifndef hsql_lex_destroy_ALREADY_DEFINED
+#undef yylex_destroy
+#endif
+#ifndef hsql_get_debug_ALREADY_DEFINED
+#undef yyget_debug
+#endif
+#ifndef hsql_set_debug_ALREADY_DEFINED
+#undef yyset_debug
+#endif
+#ifndef hsql_get_extra_ALREADY_DEFINED
+#undef yyget_extra
+#endif
+#ifndef hsql_set_extra_ALREADY_DEFINED
+#undef yyset_extra
+#endif
+#ifndef hsql_get_in_ALREADY_DEFINED
+#undef yyget_in
+#endif
+#ifndef hsql_set_in_ALREADY_DEFINED
+#undef yyset_in
+#endif
+#ifndef hsql_get_out_ALREADY_DEFINED
+#undef yyget_out
+#endif
+#ifndef hsql_set_out_ALREADY_DEFINED
+#undef yyset_out
+#endif
+#ifndef hsql_get_leng_ALREADY_DEFINED
+#undef yyget_leng
+#endif
+#ifndef hsql_get_text_ALREADY_DEFINED
+#undef yyget_text
+#endif
+#ifndef hsql_get_lineno_ALREADY_DEFINED
+#undef yyget_lineno
+#endif
+#ifndef hsql_set_lineno_ALREADY_DEFINED
+#undef yyset_lineno
+#endif
+#ifndef hsql_get_column_ALREADY_DEFINED
+#undef yyget_column
+#endif
+#ifndef hsql_set_column_ALREADY_DEFINED
+#undef yyset_column
+#endif
+#ifndef hsql_wrap_ALREADY_DEFINED
+#undef yywrap
+#endif
+#ifndef hsql_get_lval_ALREADY_DEFINED
+#undef yyget_lval
+#endif
+#ifndef hsql_set_lval_ALREADY_DEFINED
+#undef yyset_lval
+#endif
+#ifndef hsql_get_lloc_ALREADY_DEFINED
+#undef yyget_lloc
+#endif
+#ifndef hsql_set_lloc_ALREADY_DEFINED
+#undef yyset_lloc
+#endif
+#ifndef hsql_alloc_ALREADY_DEFINED
+#undef yyalloc
+#endif
+#ifndef hsql_realloc_ALREADY_DEFINED
+#undef yyrealloc
+#endif
+#ifndef hsql_free_ALREADY_DEFINED
+#undef yyfree
+#endif
+#ifndef hsql_text_ALREADY_DEFINED
+#undef yytext
+#endif
+#ifndef hsql_leng_ALREADY_DEFINED
+#undef yyleng
+#endif
+#ifndef hsql_in_ALREADY_DEFINED
+#undef yyin
+#endif
+#ifndef hsql_out_ALREADY_DEFINED
+#undef yyout
+#endif
+#ifndef hsql__flex_debug_ALREADY_DEFINED
+#undef yy_flex_debug
+#endif
+#ifndef hsql_lineno_ALREADY_DEFINED
+#undef yylineno
+#endif
+#ifndef hsql_tables_fload_ALREADY_DEFINED
+#undef yytables_fload
+#endif
+#ifndef hsql_tables_destroy_ALREADY_DEFINED
+#undef yytables_destroy
+#endif
+#ifndef hsql_TABLES_NAME_ALREADY_DEFINED
+#undef yyTABLES_NAME
+#endif
+
+#line 298 "flex_lexer.l"
 
 
-#line 352 "flex_lexer.h"
+#line 736 "flex_lexer.h"
 #undef hsql_IN_HEADER
 #endif /* hsql_HEADER_H */

--- a/src/parser/flex_lexer.h
+++ b/src/parser/flex_lexer.h
@@ -2,9 +2,9 @@
 #define hsql_HEADER_H 1
 #define hsql_IN_HEADER 1
 
-#line 5 "flex_lexer.h"
+#line 6 "flex_lexer.h"
 
-#line 7 "flex_lexer.h"
+#line 8 "flex_lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -733,6 +733,6 @@ extern int yylex \
 #line 298 "flex_lexer.l"
 
 
-#line 736 "flex_lexer.h"
+#line 737 "flex_lexer.h"
 #undef hsql_IN_HEADER
 #endif /* hsql_HEADER_H */

--- a/src/parser/flex_lexer.l
+++ b/src/parser/flex_lexer.l
@@ -238,6 +238,16 @@ CHARACTER[ \t\n]+VARYING TOKEN(CHARACTER_VARYING)
 ">="        TOKEN(GREATEREQ)
 "||"        TOKEN(CONCAT)
 
+\$[0-9]+    {
+  yylval->ival = atoll(yytext + 1);
+  return SQL_DOLLAR_PARAM;
+}
+
+:[A-Za-z][A-Za-z0-9_]*  {
+  yylval->sval = strdup(yytext + 1);
+  return SQL_NAMED_PARAM;
+}
+
 [-+*/(){},.;<>=^%:?[\]|]    { return yytext[0]; }
 
 [0-9]+"."[0-9]* |

--- a/src/parser/flex_lexer.l
+++ b/src/parser/flex_lexer.l
@@ -41,7 +41,7 @@ static thread_local std::stringstream strbuf;
 
 /* other flags */
 %option noyywrap
-%option nounput
+%option noinput nounput
 %option warn
 %option case-insensitive
 %option prefix="hsql_"

--- a/src/sql/Expr.cpp
+++ b/src/sql/Expr.cpp
@@ -221,7 +221,8 @@ Expr* Expr::makeFunctionRef(char* func_name, std::vector<Expr*>* exprList, bool 
   return e;
 }
 
-Expr* Expr::makeFunctionRef(char* func_name, char* schema, std::vector<Expr*>* exprList, bool distinct, WindowDescription* window) {
+Expr* Expr::makeFunctionRef(char* func_name, char* schema, std::vector<Expr*>* exprList, bool distinct,
+                            WindowDescription* window) {
   Expr* e = new Expr(kExprFunctionRef);
   e->name = func_name;
   e->schema = schema;
@@ -247,6 +248,18 @@ Expr* Expr::makeArrayIndex(Expr* expr, int64_t index) {
 Expr* Expr::makeParameter(int id) {
   Expr* e = new Expr(kExprParameter);
   e->ival = id;
+  return e;
+}
+
+Expr* Expr::makeDollarParameter(int64_t n) {
+  Expr* e = new Expr(kExprParameterDollar);
+  e->ival = n;
+  return e;
+}
+
+Expr* Expr::makeNamedParameter(char* name) {
+  Expr* e = new Expr(kExprParameterNamed);
+  e->name = name;
   return e;
 }
 
@@ -299,7 +312,8 @@ bool Expr::isType(ExprType exprType) const { return exprType == type; }
 
 bool Expr::isLiteral() const {
   return isType(kExprLiteralInt) || isType(kExprLiteralFloat) || isType(kExprLiteralString) || isType(kExprParameter) ||
-         isType(kExprLiteralNull) || isType(kExprLiteralDate) || isType(kExprLiteralInterval);
+         isType(kExprParameterDollar) || isType(kExprParameterNamed) || isType(kExprLiteralNull) ||
+         isType(kExprLiteralDate) || isType(kExprLiteralInterval);
 }
 
 bool Expr::hasAlias() const { return alias != nullptr; }

--- a/src/sql/Expr.h
+++ b/src/sql/Expr.h
@@ -23,6 +23,8 @@ enum ExprType {
   kExprLiteralInterval,
   kExprStar,
   kExprParameter,
+  kExprParameterDollar,
+  kExprParameterNamed,
   kExprColumnRef,
   kExprFunctionRef,
   kExprOperator,
@@ -201,13 +203,18 @@ struct Expr {
 
   static Expr* makeFunctionRef(char* func_name, std::vector<Expr*>* exprList, bool distinct, WindowDescription* window);
 
-  static Expr* makeFunctionRef(char* func_name, char* schema, std::vector<Expr*>* exprList, bool distinct, WindowDescription* window);
+  static Expr* makeFunctionRef(char* func_name, char* schema, std::vector<Expr*>* exprList, bool distinct,
+                               WindowDescription* window);
 
   static Expr* makeArray(std::vector<Expr*>* exprList);
 
   static Expr* makeArrayIndex(Expr* expr, int64_t index);
 
   static Expr* makeParameter(int id);
+
+  static Expr* makeDollarParameter(int64_t n);
+
+  static Expr* makeNamedParameter(char* name);
 
   static Expr* makeSelect(SelectStatement* select);
 

--- a/src/util/sqlhelper.cpp
+++ b/src/util/sqlhelper.cpp
@@ -1,9 +1,9 @@
 #include "sqlhelper.h"
 
+#include <stdint.h>
 #include <iostream>
 #include <map>
 #include <sstream>
-#include <stdint.h>
 #include <string>
 
 namespace hsql {
@@ -151,6 +151,12 @@ void printExpression(Expr* expr, uintmax_t num_indent) {
       break;
     case kExprParameter:
       inprint(expr->ival, num_indent);
+      break;
+    case kExprParameterDollar:
+      inprint(expr->ival, num_indent);
+      break;
+    case kExprParameterNamed:
+      inprint(expr->name, num_indent);
       break;
     case kExprArray:
       for (Expr* e : *expr->exprList) {

--- a/test/prepare_tests.cpp
+++ b/test/prepare_tests.cpp
@@ -5,6 +5,8 @@
 
 using hsql::kExprLiteralInt;
 using hsql::kExprParameter;
+using hsql::kExprParameterDollar;
+using hsql::kExprParameterNamed;
 
 using hsql::kStmtDrop;
 using hsql::kStmtExecute;
@@ -60,6 +62,49 @@ TEST(StatementWithParameters) {
   ASSERT(eq2->expr2->isType(kExprParameter));
   ASSERT_EQ(eq2->expr2->ival, 1);
   ASSERT_EQ(result.parameters()[1], eq2->expr2);
+}
+
+TEST(StatementWithDollarParameters) {
+  TEST_PARSE_SINGLE_SQL("SELECT * FROM test WHERE a = $1 AND b = $2", kStmtSelect, SelectStatement, result, stmt);
+
+  const hsql::Expr* eq1 = stmt->whereClause->expr;
+  const hsql::Expr* eq2 = stmt->whereClause->expr2;
+
+  ASSERT_EQ(result.parameters().size(), 2);
+
+  ASSERT(eq1->expr2->isType(kExprParameterDollar));
+  ASSERT_EQ(eq1->expr2->ival, 1);
+
+  ASSERT(eq2->expr2->isType(kExprParameterDollar));
+  ASSERT_EQ(eq2->expr2->ival, 2);
+}
+
+TEST(StatementWithDollarParametersOutOfOrder) {
+  TEST_PARSE_SINGLE_SQL("SELECT * FROM test WHERE a = $2 AND b = $1", kStmtSelect, SelectStatement, result, stmt);
+  (void)stmt;
+
+  ASSERT_EQ(result.parameters().size(), 2);
+
+  // addParameter sorts by ival, so the explicit positions order the result vector.
+  ASSERT(result.parameters()[0]->isType(kExprParameterDollar));
+  ASSERT_EQ(result.parameters()[0]->ival, 1);
+  ASSERT(result.parameters()[1]->isType(kExprParameterDollar));
+  ASSERT_EQ(result.parameters()[1]->ival, 2);
+}
+
+TEST(StatementWithNamedParameters) {
+  TEST_PARSE_SINGLE_SQL("SELECT * FROM test WHERE a = :user AND b = :id", kStmtSelect, SelectStatement, result, stmt);
+
+  const hsql::Expr* eq1 = stmt->whereClause->expr;
+  const hsql::Expr* eq2 = stmt->whereClause->expr2;
+
+  ASSERT_EQ(result.parameters().size(), 2);
+
+  ASSERT(eq1->expr2->isType(kExprParameterNamed));
+  ASSERT_STREQ(eq1->expr2->name, "user");
+
+  ASSERT(eq2->expr2->isType(kExprParameterNamed));
+  ASSERT_STREQ(eq2->expr2->name, "id");
 }
 
 TEST(ExecuteStatementTest) {

--- a/test/prepare_tests.cpp
+++ b/test/prepare_tests.cpp
@@ -55,12 +55,14 @@ TEST(StatementWithParameters) {
   ASSERT(eq1->expr->isType(hsql::kExprColumnRef));
   ASSERT(eq1->expr2->isType(kExprParameter));
   ASSERT_EQ(eq1->expr2->ival, 0);
+  ASSERT_EQ(eq1->expr2->ival2, 29);  // start column of first '?'
   ASSERT_EQ(result.parameters()[0], eq1->expr2);
 
   ASSERT_EQ(eq2->opType, hsql::kOpEquals);
   ASSERT(eq2->expr->isType(hsql::kExprColumnRef));
   ASSERT(eq2->expr2->isType(kExprParameter));
   ASSERT_EQ(eq2->expr2->ival, 1);
+  ASSERT_EQ(eq2->expr2->ival2, 39);  // start column of second '?'
   ASSERT_EQ(result.parameters()[1], eq2->expr2);
 }
 
@@ -74,9 +76,11 @@ TEST(StatementWithDollarParameters) {
 
   ASSERT(eq1->expr2->isType(kExprParameterDollar));
   ASSERT_EQ(eq1->expr2->ival, 1);
+  ASSERT_EQ(eq1->expr2->ival2, 29);  // start column of "$1"
 
   ASSERT(eq2->expr2->isType(kExprParameterDollar));
   ASSERT_EQ(eq2->expr2->ival, 2);
+  ASSERT_EQ(eq2->expr2->ival2, 40);  // start column of "$2"
 }
 
 TEST(StatementWithDollarParametersOutOfOrder) {
@@ -85,11 +89,14 @@ TEST(StatementWithDollarParametersOutOfOrder) {
 
   ASSERT_EQ(result.parameters().size(), 2);
 
-  // addParameter sorts by ival, so the explicit positions order the result vector.
+  // addParameter sorts by ival, so the explicit positions order the result vector
+  // but ival2 (source column) is independent and reflects the textual order.
   ASSERT(result.parameters()[0]->isType(kExprParameterDollar));
   ASSERT_EQ(result.parameters()[0]->ival, 1);
+  ASSERT_EQ(result.parameters()[0]->ival2, 40);  // "$1" appears at column 40
   ASSERT(result.parameters()[1]->isType(kExprParameterDollar));
   ASSERT_EQ(result.parameters()[1]->ival, 2);
+  ASSERT_EQ(result.parameters()[1]->ival2, 29);  // "$2" appears at column 29
 }
 
 TEST(StatementWithNamedParameters) {
@@ -102,9 +109,11 @@ TEST(StatementWithNamedParameters) {
 
   ASSERT(eq1->expr2->isType(kExprParameterNamed));
   ASSERT_STREQ(eq1->expr2->name, "user");
+  ASSERT_EQ(eq1->expr2->ival2, 29);  // start column of ":user"
 
   ASSERT(eq2->expr2->isType(kExprParameterNamed));
   ASSERT_STREQ(eq2->expr2->name, "id");
+  ASSERT_EQ(eq2->expr2->ival2, 43);  // start column of ":id"
 }
 
 TEST(ExecuteStatementTest) {

--- a/test/queries/queries-bad.sql
+++ b/test/queries/queries-bad.sql
@@ -110,3 +110,6 @@
 !COPY students FROM 'file_path' WITH (NULL '', QUOTE '"', DELIMITER '|', DELIMITER '/');
 !COPY students FROM 'file_path' WITH (QUOTE '"', NULL '', DELIMITER '/', QUOTE '_',);
 !COPY students FROM 'file_path' WITH (FORMAT CSV, QUOTE '"', DELIMINIMITER '|');
+# Placeholders: rejected $0, lone $
+!SELECT * FROM t WHERE a = $0;
+!SELECT * FROM t WHERE a = $;

--- a/test/queries/queries-bad.sql
+++ b/test/queries/queries-bad.sql
@@ -84,10 +84,9 @@
 !SELECT * FROM foo INNER JOIN bar USING (a AS b);
 !SELECT * FROM foo INNER JOIN bar USING (1);
 # INSERT, EXECUTE, and HINTS only allow specific expressions.
-!INSERT INTO foo VALUES (?);
+# '?', '$N' and ':name' placeholders are accepted in INSERT VALUES and EXECUTE.
 !INSERT INTO foo VALUES (CAST(column_a AS INT));
 !INSERT INTO foo VALUES (AVG(another_column));
-!EXECUTE statement_a(?);
 !EXECUTE statement_a(CAST(column_a AS INT));
 !EXECUTE statement_a(AVG(another_column));
 !SELECT * FROM foo WITH HINT (?);

--- a/test/queries/queries-good.sql
+++ b/test/queries/queries-good.sql
@@ -124,3 +124,5 @@ SELECT rank() OVER (PARTITION BY test1 ORDER BY test2) FROM test;
 SELECT * FROM t WHERE a = $1 AND b = $2;
 SELECT * FROM t WHERE a = :user AND b = :id;
 SELECT * FROM t WHERE a = ? AND b = :id AND c = $3;
+INSERT INTO foo VALUES (?);
+EXECUTE statement_a(?);

--- a/test/queries/queries-good.sql
+++ b/test/queries/queries-good.sql
@@ -120,3 +120,7 @@ SELECT test1, rank() OVER (ORDER BY test2 DESC, test3 ASC) rnk FROM test;
 SELECT rank() OVER () FROM test;
 SELECT rank() OVER (PARTITION BY test1) FROM test;
 SELECT rank() OVER (PARTITION BY test1 ORDER BY test2) FROM test;
+# Placeholders: PostgreSQL $N and SQLite :name
+SELECT * FROM t WHERE a = $1 AND b = $2;
+SELECT * FROM t WHERE a = :user AND b = :id;
+SELECT * FROM t WHERE a = ? AND b = :id AND c = $3;

--- a/test/thirdparty/microtest/microtest.h
+++ b/test/thirdparty/microtest/microtest.h
@@ -23,51 +23,59 @@
 
 #define ASSERT(cond) ASSERT_TRUE(cond)
 
-#define ASSERT_TRUE(cond)                                       \
-  if (!(cond)) {                                                \
-    throw mt::AssertFailedException(#cond, __FILE__, __LINE__); \
-  }                                                             \
-  static_assert(true, "End call of macro with a semicolon.")
+#define ASSERT_TRUE(cond)                                         \
+  do {                                                            \
+    if (!(cond)) {                                                \
+      throw mt::AssertFailedException(#cond, __FILE__, __LINE__); \
+    }                                                             \
+  } while (false)
 
-#define ASSERT_FALSE(cond)                                      \
-  if (cond) {                                                   \
-    throw mt::AssertFailedException(#cond, __FILE__, __LINE__); \
-  }                                                             \
-  static_assert(true, "End call of macro with a semicolon.")
+#define ASSERT_FALSE(cond)                                        \
+  do {                                                            \
+    if (cond) {                                                   \
+      throw mt::AssertFailedException(#cond, __FILE__, __LINE__); \
+    }                                                             \
+  } while (false)
 
 #define ASSERT_NULL(value) ASSERT_TRUE(value == NULL)
 
 #define ASSERT_NOTNULL(value) ASSERT_TRUE(value != NULL)
 
-#define ASSERT_STREQ(a, b)                                             \
-  if (std::string(a).compare(std::string(b)) != 0) {                   \
-    printf("%s{    info} %s", mt::yellow(), mt::def());                \
-    std::cout << "Actual values: " << a << " != " << b << std::endl;   \
-    throw mt::AssertFailedException(#a " == " #b, __FILE__, __LINE__); \
-  }                                                                    \
-  static_assert(true, "End call of macro with a semicolon.")
+#define ASSERT_STREQ(a, b)                                               \
+  do {                                                                   \
+    if (std::string(a).compare(std::string(b)) != 0) {                   \
+      printf("%s{    info} %s", mt::yellow(), mt::def());                \
+      std::cout << "Actual values: " << a << " != " << b << std::endl;   \
+      throw mt::AssertFailedException(#a " == " #b, __FILE__, __LINE__); \
+    }                                                                    \
+  } while (false)
 
-#define ASSERT_STRNEQ(a, b)                                            \
-  if (std::string(a).compare(std::string(b)) == 0) {                   \
-    printf("%s{    info} %s", mt::yellow(), mt::def());                \
-    std::cout << "Actual values: " << a << " == " << b << std::endl;   \
-    throw mt::AssertFailedException(#a " != " #b, __FILE__, __LINE__); \
-  }                                                                    \
-  static_assert(true, "End call of macro with a semicolon.")
+#define ASSERT_STRNEQ(a, b)                                              \
+  do {                                                                   \
+    if (std::string(a).compare(std::string(b)) == 0) {                   \
+      printf("%s{    info} %s", mt::yellow(), mt::def());                \
+      std::cout << "Actual values: " << a << " == " << b << std::endl;   \
+      throw mt::AssertFailedException(#a " != " #b, __FILE__, __LINE__); \
+    }                                                                    \
+  } while (false)
 
-#define ASSERT_EQ(a, b)                                              \
-  if (a != b) {                                                      \
-    printf("%s{    info} %s", mt::yellow(), mt::def());              \
-    std::cout << "Actual values: " << a << " != " << b << std::endl; \
-  }                                                                  \
-  ASSERT(a == b)
+#define ASSERT_EQ(a, b)                                                \
+  do {                                                                 \
+    if (a != b) {                                                      \
+      printf("%s{    info} %s", mt::yellow(), mt::def());              \
+      std::cout << "Actual values: " << a << " != " << b << std::endl; \
+    }                                                                  \
+    ASSERT(a == b);                                                    \
+  } while (false)
 
-#define ASSERT_NEQ(a, b)                                             \
-  if (a == b) {                                                      \
-    printf("%s{    info} %s", mt::yellow(), mt::def());              \
-    std::cout << "Actual values: " << a << " == " << b << std::endl; \
-  }                                                                  \
-  ASSERT(a != b)
+#define ASSERT_NEQ(a, b)                                               \
+  do {                                                                 \
+    if (a == b) {                                                      \
+      printf("%s{    info} %s", mt::yellow(), mt::def());              \
+      std::cout << "Actual values: " << a << " == " << b << std::endl; \
+    }                                                                  \
+    ASSERT(a != b);                                                    \
+  } while (false)
 
 ////////////////
 // Unit Tests //

--- a/test/thirdparty/microtest/microtest.h
+++ b/test/thirdparty/microtest/microtest.h
@@ -48,7 +48,7 @@
   static_assert(true, "End call of macro with a semicolon.")
 
 #define ASSERT_STRNEQ(a, b)                                            \
-  if (std::string(a).compare(std::string(b)) != = 0) {                 \
+  if (std::string(a).compare(std::string(b)) == 0) {                   \
     printf("%s{    info} %s", mt::yellow(), mt::def());                \
     std::cout << "Actual values: " << a << " == " << b << std::endl;   \
     throw mt::AssertFailedException(#a " != " #b, __FILE__, __LINE__); \


### PR DESCRIPTION
Extends the parser to recognise two placeholder forms alongside the existing ?:

- $N (PostgreSQL 1-based explicit numbering, e.g. WHERE a = $1)
- :name (SQLite named, e.g. WHERE a = :user)

The ? path is unchanged at every layer (lexer, parser, AST, result ordering); existing tests under test/prepare_tests.cpp pass untouched.

Implementation:

- New lexer rules for \$[0-9]+ and :[A-Za-z][A-Za-z0-9_]* placed before the punctuation catch-all. $ was previously unused; : was in the punctuation class but never referenced by any grammar rule, so the longer :identifier match wins without conflict.
- New bison tokens DOLLAR_PARAM (carries the int N) and NAMED_PARAM (carries the identifier). param_expr now has three alternatives. $0 is rejected via YYERROR at parse time.
- Three ExprType values appended (no ordinal change): kExprParameter for ?, kExprParameterDollar for $N (ival = N, 1-based), and kExprParameterNamed for :name (name = identifier). Distinct enum values rather than one with discriminator fields keep consumer switch statements explicit and round-trip printing straightforward.
- Factory functions Expr::makeDollarParameter and makeNamedParameter. isLiteral returns true for all three. The destructor already frees name so no further changes are needed.
- The top-level input rule's renumber loop only touches kExprParameter; $N keeps its explicit ival, :name keeps its name. SQLParserResult::addParameter still sorts by ival, which now orders $N by explicit position and clusters named placeholders.
- sqlhelper print case extended to handle the two new ExprType values.

Tests:

- Three new cases in test/prepare_tests.cpp covering $N, $N declared out of order (verifying ival-sorted result vector), and :name.
- Three new good queries and two new bad queries ($0, lone $) in test/queries/.
- bison -v reports no new shift/reduce or reduce/reduce conflicts.
- make test passes all three checks (SQL tests, valgrind, grammar).