### PR TITLE
Add support for three-part column references

### DIFF
--- a/src/parser/bison_parser.cpp
+++ b/src/parser/bison_parser.cpp
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -33,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -40,11 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Identify Bison output.  */
-#define YYBISON 1
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -68,9 +73,8 @@
 #define yydebug         hsql_debug
 #define yynerrs         hsql_nerrs
 
-
-/* Copy the first part of user declarations.  */
-#line 2 "bison_parser.y" /* yacc.c:339  */
+/* First part of user prologue.  */
+#line 2 "bison_parser.y"
 
 
 /**
@@ -101,394 +105,460 @@
   }
   // clang-format off
 
-#line 105 "bison_parser.cpp" /* yacc.c:339  */
+#line 109 "bison_parser.cpp"
 
-# ifndef YY_NULLPTR
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULLPTR nullptr
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
 #  else
-#   define YY_NULLPTR 0
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
 #  endif
 # endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 1
-#endif
-
-/* In a future release of Bison, this section will be replaced
-   by #include "bison_parser.h".  */
-#ifndef YY_HSQL_BISON_PARSER_H_INCLUDED
-# define YY_HSQL_BISON_PARSER_H_INCLUDED
-/* Debug traces.  */
-#ifndef HSQL_DEBUG
-# if defined YYDEBUG
-#if YYDEBUG
-#   define HSQL_DEBUG 1
-#  else
-#   define HSQL_DEBUG 0
-#  endif
-# else /* ! defined YYDEBUG */
-#  define HSQL_DEBUG 0
-# endif /* ! defined YYDEBUG */
-#endif  /* ! defined HSQL_DEBUG */
-#if HSQL_DEBUG
-extern int hsql_debug;
-#endif
-/* "%code requires" blocks.  */
-#line 39 "bison_parser.y" /* yacc.c:355  */
-
-// %code requires block
-
-#include "../SQLParserResult.h"
-#include "../sql/statements.h"
-#include "parser_typedef.h"
-
-// Auto update column and line number
-#define YY_USER_ACTION                        \
-  yylloc->first_line = yylloc->last_line;     \
-  yylloc->first_column = yylloc->last_column; \
-  for (int i = 0; yytext[i] != '\0'; i++) {   \
-    yylloc->total_column++;                   \
-    yylloc->string_length++;                  \
-    if (yytext[i] == '\n') {                  \
-      yylloc->last_line++;                    \
-      yylloc->last_column = 0;                \
-    } else {                                  \
-      yylloc->last_column++;                  \
-    }                                         \
-  }
-
-#line 166 "bison_parser.cpp" /* yacc.c:355  */
-
-/* Token type.  */
-#ifndef HSQL_TOKENTYPE
-# define HSQL_TOKENTYPE
-  enum hsql_tokentype
-  {
-    SQL_IDENTIFIER = 258,
-    SQL_STRING = 259,
-    SQL_FLOATVAL = 260,
-    SQL_INTVAL = 261,
-    SQL_DEALLOCATE = 262,
-    SQL_PARAMETERS = 263,
-    SQL_INTERSECT = 264,
-    SQL_TEMPORARY = 265,
-    SQL_TIMESTAMP = 266,
-    SQL_DISTINCT = 267,
-    SQL_NVARCHAR = 268,
-    SQL_RESTRICT = 269,
-    SQL_TRUNCATE = 270,
-    SQL_ANALYZE = 271,
-    SQL_BETWEEN = 272,
-    SQL_CASCADE = 273,
-    SQL_COLUMNS = 274,
-    SQL_CONTROL = 275,
-    SQL_DEFAULT = 276,
-    SQL_EXECUTE = 277,
-    SQL_EXPLAIN = 278,
-    SQL_ENCODING = 279,
-    SQL_INTEGER = 280,
-    SQL_NATURAL = 281,
-    SQL_PREPARE = 282,
-    SQL_SCHEMAS = 283,
-    SQL_CHARACTER_VARYING = 284,
-    SQL_REAL = 285,
-    SQL_DECIMAL = 286,
-    SQL_SMALLINT = 287,
-    SQL_BIGINT = 288,
-    SQL_SPATIAL = 289,
-    SQL_VARCHAR = 290,
-    SQL_VIRTUAL = 291,
-    SQL_DESCRIBE = 292,
-    SQL_BEFORE = 293,
-    SQL_COLUMN = 294,
-    SQL_CREATE = 295,
-    SQL_DELETE = 296,
-    SQL_DIRECT = 297,
-    SQL_DOUBLE = 298,
-    SQL_ESCAPE = 299,
-    SQL_EXCEPT = 300,
-    SQL_EXISTS = 301,
-    SQL_EXTRACT = 302,
-    SQL_CAST = 303,
-    SQL_FORMAT = 304,
-    SQL_GLOBAL = 305,
-    SQL_HAVING = 306,
-    SQL_IMPORT = 307,
-    SQL_INSERT = 308,
-    SQL_ISNULL = 309,
-    SQL_OFFSET = 310,
-    SQL_RENAME = 311,
-    SQL_SCHEMA = 312,
-    SQL_SELECT = 313,
-    SQL_SORTED = 314,
-    SQL_TABLES = 315,
-    SQL_UNLOAD = 316,
-    SQL_UPDATE = 317,
-    SQL_VALUES = 318,
-    SQL_AFTER = 319,
-    SQL_ALTER = 320,
-    SQL_CROSS = 321,
-    SQL_DELTA = 322,
-    SQL_FLOAT = 323,
-    SQL_GROUP = 324,
-    SQL_INDEX = 325,
-    SQL_INNER = 326,
-    SQL_LIMIT = 327,
-    SQL_LOCAL = 328,
-    SQL_MERGE = 329,
-    SQL_MINUS = 330,
-    SQL_ORDER = 331,
-    SQL_OVER = 332,
-    SQL_OUTER = 333,
-    SQL_RIGHT = 334,
-    SQL_TABLE = 335,
-    SQL_UNION = 336,
-    SQL_USING = 337,
-    SQL_WHERE = 338,
-    SQL_CALL = 339,
-    SQL_CASE = 340,
-    SQL_CHAR = 341,
-    SQL_COPY = 342,
-    SQL_DATE = 343,
-    SQL_DATETIME = 344,
-    SQL_DESC = 345,
-    SQL_DROP = 346,
-    SQL_ELSE = 347,
-    SQL_FILE = 348,
-    SQL_FROM = 349,
-    SQL_FULL = 350,
-    SQL_HASH = 351,
-    SQL_HINT = 352,
-    SQL_INTO = 353,
-    SQL_JOIN = 354,
-    SQL_LEFT = 355,
-    SQL_LIKE = 356,
-    SQL_LOAD = 357,
-    SQL_LONG = 358,
-    SQL_NULL = 359,
-    SQL_PARTITION = 360,
-    SQL_PLAN = 361,
-    SQL_SHOW = 362,
-    SQL_TEXT = 363,
-    SQL_THEN = 364,
-    SQL_TIME = 365,
-    SQL_VIEW = 366,
-    SQL_WHEN = 367,
-    SQL_WITH = 368,
-    SQL_ADD = 369,
-    SQL_ALL = 370,
-    SQL_AND = 371,
-    SQL_ASC = 372,
-    SQL_END = 373,
-    SQL_FOR = 374,
-    SQL_INT = 375,
-    SQL_NOT = 376,
-    SQL_OFF = 377,
-    SQL_SET = 378,
-    SQL_TOP = 379,
-    SQL_AS = 380,
-    SQL_BY = 381,
-    SQL_IF = 382,
-    SQL_IN = 383,
-    SQL_IS = 384,
-    SQL_OF = 385,
-    SQL_ON = 386,
-    SQL_OR = 387,
-    SQL_TO = 388,
-    SQL_NO = 389,
-    SQL_ARRAY = 390,
-    SQL_CONCAT = 391,
-    SQL_ILIKE = 392,
-    SQL_SECOND = 393,
-    SQL_MINUTE = 394,
-    SQL_HOUR = 395,
-    SQL_DAY = 396,
-    SQL_MONTH = 397,
-    SQL_YEAR = 398,
-    SQL_SECONDS = 399,
-    SQL_MINUTES = 400,
-    SQL_HOURS = 401,
-    SQL_DAYS = 402,
-    SQL_MONTHS = 403,
-    SQL_YEARS = 404,
-    SQL_INTERVAL = 405,
-    SQL_TRUE = 406,
-    SQL_FALSE = 407,
-    SQL_BOOLEAN = 408,
-    SQL_TRANSACTION = 409,
-    SQL_BEGIN = 410,
-    SQL_COMMIT = 411,
-    SQL_ROLLBACK = 412,
-    SQL_NOWAIT = 413,
-    SQL_SKIP = 414,
-    SQL_LOCKED = 415,
-    SQL_SHARE = 416,
-    SQL_RANGE = 417,
-    SQL_ROWS = 418,
-    SQL_GROUPS = 419,
-    SQL_UNBOUNDED = 420,
-    SQL_FOLLOWING = 421,
-    SQL_PRECEDING = 422,
-    SQL_CURRENT_ROW = 423,
-    SQL_UNIQUE = 424,
-    SQL_PRIMARY = 425,
-    SQL_FOREIGN = 426,
-    SQL_KEY = 427,
-    SQL_REFERENCES = 428,
-    SQL_EQUALS = 429,
-    SQL_NOTEQUALS = 430,
-    SQL_LESS = 431,
-    SQL_GREATER = 432,
-    SQL_LESSEQ = 433,
-    SQL_GREATEREQ = 434,
-    SQL_NOTNULL = 435,
-    SQL_UMINUS = 436
-  };
-#endif
-
-/* Value type.  */
-#if ! defined HSQL_STYPE && ! defined HSQL_STYPE_IS_DECLARED
-
-union HSQL_STYPE
+#include "bison_parser.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
 {
-#line 102 "bison_parser.y" /* yacc.c:355  */
-
-  // clang-format on
-  bool bval;
-  char* sval;
-  double fval;
-  int64_t ival;
-  uintmax_t uval;
-
-  // statements
-  hsql::AlterStatement* alter_stmt;
-  hsql::CreateStatement* create_stmt;
-  hsql::DeleteStatement* delete_stmt;
-  hsql::DropStatement* drop_stmt;
-  hsql::ExecuteStatement* exec_stmt;
-  hsql::ExportStatement* export_stmt;
-  hsql::ImportStatement* import_stmt;
-  hsql::InsertStatement* insert_stmt;
-  hsql::PrepareStatement* prep_stmt;
-  hsql::SelectStatement* select_stmt;
-  hsql::ShowStatement* show_stmt;
-  hsql::SQLStatement* statement;
-  hsql::TransactionStatement* transaction_stmt;
-  hsql::UpdateStatement* update_stmt;
-
-  hsql::Alias* alias_t;
-  hsql::AlterAction* alter_action_t;
-  hsql::ColumnConstraints* column_constraints_t;
-  hsql::ColumnDefinition* column_t;
-  hsql::ColumnType column_type_t;
-  hsql::ConstraintType column_constraint_t;
-  hsql::DatetimeField datetime_field;
-  hsql::DropColumnAction* drop_action_t;
-  hsql::Expr* expr;
-  hsql::FrameBound* frame_bound;
-  hsql::FrameDescription* frame_description;
-  hsql::FrameType frame_type;
-  hsql::GroupByDescription* group_t;
-  hsql::ImportType import_type_t;
-  hsql::JoinType join_type;
-  hsql::LimitDescription* limit;
-  hsql::LockingClause* locking_t;
-  hsql::OrderDescription* order;
-  hsql::OrderType order_type;
-  hsql::NullOrdering null_ordering_t;
-  hsql::ReferencesSpecification* references_spec_t;
-  hsql::SetOperation* set_operator_t;
-  hsql::TableConstraint* table_constraint_t;
-  hsql::TableElement* table_element_t;
-  hsql::TableName table_name;
-  hsql::TableRef* table;
-  hsql::UpdateClause* update_t;
-  hsql::WindowDescription* window_description;
-  hsql::WithDescription* with_description_t;
-
-  std::vector<char*>* str_vec;
-  std::vector<hsql::Expr*>* expr_vec;
-  std::vector<hsql::OrderDescription*>* order_vec;
-  std::vector<hsql::SQLStatement*>* stmt_vec;
-  std::vector<hsql::TableElement*>* table_element_vec;
-  std::vector<hsql::TableRef*>* table_vec;
-  std::vector<hsql::UpdateClause*>* update_vec;
-  std::vector<hsql::WithDescription*>* with_description_vec;
-  std::vector<hsql::LockingClause*>* locking_clause_vec;
-
-  std::pair<int64_t, int64_t>* ival_pair;
-
-  hsql::RowLockMode lock_mode_t;
-  hsql::RowLockWaitPolicy lock_wait_policy_t;
-
-  hsql::ImportExportOptions* import_export_option_t;
-  std::pair<hsql::CsvOptionType, char*>* csv_option_t;
-
-  // clang-format off
-
-#line 435 "bison_parser.cpp" /* yacc.c:355  */
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_IDENTIFIER = 3,                 /* IDENTIFIER  */
+  YYSYMBOL_STRING = 4,                     /* STRING  */
+  YYSYMBOL_FLOATVAL = 5,                   /* FLOATVAL  */
+  YYSYMBOL_INTVAL = 6,                     /* INTVAL  */
+  YYSYMBOL_DEALLOCATE = 7,                 /* DEALLOCATE  */
+  YYSYMBOL_PARAMETERS = 8,                 /* PARAMETERS  */
+  YYSYMBOL_INTERSECT = 9,                  /* INTERSECT  */
+  YYSYMBOL_TEMPORARY = 10,                 /* TEMPORARY  */
+  YYSYMBOL_TIMESTAMP = 11,                 /* TIMESTAMP  */
+  YYSYMBOL_DISTINCT = 12,                  /* DISTINCT  */
+  YYSYMBOL_NVARCHAR = 13,                  /* NVARCHAR  */
+  YYSYMBOL_RESTRICT = 14,                  /* RESTRICT  */
+  YYSYMBOL_TRUNCATE = 15,                  /* TRUNCATE  */
+  YYSYMBOL_ANALYZE = 16,                   /* ANALYZE  */
+  YYSYMBOL_BETWEEN = 17,                   /* BETWEEN  */
+  YYSYMBOL_CASCADE = 18,                   /* CASCADE  */
+  YYSYMBOL_COLUMNS = 19,                   /* COLUMNS  */
+  YYSYMBOL_CONTROL = 20,                   /* CONTROL  */
+  YYSYMBOL_DEFAULT = 21,                   /* DEFAULT  */
+  YYSYMBOL_EXECUTE = 22,                   /* EXECUTE  */
+  YYSYMBOL_EXPLAIN = 23,                   /* EXPLAIN  */
+  YYSYMBOL_ENCODING = 24,                  /* ENCODING  */
+  YYSYMBOL_INTEGER = 25,                   /* INTEGER  */
+  YYSYMBOL_NATURAL = 26,                   /* NATURAL  */
+  YYSYMBOL_PREPARE = 27,                   /* PREPARE  */
+  YYSYMBOL_SCHEMAS = 28,                   /* SCHEMAS  */
+  YYSYMBOL_CHARACTER_VARYING = 29,         /* CHARACTER_VARYING  */
+  YYSYMBOL_REAL = 30,                      /* REAL  */
+  YYSYMBOL_DECIMAL = 31,                   /* DECIMAL  */
+  YYSYMBOL_SMALLINT = 32,                  /* SMALLINT  */
+  YYSYMBOL_BIGINT = 33,                    /* BIGINT  */
+  YYSYMBOL_SPATIAL = 34,                   /* SPATIAL  */
+  YYSYMBOL_VARCHAR = 35,                   /* VARCHAR  */
+  YYSYMBOL_VIRTUAL = 36,                   /* VIRTUAL  */
+  YYSYMBOL_DESCRIBE = 37,                  /* DESCRIBE  */
+  YYSYMBOL_BEFORE = 38,                    /* BEFORE  */
+  YYSYMBOL_COLUMN = 39,                    /* COLUMN  */
+  YYSYMBOL_CREATE = 40,                    /* CREATE  */
+  YYSYMBOL_DELETE = 41,                    /* DELETE  */
+  YYSYMBOL_DIRECT = 42,                    /* DIRECT  */
+  YYSYMBOL_DOUBLE = 43,                    /* DOUBLE  */
+  YYSYMBOL_ESCAPE = 44,                    /* ESCAPE  */
+  YYSYMBOL_EXCEPT = 45,                    /* EXCEPT  */
+  YYSYMBOL_EXISTS = 46,                    /* EXISTS  */
+  YYSYMBOL_EXTRACT = 47,                   /* EXTRACT  */
+  YYSYMBOL_CAST = 48,                      /* CAST  */
+  YYSYMBOL_FORMAT = 49,                    /* FORMAT  */
+  YYSYMBOL_GLOBAL = 50,                    /* GLOBAL  */
+  YYSYMBOL_HAVING = 51,                    /* HAVING  */
+  YYSYMBOL_IMPORT = 52,                    /* IMPORT  */
+  YYSYMBOL_INSERT = 53,                    /* INSERT  */
+  YYSYMBOL_ISNULL = 54,                    /* ISNULL  */
+  YYSYMBOL_OFFSET = 55,                    /* OFFSET  */
+  YYSYMBOL_RENAME = 56,                    /* RENAME  */
+  YYSYMBOL_SCHEMA = 57,                    /* SCHEMA  */
+  YYSYMBOL_SELECT = 58,                    /* SELECT  */
+  YYSYMBOL_SORTED = 59,                    /* SORTED  */
+  YYSYMBOL_TABLES = 60,                    /* TABLES  */
+  YYSYMBOL_UNLOAD = 61,                    /* UNLOAD  */
+  YYSYMBOL_UPDATE = 62,                    /* UPDATE  */
+  YYSYMBOL_VALUES = 63,                    /* VALUES  */
+  YYSYMBOL_AFTER = 64,                     /* AFTER  */
+  YYSYMBOL_ALTER = 65,                     /* ALTER  */
+  YYSYMBOL_CROSS = 66,                     /* CROSS  */
+  YYSYMBOL_DELTA = 67,                     /* DELTA  */
+  YYSYMBOL_FLOAT = 68,                     /* FLOAT  */
+  YYSYMBOL_GROUP = 69,                     /* GROUP  */
+  YYSYMBOL_INDEX = 70,                     /* INDEX  */
+  YYSYMBOL_INNER = 71,                     /* INNER  */
+  YYSYMBOL_LIMIT = 72,                     /* LIMIT  */
+  YYSYMBOL_LOCAL = 73,                     /* LOCAL  */
+  YYSYMBOL_MERGE = 74,                     /* MERGE  */
+  YYSYMBOL_MINUS = 75,                     /* MINUS  */
+  YYSYMBOL_ORDER = 76,                     /* ORDER  */
+  YYSYMBOL_OVER = 77,                      /* OVER  */
+  YYSYMBOL_OUTER = 78,                     /* OUTER  */
+  YYSYMBOL_RIGHT = 79,                     /* RIGHT  */
+  YYSYMBOL_TABLE = 80,                     /* TABLE  */
+  YYSYMBOL_UNION = 81,                     /* UNION  */
+  YYSYMBOL_USING = 82,                     /* USING  */
+  YYSYMBOL_WHERE = 83,                     /* WHERE  */
+  YYSYMBOL_CALL = 84,                      /* CALL  */
+  YYSYMBOL_CASE = 85,                      /* CASE  */
+  YYSYMBOL_CHAR = 86,                      /* CHAR  */
+  YYSYMBOL_COPY = 87,                      /* COPY  */
+  YYSYMBOL_DATE = 88,                      /* DATE  */
+  YYSYMBOL_DATETIME = 89,                  /* DATETIME  */
+  YYSYMBOL_DESC = 90,                      /* DESC  */
+  YYSYMBOL_DROP = 91,                      /* DROP  */
+  YYSYMBOL_ELSE = 92,                      /* ELSE  */
+  YYSYMBOL_FILE = 93,                      /* FILE  */
+  YYSYMBOL_FROM = 94,                      /* FROM  */
+  YYSYMBOL_FULL = 95,                      /* FULL  */
+  YYSYMBOL_HASH = 96,                      /* HASH  */
+  YYSYMBOL_HINT = 97,                      /* HINT  */
+  YYSYMBOL_INTO = 98,                      /* INTO  */
+  YYSYMBOL_JOIN = 99,                      /* JOIN  */
+  YYSYMBOL_LEFT = 100,                     /* LEFT  */
+  YYSYMBOL_LIKE = 101,                     /* LIKE  */
+  YYSYMBOL_LOAD = 102,                     /* LOAD  */
+  YYSYMBOL_LONG = 103,                     /* LONG  */
+  YYSYMBOL_NULL = 104,                     /* NULL  */
+  YYSYMBOL_PARTITION = 105,                /* PARTITION  */
+  YYSYMBOL_PLAN = 106,                     /* PLAN  */
+  YYSYMBOL_SHOW = 107,                     /* SHOW  */
+  YYSYMBOL_TEXT = 108,                     /* TEXT  */
+  YYSYMBOL_THEN = 109,                     /* THEN  */
+  YYSYMBOL_TIME = 110,                     /* TIME  */
+  YYSYMBOL_VIEW = 111,                     /* VIEW  */
+  YYSYMBOL_WHEN = 112,                     /* WHEN  */
+  YYSYMBOL_WITH = 113,                     /* WITH  */
+  YYSYMBOL_ADD = 114,                      /* ADD  */
+  YYSYMBOL_ALL = 115,                      /* ALL  */
+  YYSYMBOL_AND = 116,                      /* AND  */
+  YYSYMBOL_ASC = 117,                      /* ASC  */
+  YYSYMBOL_END = 118,                      /* END  */
+  YYSYMBOL_FOR = 119,                      /* FOR  */
+  YYSYMBOL_INT = 120,                      /* INT  */
+  YYSYMBOL_NOT = 121,                      /* NOT  */
+  YYSYMBOL_OFF = 122,                      /* OFF  */
+  YYSYMBOL_SET = 123,                      /* SET  */
+  YYSYMBOL_TOP = 124,                      /* TOP  */
+  YYSYMBOL_AS = 125,                       /* AS  */
+  YYSYMBOL_BY = 126,                       /* BY  */
+  YYSYMBOL_IF = 127,                       /* IF  */
+  YYSYMBOL_IN = 128,                       /* IN  */
+  YYSYMBOL_IS = 129,                       /* IS  */
+  YYSYMBOL_OF = 130,                       /* OF  */
+  YYSYMBOL_ON = 131,                       /* ON  */
+  YYSYMBOL_OR = 132,                       /* OR  */
+  YYSYMBOL_TO = 133,                       /* TO  */
+  YYSYMBOL_NO = 134,                       /* NO  */
+  YYSYMBOL_ARRAY = 135,                    /* ARRAY  */
+  YYSYMBOL_CONCAT = 136,                   /* CONCAT  */
+  YYSYMBOL_ILIKE = 137,                    /* ILIKE  */
+  YYSYMBOL_SECOND = 138,                   /* SECOND  */
+  YYSYMBOL_MINUTE = 139,                   /* MINUTE  */
+  YYSYMBOL_HOUR = 140,                     /* HOUR  */
+  YYSYMBOL_DAY = 141,                      /* DAY  */
+  YYSYMBOL_MONTH = 142,                    /* MONTH  */
+  YYSYMBOL_YEAR = 143,                     /* YEAR  */
+  YYSYMBOL_SECONDS = 144,                  /* SECONDS  */
+  YYSYMBOL_MINUTES = 145,                  /* MINUTES  */
+  YYSYMBOL_HOURS = 146,                    /* HOURS  */
+  YYSYMBOL_DAYS = 147,                     /* DAYS  */
+  YYSYMBOL_MONTHS = 148,                   /* MONTHS  */
+  YYSYMBOL_YEARS = 149,                    /* YEARS  */
+  YYSYMBOL_INTERVAL = 150,                 /* INTERVAL  */
+  YYSYMBOL_TRUE = 151,                     /* TRUE  */
+  YYSYMBOL_FALSE = 152,                    /* FALSE  */
+  YYSYMBOL_BOOLEAN = 153,                  /* BOOLEAN  */
+  YYSYMBOL_TRANSACTION = 154,              /* TRANSACTION  */
+  YYSYMBOL_BEGIN = 155,                    /* BEGIN  */
+  YYSYMBOL_COMMIT = 156,                   /* COMMIT  */
+  YYSYMBOL_ROLLBACK = 157,                 /* ROLLBACK  */
+  YYSYMBOL_NOWAIT = 158,                   /* NOWAIT  */
+  YYSYMBOL_SKIP = 159,                     /* SKIP  */
+  YYSYMBOL_LOCKED = 160,                   /* LOCKED  */
+  YYSYMBOL_SHARE = 161,                    /* SHARE  */
+  YYSYMBOL_RANGE = 162,                    /* RANGE  */
+  YYSYMBOL_ROWS = 163,                     /* ROWS  */
+  YYSYMBOL_GROUPS = 164,                   /* GROUPS  */
+  YYSYMBOL_UNBOUNDED = 165,                /* UNBOUNDED  */
+  YYSYMBOL_FOLLOWING = 166,                /* FOLLOWING  */
+  YYSYMBOL_PRECEDING = 167,                /* PRECEDING  */
+  YYSYMBOL_CURRENT_ROW = 168,              /* CURRENT_ROW  */
+  YYSYMBOL_UNIQUE = 169,                   /* UNIQUE  */
+  YYSYMBOL_PRIMARY = 170,                  /* PRIMARY  */
+  YYSYMBOL_FOREIGN = 171,                  /* FOREIGN  */
+  YYSYMBOL_KEY = 172,                      /* KEY  */
+  YYSYMBOL_REFERENCES = 173,               /* REFERENCES  */
+  YYSYMBOL_174_ = 174,                     /* '='  */
+  YYSYMBOL_EQUALS = 175,                   /* EQUALS  */
+  YYSYMBOL_NOTEQUALS = 176,                /* NOTEQUALS  */
+  YYSYMBOL_177_ = 177,                     /* '<'  */
+  YYSYMBOL_178_ = 178,                     /* '>'  */
+  YYSYMBOL_LESS = 179,                     /* LESS  */
+  YYSYMBOL_GREATER = 180,                  /* GREATER  */
+  YYSYMBOL_LESSEQ = 181,                   /* LESSEQ  */
+  YYSYMBOL_GREATEREQ = 182,                /* GREATEREQ  */
+  YYSYMBOL_NOTNULL = 183,                  /* NOTNULL  */
+  YYSYMBOL_184_ = 184,                     /* '+'  */
+  YYSYMBOL_185_ = 185,                     /* '-'  */
+  YYSYMBOL_186_ = 186,                     /* '*'  */
+  YYSYMBOL_187_ = 187,                     /* '/'  */
+  YYSYMBOL_188_ = 188,                     /* '%'  */
+  YYSYMBOL_189_ = 189,                     /* '^'  */
+  YYSYMBOL_UMINUS = 190,                   /* UMINUS  */
+  YYSYMBOL_191_ = 191,                     /* '['  */
+  YYSYMBOL_192_ = 192,                     /* ']'  */
+  YYSYMBOL_193_ = 193,                     /* '('  */
+  YYSYMBOL_194_ = 194,                     /* ')'  */
+  YYSYMBOL_195_ = 195,                     /* '.'  */
+  YYSYMBOL_196_ = 196,                     /* ';'  */
+  YYSYMBOL_197_ = 197,                     /* ','  */
+  YYSYMBOL_198_ = 198,                     /* '?'  */
+  YYSYMBOL_YYACCEPT = 199,                 /* $accept  */
+  YYSYMBOL_input = 200,                    /* input  */
+  YYSYMBOL_statement_list = 201,           /* statement_list  */
+  YYSYMBOL_statement = 202,                /* statement  */
+  YYSYMBOL_preparable_statement = 203,     /* preparable_statement  */
+  YYSYMBOL_opt_hints = 204,                /* opt_hints  */
+  YYSYMBOL_hint_list = 205,                /* hint_list  */
+  YYSYMBOL_hint = 206,                     /* hint  */
+  YYSYMBOL_transaction_statement = 207,    /* transaction_statement  */
+  YYSYMBOL_opt_transaction_keyword = 208,  /* opt_transaction_keyword  */
+  YYSYMBOL_prepare_statement = 209,        /* prepare_statement  */
+  YYSYMBOL_prepare_target_query = 210,     /* prepare_target_query  */
+  YYSYMBOL_execute_statement = 211,        /* execute_statement  */
+  YYSYMBOL_import_statement = 212,         /* import_statement  */
+  YYSYMBOL_file_type = 213,                /* file_type  */
+  YYSYMBOL_file_path = 214,                /* file_path  */
+  YYSYMBOL_opt_import_export_options = 215, /* opt_import_export_options  */
+  YYSYMBOL_import_export_options = 216,    /* import_export_options  */
+  YYSYMBOL_csv_option = 217,               /* csv_option  */
+  YYSYMBOL_export_statement = 218,         /* export_statement  */
+  YYSYMBOL_show_statement = 219,           /* show_statement  */
+  YYSYMBOL_create_statement = 220,         /* create_statement  */
+  YYSYMBOL_opt_not_exists = 221,           /* opt_not_exists  */
+  YYSYMBOL_table_elem_commalist = 222,     /* table_elem_commalist  */
+  YYSYMBOL_table_elem = 223,               /* table_elem  */
+  YYSYMBOL_column_def = 224,               /* column_def  */
+  YYSYMBOL_column_type = 225,              /* column_type  */
+  YYSYMBOL_opt_time_precision = 226,       /* opt_time_precision  */
+  YYSYMBOL_opt_decimal_specification = 227, /* opt_decimal_specification  */
+  YYSYMBOL_opt_column_constraints = 228,   /* opt_column_constraints  */
+  YYSYMBOL_column_constraints = 229,       /* column_constraints  */
+  YYSYMBOL_column_constraint = 230,        /* column_constraint  */
+  YYSYMBOL_table_constraint = 231,         /* table_constraint  */
+  YYSYMBOL_references_spec = 232,          /* references_spec  */
+  YYSYMBOL_drop_statement = 233,           /* drop_statement  */
+  YYSYMBOL_opt_exists = 234,               /* opt_exists  */
+  YYSYMBOL_alter_statement = 235,          /* alter_statement  */
+  YYSYMBOL_alter_action = 236,             /* alter_action  */
+  YYSYMBOL_drop_action = 237,              /* drop_action  */
+  YYSYMBOL_delete_statement = 238,         /* delete_statement  */
+  YYSYMBOL_truncate_statement = 239,       /* truncate_statement  */
+  YYSYMBOL_insert_statement = 240,         /* insert_statement  */
+  YYSYMBOL_opt_column_list = 241,          /* opt_column_list  */
+  YYSYMBOL_update_statement = 242,         /* update_statement  */
+  YYSYMBOL_update_clause_commalist = 243,  /* update_clause_commalist  */
+  YYSYMBOL_update_clause = 244,            /* update_clause  */
+  YYSYMBOL_select_statement = 245,         /* select_statement  */
+  YYSYMBOL_select_within_set_operation = 246, /* select_within_set_operation  */
+  YYSYMBOL_select_within_set_operation_no_parentheses = 247, /* select_within_set_operation_no_parentheses  */
+  YYSYMBOL_select_with_paren = 248,        /* select_with_paren  */
+  YYSYMBOL_select_no_paren = 249,          /* select_no_paren  */
+  YYSYMBOL_set_operator = 250,             /* set_operator  */
+  YYSYMBOL_set_type = 251,                 /* set_type  */
+  YYSYMBOL_opt_all = 252,                  /* opt_all  */
+  YYSYMBOL_select_clause = 253,            /* select_clause  */
+  YYSYMBOL_opt_distinct = 254,             /* opt_distinct  */
+  YYSYMBOL_select_list = 255,              /* select_list  */
+  YYSYMBOL_opt_from_clause = 256,          /* opt_from_clause  */
+  YYSYMBOL_from_clause = 257,              /* from_clause  */
+  YYSYMBOL_opt_where = 258,                /* opt_where  */
+  YYSYMBOL_opt_group = 259,                /* opt_group  */
+  YYSYMBOL_opt_having = 260,               /* opt_having  */
+  YYSYMBOL_opt_order = 261,                /* opt_order  */
+  YYSYMBOL_order_list = 262,               /* order_list  */
+  YYSYMBOL_order_desc = 263,               /* order_desc  */
+  YYSYMBOL_opt_order_type = 264,           /* opt_order_type  */
+  YYSYMBOL_opt_null_ordering = 265,        /* opt_null_ordering  */
+  YYSYMBOL_opt_top = 266,                  /* opt_top  */
+  YYSYMBOL_opt_limit = 267,                /* opt_limit  */
+  YYSYMBOL_expr_list = 268,                /* expr_list  */
+  YYSYMBOL_opt_extended_literal_list = 269, /* opt_extended_literal_list  */
+  YYSYMBOL_extended_literal_list = 270,    /* extended_literal_list  */
+  YYSYMBOL_casted_extended_literal = 271,  /* casted_extended_literal  */
+  YYSYMBOL_extended_literal = 272,         /* extended_literal  */
+  YYSYMBOL_expr_alias = 273,               /* expr_alias  */
+  YYSYMBOL_expr = 274,                     /* expr  */
+  YYSYMBOL_operand = 275,                  /* operand  */
+  YYSYMBOL_scalar_expr = 276,              /* scalar_expr  */
+  YYSYMBOL_unary_expr = 277,               /* unary_expr  */
+  YYSYMBOL_binary_expr = 278,              /* binary_expr  */
+  YYSYMBOL_logic_expr = 279,               /* logic_expr  */
+  YYSYMBOL_in_expr = 280,                  /* in_expr  */
+  YYSYMBOL_case_expr = 281,                /* case_expr  */
+  YYSYMBOL_case_list = 282,                /* case_list  */
+  YYSYMBOL_exists_expr = 283,              /* exists_expr  */
+  YYSYMBOL_comp_expr = 284,                /* comp_expr  */
+  YYSYMBOL_function_expr = 285,            /* function_expr  */
+  YYSYMBOL_opt_window = 286,               /* opt_window  */
+  YYSYMBOL_opt_partition = 287,            /* opt_partition  */
+  YYSYMBOL_opt_frame_clause = 288,         /* opt_frame_clause  */
+  YYSYMBOL_frame_type = 289,               /* frame_type  */
+  YYSYMBOL_frame_bound = 290,              /* frame_bound  */
+  YYSYMBOL_extract_expr = 291,             /* extract_expr  */
+  YYSYMBOL_cast_expr = 292,                /* cast_expr  */
+  YYSYMBOL_datetime_field = 293,           /* datetime_field  */
+  YYSYMBOL_datetime_field_plural = 294,    /* datetime_field_plural  */
+  YYSYMBOL_duration_field = 295,           /* duration_field  */
+  YYSYMBOL_array_expr = 296,               /* array_expr  */
+  YYSYMBOL_array_index = 297,              /* array_index  */
+  YYSYMBOL_between_expr = 298,             /* between_expr  */
+  YYSYMBOL_column_name = 299,              /* column_name  */
+  YYSYMBOL_literal = 300,                  /* literal  */
+  YYSYMBOL_string_literal = 301,           /* string_literal  */
+  YYSYMBOL_bool_literal = 302,             /* bool_literal  */
+  YYSYMBOL_num_literal = 303,              /* num_literal  */
+  YYSYMBOL_int_literal = 304,              /* int_literal  */
+  YYSYMBOL_null_literal = 305,             /* null_literal  */
+  YYSYMBOL_date_literal = 306,             /* date_literal  */
+  YYSYMBOL_interval_literal = 307,         /* interval_literal  */
+  YYSYMBOL_param_expr = 308,               /* param_expr  */
+  YYSYMBOL_table_ref = 309,                /* table_ref  */
+  YYSYMBOL_table_ref_atomic = 310,         /* table_ref_atomic  */
+  YYSYMBOL_nonjoin_table_ref_atomic = 311, /* nonjoin_table_ref_atomic  */
+  YYSYMBOL_table_ref_commalist = 312,      /* table_ref_commalist  */
+  YYSYMBOL_table_ref_name = 313,           /* table_ref_name  */
+  YYSYMBOL_table_ref_name_no_alias = 314,  /* table_ref_name_no_alias  */
+  YYSYMBOL_table_name = 315,               /* table_name  */
+  YYSYMBOL_opt_index_name = 316,           /* opt_index_name  */
+  YYSYMBOL_table_alias = 317,              /* table_alias  */
+  YYSYMBOL_opt_table_alias = 318,          /* opt_table_alias  */
+  YYSYMBOL_alias = 319,                    /* alias  */
+  YYSYMBOL_opt_alias = 320,                /* opt_alias  */
+  YYSYMBOL_opt_locking_clause = 321,       /* opt_locking_clause  */
+  YYSYMBOL_opt_locking_clause_list = 322,  /* opt_locking_clause_list  */
+  YYSYMBOL_locking_clause = 323,           /* locking_clause  */
+  YYSYMBOL_row_lock_mode = 324,            /* row_lock_mode  */
+  YYSYMBOL_opt_row_lock_policy = 325,      /* opt_row_lock_policy  */
+  YYSYMBOL_opt_with_clause = 326,          /* opt_with_clause  */
+  YYSYMBOL_with_clause = 327,              /* with_clause  */
+  YYSYMBOL_with_description_list = 328,    /* with_description_list  */
+  YYSYMBOL_with_description = 329,         /* with_description  */
+  YYSYMBOL_join_clause = 330,              /* join_clause  */
+  YYSYMBOL_opt_join_type = 331,            /* opt_join_type  */
+  YYSYMBOL_join_condition = 332,           /* join_condition  */
+  YYSYMBOL_opt_semicolon = 333,            /* opt_semicolon  */
+  YYSYMBOL_ident_commalist = 334           /* ident_commalist  */
 };
-
-typedef union HSQL_STYPE HSQL_STYPE;
-# define HSQL_STYPE_IS_TRIVIAL 1
-# define HSQL_STYPE_IS_DECLARED 1
-#endif
-
-/* Location type.  */
-#if ! defined HSQL_LTYPE && ! defined HSQL_LTYPE_IS_DECLARED
-typedef struct HSQL_LTYPE HSQL_LTYPE;
-struct HSQL_LTYPE
-{
-  int first_line;
-  int first_column;
-  int last_line;
-  int last_column;
-};
-# define HSQL_LTYPE_IS_DECLARED 1
-# define HSQL_LTYPE_IS_TRIVIAL 1
-#endif
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 
 
-int hsql_parse (hsql::SQLParserResult* result, yyscan_t scanner);
-
-#endif /* !YY_HSQL_BISON_PARSER_H_INCLUDED  */
-
-/* Copy the second part of user declarations.  */
-
-#line 465 "bison_parser.cpp" /* yacc.c:358  */
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
 #else
 typedef signed char yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -496,15 +566,28 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int16 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
@@ -518,47 +601,43 @@ typedef short int yytype_int16;
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE
-# if (defined __GNUC__                                               \
-      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
-     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
-#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
 # else
-#  define YY_ATTRIBUTE(Spec) /* empty */
+#  define YY_ATTRIBUTE_PURE
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE_PURE
-# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
-#endif
-
 #ifndef YY_ATTRIBUTE_UNUSED
-# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
-#endif
-
-#if !defined _Noreturn \
-     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
-# if defined _MSC_VER && 1200 <= _MSC_VER
-#  define _Noreturn __declspec (noreturn)
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
 # else
-#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+#  define YY_ATTRIBUTE_UNUSED
 # endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
-    _Pragma ("GCC diagnostic push") \
-    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
 # define YY_INITIAL_VALUE(Value) Value
@@ -571,8 +650,22 @@ typedef short int yytype_int16;
 # define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if 1
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -637,8 +730,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* 1 */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -648,18 +740,19 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss_alloc;
+  yy_state_t yyss_alloc;
   YYSTYPE yyvs_alloc;
   YYLTYPE yyls_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE) + sizeof (YYLTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE) \
+             + YYSIZEOF (YYLTYPE)) \
       + 2 * YYSTACK_GAP_MAXIMUM)
 
 # define YYCOPY_NEEDED 1
@@ -672,11 +765,11 @@ union yyalloc
 # define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
     do                                                                  \
       {                                                                 \
-        YYSIZE_T yynewbytes;                                            \
+        YYPTRDIFF_T yynewbytes;                                         \
         YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
         Stack = &yyptr->Stack_alloc;                                    \
-        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-        yyptr += yynewbytes / sizeof (*yyptr);                          \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
       }                                                                 \
     while (0)
 
@@ -688,12 +781,12 @@ union yyalloc
 # ifndef YYCOPY
 #  if defined __GNUC__ && 1 < __GNUC__
 #   define YYCOPY(Dst, Src, Count) \
-      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
 #  else
 #   define YYCOPY(Dst, Src, Count)              \
       do                                        \
         {                                       \
-          YYSIZE_T yyi;                         \
+          YYPTRDIFF_T yyi;                      \
           for (yyi = 0; yyi < (Count); yyi++)   \
             (Dst)[yyi] = (Src)[yyi];            \
         }                                       \
@@ -705,27 +798,30 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  69
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   856
+#define YYLAST   904
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  199
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  136
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  357
+#define YYNRULES  358
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  656
+#define YYNSTATES  658
 
-/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
-   by yylex, with out-of-bounds checking.  */
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   436
 
-#define YYTRANSLATE(YYX)                                                \
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, without out-of-bounds checking.  */
+   as returned by yylex.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -775,8 +871,8 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if HSQL_DEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_uint16 yyrline[] =
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static const yytype_int16 yyrline[] =
 {
        0,   343,   343,   362,   368,   375,   379,   383,   384,   385,
      387,   388,   389,   390,   391,   392,   393,   394,   395,   396,
@@ -806,57 +902,65 @@ static const yytype_uint16 yyrline[] =
     1196,  1197,  1199,  1200,  1201,  1202,  1203,  1205,  1207,  1209,
     1210,  1211,  1212,  1213,  1214,  1216,  1217,  1218,  1219,  1220,
     1221,  1223,  1223,  1225,  1227,  1229,  1231,  1232,  1233,  1234,
-    1236,  1236,  1236,  1236,  1236,  1236,  1236,  1238,  1240,  1241,
-    1243,  1244,  1246,  1248,  1250,  1261,  1262,  1273,  1305,  1314,
-    1314,  1321,  1321,  1323,  1323,  1330,  1334,  1339,  1347,  1353,
-    1357,  1362,  1363,  1365,  1365,  1367,  1367,  1369,  1370,  1372,
-    1372,  1378,  1379,  1381,  1385,  1390,  1396,  1403,  1404,  1405,
-    1406,  1408,  1409,  1410,  1416,  1416,  1418,  1420,  1424,  1429,
-    1439,  1446,  1454,  1463,  1464,  1465,  1466,  1467,  1468,  1469,
-    1470,  1471,  1472,  1474,  1480,  1480,  1483,  1487
+    1235,  1237,  1237,  1237,  1237,  1237,  1237,  1237,  1239,  1241,
+    1242,  1244,  1245,  1247,  1249,  1251,  1262,  1263,  1274,  1306,
+    1315,  1315,  1322,  1322,  1324,  1324,  1331,  1335,  1340,  1348,
+    1354,  1358,  1363,  1364,  1366,  1366,  1368,  1368,  1370,  1371,
+    1373,  1373,  1379,  1380,  1382,  1386,  1391,  1397,  1404,  1405,
+    1406,  1407,  1409,  1410,  1411,  1417,  1417,  1419,  1421,  1425,
+    1430,  1440,  1447,  1455,  1464,  1465,  1466,  1467,  1468,  1469,
+    1470,  1471,  1472,  1473,  1475,  1481,  1481,  1484,  1488
 };
 #endif
 
-#if HSQL_DEBUG || YYERROR_VERBOSE || 1
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "IDENTIFIER", "STRING", "FLOATVAL",
-  "INTVAL", "DEALLOCATE", "PARAMETERS", "INTERSECT", "TEMPORARY",
-  "TIMESTAMP", "DISTINCT", "NVARCHAR", "RESTRICT", "TRUNCATE", "ANALYZE",
-  "BETWEEN", "CASCADE", "COLUMNS", "CONTROL", "DEFAULT", "EXECUTE",
-  "EXPLAIN", "ENCODING", "INTEGER", "NATURAL", "PREPARE", "SCHEMAS",
-  "CHARACTER_VARYING", "REAL", "DECIMAL", "SMALLINT", "BIGINT", "SPATIAL",
-  "VARCHAR", "VIRTUAL", "DESCRIBE", "BEFORE", "COLUMN", "CREATE", "DELETE",
-  "DIRECT", "DOUBLE", "ESCAPE", "EXCEPT", "EXISTS", "EXTRACT", "CAST",
-  "FORMAT", "GLOBAL", "HAVING", "IMPORT", "INSERT", "ISNULL", "OFFSET",
-  "RENAME", "SCHEMA", "SELECT", "SORTED", "TABLES", "UNLOAD", "UPDATE",
-  "VALUES", "AFTER", "ALTER", "CROSS", "DELTA", "FLOAT", "GROUP", "INDEX",
-  "INNER", "LIMIT", "LOCAL", "MERGE", "MINUS", "ORDER", "OVER", "OUTER",
-  "RIGHT", "TABLE", "UNION", "USING", "WHERE", "CALL", "CASE", "CHAR",
-  "COPY", "DATE", "DATETIME", "DESC", "DROP", "ELSE", "FILE", "FROM",
-  "FULL", "HASH", "HINT", "INTO", "JOIN", "LEFT", "LIKE", "LOAD", "LONG",
-  "NULL", "PARTITION", "PLAN", "SHOW", "TEXT", "THEN", "TIME", "VIEW",
-  "WHEN", "WITH", "ADD", "ALL", "AND", "ASC", "END", "FOR", "INT", "NOT",
-  "OFF", "SET", "TOP", "AS", "BY", "IF", "IN", "IS", "OF", "ON", "OR",
-  "TO", "NO", "ARRAY", "CONCAT", "ILIKE", "SECOND", "MINUTE", "HOUR",
-  "DAY", "MONTH", "YEAR", "SECONDS", "MINUTES", "HOURS", "DAYS", "MONTHS",
-  "YEARS", "INTERVAL", "TRUE", "FALSE", "BOOLEAN", "TRANSACTION", "BEGIN",
-  "COMMIT", "ROLLBACK", "NOWAIT", "SKIP", "LOCKED", "SHARE", "RANGE",
-  "ROWS", "GROUPS", "UNBOUNDED", "FOLLOWING", "PRECEDING", "CURRENT_ROW",
-  "UNIQUE", "PRIMARY", "FOREIGN", "KEY", "REFERENCES", "'='", "EQUALS",
-  "NOTEQUALS", "'<'", "'>'", "LESS", "GREATER", "LESSEQ", "GREATEREQ",
-  "NOTNULL", "'+'", "'-'", "'*'", "'/'", "'%'", "'^'", "UMINUS", "'['",
-  "']'", "'('", "')'", "'.'", "';'", "','", "'?'", "$accept", "input",
-  "statement_list", "statement", "preparable_statement", "opt_hints",
-  "hint_list", "hint", "transaction_statement", "opt_transaction_keyword",
-  "prepare_statement", "prepare_target_query", "execute_statement",
-  "import_statement", "file_type", "file_path",
-  "opt_import_export_options", "import_export_options", "csv_option",
-  "export_statement", "show_statement", "create_statement",
-  "opt_not_exists", "table_elem_commalist", "table_elem", "column_def",
-  "column_type", "opt_time_precision", "opt_decimal_specification",
+  "\"end of file\"", "error", "\"invalid token\"", "IDENTIFIER", "STRING",
+  "FLOATVAL", "INTVAL", "DEALLOCATE", "PARAMETERS", "INTERSECT",
+  "TEMPORARY", "TIMESTAMP", "DISTINCT", "NVARCHAR", "RESTRICT", "TRUNCATE",
+  "ANALYZE", "BETWEEN", "CASCADE", "COLUMNS", "CONTROL", "DEFAULT",
+  "EXECUTE", "EXPLAIN", "ENCODING", "INTEGER", "NATURAL", "PREPARE",
+  "SCHEMAS", "CHARACTER_VARYING", "REAL", "DECIMAL", "SMALLINT", "BIGINT",
+  "SPATIAL", "VARCHAR", "VIRTUAL", "DESCRIBE", "BEFORE", "COLUMN",
+  "CREATE", "DELETE", "DIRECT", "DOUBLE", "ESCAPE", "EXCEPT", "EXISTS",
+  "EXTRACT", "CAST", "FORMAT", "GLOBAL", "HAVING", "IMPORT", "INSERT",
+  "ISNULL", "OFFSET", "RENAME", "SCHEMA", "SELECT", "SORTED", "TABLES",
+  "UNLOAD", "UPDATE", "VALUES", "AFTER", "ALTER", "CROSS", "DELTA",
+  "FLOAT", "GROUP", "INDEX", "INNER", "LIMIT", "LOCAL", "MERGE", "MINUS",
+  "ORDER", "OVER", "OUTER", "RIGHT", "TABLE", "UNION", "USING", "WHERE",
+  "CALL", "CASE", "CHAR", "COPY", "DATE", "DATETIME", "DESC", "DROP",
+  "ELSE", "FILE", "FROM", "FULL", "HASH", "HINT", "INTO", "JOIN", "LEFT",
+  "LIKE", "LOAD", "LONG", "NULL", "PARTITION", "PLAN", "SHOW", "TEXT",
+  "THEN", "TIME", "VIEW", "WHEN", "WITH", "ADD", "ALL", "AND", "ASC",
+  "END", "FOR", "INT", "NOT", "OFF", "SET", "TOP", "AS", "BY", "IF", "IN",
+  "IS", "OF", "ON", "OR", "TO", "NO", "ARRAY", "CONCAT", "ILIKE", "SECOND",
+  "MINUTE", "HOUR", "DAY", "MONTH", "YEAR", "SECONDS", "MINUTES", "HOURS",
+  "DAYS", "MONTHS", "YEARS", "INTERVAL", "TRUE", "FALSE", "BOOLEAN",
+  "TRANSACTION", "BEGIN", "COMMIT", "ROLLBACK", "NOWAIT", "SKIP", "LOCKED",
+  "SHARE", "RANGE", "ROWS", "GROUPS", "UNBOUNDED", "FOLLOWING",
+  "PRECEDING", "CURRENT_ROW", "UNIQUE", "PRIMARY", "FOREIGN", "KEY",
+  "REFERENCES", "'='", "EQUALS", "NOTEQUALS", "'<'", "'>'", "LESS",
+  "GREATER", "LESSEQ", "GREATEREQ", "NOTNULL", "'+'", "'-'", "'*'", "'/'",
+  "'%'", "'^'", "UMINUS", "'['", "']'", "'('", "')'", "'.'", "';'", "','",
+  "'?'", "$accept", "input", "statement_list", "statement",
+  "preparable_statement", "opt_hints", "hint_list", "hint",
+  "transaction_statement", "opt_transaction_keyword", "prepare_statement",
+  "prepare_target_query", "execute_statement", "import_statement",
+  "file_type", "file_path", "opt_import_export_options",
+  "import_export_options", "csv_option", "export_statement",
+  "show_statement", "create_statement", "opt_not_exists",
+  "table_elem_commalist", "table_elem", "column_def", "column_type",
+  "opt_time_precision", "opt_decimal_specification",
   "opt_column_constraints", "column_constraints", "column_constraint",
   "table_constraint", "references_spec", "drop_statement", "opt_exists",
   "alter_statement", "alter_action", "drop_action", "delete_statement",
@@ -887,415 +991,403 @@ static const char *const yytname[] =
   "with_description_list", "with_description", "join_clause",
   "opt_join_type", "join_condition", "opt_semicolon", "ident_commalist", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_uint16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
-     295,   296,   297,   298,   299,   300,   301,   302,   303,   304,
-     305,   306,   307,   308,   309,   310,   311,   312,   313,   314,
-     315,   316,   317,   318,   319,   320,   321,   322,   323,   324,
-     325,   326,   327,   328,   329,   330,   331,   332,   333,   334,
-     335,   336,   337,   338,   339,   340,   341,   342,   343,   344,
-     345,   346,   347,   348,   349,   350,   351,   352,   353,   354,
-     355,   356,   357,   358,   359,   360,   361,   362,   363,   364,
-     365,   366,   367,   368,   369,   370,   371,   372,   373,   374,
-     375,   376,   377,   378,   379,   380,   381,   382,   383,   384,
-     385,   386,   387,   388,   389,   390,   391,   392,   393,   394,
-     395,   396,   397,   398,   399,   400,   401,   402,   403,   404,
-     405,   406,   407,   408,   409,   410,   411,   412,   413,   414,
-     415,   416,   417,   418,   419,   420,   421,   422,   423,   424,
-     425,   426,   427,   428,    61,   429,   430,    60,    62,   431,
-     432,   433,   434,   435,    43,    45,    42,    47,    37,    94,
-     436,    91,    93,    40,    41,    46,    59,    44,    63
-};
-# endif
+#define YYPACT_NINF (-480)
 
-#define YYPACT_NINF -529
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-529)))
+#define YYTABLE_NINF (-356)
 
-#define YYTABLE_NINF -355
+#define yytable_value_is_error(Yyn) \
+  ((Yyn) == YYTABLE_NINF)
 
-#define yytable_value_is_error(Yytable_value) \
-  (!!((Yytable_value) == (-355)))
-
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-     595,    27,    65,    71,    99,    65,   113,    83,   137,   140,
-      65,   190,    21,   195,    37,   292,   120,   120,   120,   287,
-     103,  -529,   221,  -529,   221,  -529,  -529,  -529,  -529,  -529,
-    -529,  -529,  -529,  -529,  -529,  -529,  -529,   -26,  -529,   342,
-     166,  -529,   183,   313,  -529,   251,   251,   251,    65,   415,
-      65,   298,  -529,   297,   -26,   293,   -37,   297,   297,   297,
-      65,  -529,   309,   267,  -529,  -529,  -529,  -529,  -529,  -529,
-     578,  -529,   369,  -529,  -529,   350,   224,  -529,    35,  -529,
-     479,   353,   486,   374,   494,    65,    65,   418,  -529,   413,
-     314,   505,   464,    65,   315,   317,   508,   508,   508,   519,
-      65,    65,  -529,   332,   292,  -529,   333,   521,   518,  -529,
-    -529,  -529,   -26,   420,   410,   -26,    15,  -529,  -529,  -529,
-     707,   344,   535,  -529,   536,  -529,  -529,    45,  -529,   349,
-     347,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,
-    -529,  -529,  -529,  -529,   500,  -529,   416,   -15,   314,   363,
-    -529,   508,   547,   198,   380,   -38,  -529,  -529,   466,  -529,
-    -529,  -529,   -75,   -75,   -75,  -529,  -529,  -529,  -529,  -529,
-     552,  -529,  -529,  -529,   363,   483,  -529,  -529,   224,  -529,
-    -529,   363,   483,   363,   151,   443,  -529,  -529,  -529,  -529,
-    -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,
-    -529,   200,  -529,   248,  -529,  -529,  -529,   353,  -529,    65,
-     561,   454,    19,   441,   129,   375,   381,   382,   244,   367,
-     396,    59,  -529,   335,    69,   395,  -529,  -529,  -529,  -529,
-    -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,  -529,
-    -529,  -529,   490,  -529,    38,   397,  -529,   363,   505,  -529,
-     550,  -529,  -529,   398,   193,  -529,   418,  -529,   402,   180,
-    -529,   502,   400,  -529,    44,    15,   -26,   401,  -529,   -31,
-      15,    69,   544,    68,   106,  -529,   443,  -529,   476,  -529,
-    -529,   411,   510,  -529,   668,   414,   434,   436,   205,  -529,
-    -529,  -529,   454,     9,    36,   551,   248,   363,   363,   268,
-     -43,   419,    59,   609,   363,   217,   417,   -23,   363,   363,
-      59,  -529,    59,    24,   421,   -27,    59,    59,    59,    59,
-      59,    59,    59,    59,    59,    59,    59,    59,    59,    59,
-      59,   521,    65,  -529,   610,   353,    69,  -529,   297,   193,
-     612,   616,   415,   617,   222,  -529,  -529,   353,  -529,   552,
-      22,   418,  -529,   363,  -529,   620,  -529,  -529,  -529,  -529,
-     363,  -529,  -529,   621,   443,   363,   363,  -529,   455,  -529,
-     465,   -70,  -529,   668,   547,   508,  -529,  -529,   432,  -529,
-     435,  -529,  -529,   440,  -529,  -529,   444,  -529,  -529,  -529,
-    -529,   445,  -529,  -529,   139,   547,   448,   449,  -529,    19,
-    -529,   557,   363,   451,  -529,   452,   555,   -13,   201,   167,
-     363,   363,  -529,   551,   528,   119,  -529,  -529,  -529,   529,
-     538,   638,    59,   457,   335,  -529,   548,   460,   638,   638,
-     638,   638,   653,   653,   653,   653,   217,   217,    92,    92,
-      92,   -96,   461,  -529,  -529,   228,   652,   234,  -529,  -529,
-    -529,  -529,  -529,   227,   239,  -529,   454,  -529,    87,  -529,
-     459,  -529,    39,  -529,   589,  -529,  -529,  -529,   658,  -529,
-    -529,    69,    69,   600,  -529,   547,  -529,   504,  -529,   472,
-     241,  -529,   662,   664,  -529,   665,   666,   667,  -529,  -529,
-     572,  -529,   506,    65,  -529,   139,  -529,  -529,   246,   547,
-     547,  -529,   484,  -529,   253,    14,  -529,   363,   668,   363,
-     363,  -529,   182,   211,   487,  -529,    59,   638,   335,   489,
-     264,  -529,  -529,  -529,  -529,  -529,   676,   415,  -529,  -529,
-     493,   585,  -529,  -529,  -529,   611,   618,   626,   591,    22,
-     685,  -529,  -529,  -529,   568,  -529,  -529,  -529,   -77,  -529,
-    -529,  -529,   501,   265,   511,   512,   515,  -529,  -529,   314,
-    -529,  -529,  -529,   266,   271,   613,   557,   557,   363,   121,
-     523,    69,   203,  -529,   363,  -529,   609,   527,   278,  -529,
-    -529,  -529,  -529,    39,    22,  -529,  -529,  -529,    22,   247,
-     539,   363,  -529,  -529,  -529,   722,  -529,  -529,  -529,  -529,
-    -529,   558,   614,   483,  -529,  -529,   279,  -529,  -529,  -529,
-      69,  -529,  -529,  -529,  -529,   463,   547,   -22,   543,  -529,
-     363,   330,   557,   549,   363,   284,   363,  -529,  -529,   400,
-    -529,  -529,  -529,   553,    61,  -529,   547,    69,  -529,  -529,
-      69,  -529,    25,    55,   188,  -529,  -529,   286,  -529,  -529,
-     625,  -529,  -529,  -529,    55,  -529
+     635,    63,    64,   125,   170,    64,   201,     9,    88,   108,
+      64,   141,    22,   272,   118,   238,    91,    91,    91,   307,
+     164,  -480,   224,  -480,   224,  -480,  -480,  -480,  -480,  -480,
+    -480,  -480,  -480,  -480,  -480,  -480,  -480,   -23,  -480,   365,
+     194,  -480,   229,   286,  -480,   287,   287,   287,    64,   398,
+      64,   317,  -480,   321,   -23,   316,    47,   321,   321,   321,
+      64,  -480,   331,   260,  -480,  -480,  -480,  -480,  -480,  -480,
+     503,  -480,   385,  -480,  -480,   354,   247,  -480,   100,  -480,
+     480,   184,   490,   380,   499,    64,    64,   422,  -480,   414,
+     315,   510,   468,    64,   325,   327,   518,   518,   518,   520,
+      64,    64,  -480,   333,   238,  -480,   334,   523,   512,  -480,
+    -480,  -480,   -23,   417,   408,   -23,     5,  -480,  -480,  -480,
+     714,   342,   532,  -480,   533,  -480,  -480,    33,  -480,   345,
+     344,  -480,  -480,  -480,  -480,  -480,  -480,  -480,  -480,  -480,
+    -480,  -480,  -480,  -480,   500,  -480,   416,   -33,   315,   274,
+    -480,   518,   542,    72,   375,   -38,  -480,  -480,   459,  -480,
+    -480,  -480,   -62,   -62,   -62,  -480,  -480,  -480,  -480,  -480,
+     548,  -480,  -480,  -480,   274,   476,  -480,  -480,   247,  -480,
+    -480,   274,   476,   274,   181,   435,  -480,  -480,  -480,  -480,
+    -480,  -480,  -480,  -480,  -480,  -480,  -480,  -480,  -480,  -480,
+    -480,    50,  -480,   304,  -480,  -480,  -480,   184,  -480,    64,
+     557,   448,    23,   439,  -136,   370,   373,   374,   205,   407,
+     379,   427,  -480,   300,   122,   452,  -480,  -480,  -480,  -480,
+    -480,  -480,  -480,  -480,  -480,  -480,  -480,  -480,  -480,  -480,
+    -480,  -480,   473,  -480,    45,   382,  -480,   274,   510,  -480,
+     535,  -480,  -480,   383,    40,  -480,   422,  -480,   389,   157,
+    -480,   478,   386,  -480,    39,     5,   -23,   387,  -480,   197,
+       5,   122,   530,   117,    96,  -480,   435,  -480,   461,  -480,
+    -480,   394,   498,  -480,   673,   402,   424,   425,   178,  -480,
+    -480,  -480,   448,    18,    17,   540,   304,   274,   274,   -47,
+     158,   406,   427,   659,   274,   250,   409,   -54,   274,   274,
+     427,  -480,   427,   -35,   411,   -34,   427,   427,   427,   427,
+     427,   427,   427,   427,   427,   427,   427,   427,   427,   427,
+     427,   523,    64,  -480,   598,   184,   122,  -480,   321,    40,
+     602,   603,   398,   604,   187,  -480,  -480,   184,  -480,   548,
+      24,   422,  -480,   274,  -480,   599,  -480,  -480,  -480,  -480,
+     274,  -480,  -480,   606,   435,   274,   274,  -480,   442,  -480,
+     450,   185,  -480,   673,   542,   518,  -480,  -480,   426,  -480,
+     428,  -480,  -480,   429,  -480,  -480,   430,  -480,  -480,  -480,
+    -480,   431,  -480,  -480,   180,   542,   451,   453,  -480,    23,
+    -480,   538,   274,   275,  -480,   423,   524,   -37,   209,   227,
+     274,   274,  -480,   540,   531,    70,  -480,  -480,  -480,   515,
+     628,   693,   427,   454,   300,  -480,   541,   444,   693,   693,
+     693,   693,   713,   713,   713,   713,   250,   250,   119,   119,
+     119,   -83,   456,  -480,  -480,   202,   646,   203,  -480,  -480,
+    -480,  -480,  -480,   234,   208,  -480,   448,  -480,     2,  -480,
+     455,  -480,    44,  -480,   582,  -480,  -480,  -480,   650,  -480,
+    -480,   122,   122,   592,  -480,   542,  -480,   495,  -480,   462,
+     221,  -480,   655,   657,  -480,   658,   660,   661,  -480,  -480,
+     561,  -480,   496,    64,  -480,   180,  -480,  -480,   222,   542,
+     542,  -480,   477,  -480,   226,    20,   666,  -480,   274,   673,
+     274,   274,  -480,   255,   261,   479,  -480,   427,   693,   300,
+     483,   264,  -480,  -480,  -480,  -480,  -480,   667,   398,  -480,
+    -480,   484,   575,  -480,  -480,  -480,   601,   605,   607,   581,
+      24,   678,  -480,  -480,  -480,   560,  -480,  -480,  -480,    -6,
+    -480,  -480,  -480,   497,   268,   501,   502,   505,  -480,  -480,
+     315,  -480,  -480,  -480,   269,   279,   584,   538,   538,   274,
+    -480,    10,   507,   122,   276,  -480,   274,  -480,   659,   513,
+     283,  -480,  -480,  -480,  -480,    44,    24,  -480,  -480,  -480,
+      24,    68,   516,   274,  -480,  -480,  -480,   684,  -480,  -480,
+    -480,  -480,  -480,   519,   567,   476,  -480,  -480,   290,  -480,
+    -480,  -480,   122,  -480,  -480,  -480,  -480,   438,   542,   -18,
+     517,  -480,   274,   326,   538,   521,   274,   302,   274,  -480,
+    -480,   386,  -480,  -480,  -480,   525,    57,  -480,   542,   122,
+    -480,  -480,   122,  -480,    30,    66,    93,  -480,  -480,   303,
+    -480,  -480,   578,  -480,  -480,  -480,    66,  -480
 };
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
-static const yytype_uint16 yydefact[] =
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
+static const yytype_int16 yydefact[] =
 {
-     335,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     336,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,    30,    30,    30,     0,
-     355,     3,    21,    19,    21,    18,     8,     9,     7,    11,
-      16,    17,    13,    14,    12,    15,    10,     0,   334,     0,
-     309,   114,    33,     0,    54,    61,    61,    61,     0,     0,
-       0,     0,   308,   109,     0,     0,     0,   109,   109,   109,
-       0,    52,     0,   336,   337,    29,    26,    28,    27,     1,
-     335,     2,     0,     6,     5,   164,   123,   124,   154,   106,
-       0,   174,     0,     0,   312,     0,     0,   148,    37,     0,
+     356,     3,    21,    19,    21,    18,     8,     9,     7,    11,
+      16,    17,    13,    14,    12,    15,    10,     0,   335,     0,
+     310,   114,    33,     0,    54,    61,    61,    61,     0,     0,
+       0,     0,   309,   109,     0,     0,     0,   109,   109,   109,
+       0,    52,     0,   337,   338,    29,    26,    28,    27,     1,
+     336,     2,     0,     6,     5,   164,   123,   124,   154,   106,
+       0,   174,     0,     0,   313,     0,     0,   148,    37,     0,
      118,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,    53,     0,     0,     4,     0,     0,   142,   136,
-     137,   135,     0,   139,     0,     0,   170,   310,   287,   290,
-     292,     0,     0,   293,     0,   288,   289,     0,   298,     0,
-     173,   175,   177,   179,   280,   281,   282,   291,   283,   284,
-     285,   286,    32,    31,     0,   311,     0,     0,   118,     0,
+     137,   135,     0,   139,     0,     0,   170,   311,   288,   291,
+     293,     0,     0,   294,     0,   289,   290,     0,   299,     0,
+     173,   175,   177,   179,   281,   282,   283,   292,   284,   285,
+     286,   287,    32,    31,     0,   312,     0,     0,   118,     0,
      113,     0,     0,     0,     0,   148,   120,   108,     0,   131,
-     130,    38,    41,    41,    41,   107,   104,   105,   339,   338,
-       0,   292,   163,   141,     0,   154,   127,   126,   128,   138,
-     134,     0,   154,     0,     0,   322,   259,   260,   261,   262,
+     130,    38,    41,    41,    41,   107,   104,   105,   340,   339,
+       0,   293,   163,   141,     0,   154,   127,   126,   128,   138,
+     134,     0,   154,     0,     0,   323,   259,   260,   261,   262,
      263,   264,   265,   266,   267,   268,   269,   270,   271,   272,
-     295,     0,   294,   297,   180,   181,    34,     0,    60,     0,
-       0,   335,     0,     0,   276,     0,     0,     0,     0,     0,
-       0,     0,   278,     0,   147,   183,   190,   191,   192,   185,
+     296,     0,   295,   298,   180,   181,    34,     0,    60,     0,
+       0,   336,     0,     0,   276,     0,     0,     0,     0,     0,
+       0,     0,   279,     0,   147,   183,   190,   191,   192,   185,
      187,   193,   186,   206,   194,   195,   196,   197,   189,   184,
-     199,   200,     0,   356,     0,     0,   116,     0,     0,   119,
+     199,   200,     0,   357,     0,     0,   116,     0,     0,   119,
        0,   110,   111,     0,     0,    51,   148,    50,    24,     0,
-      22,   145,   143,   171,   320,   170,     0,   153,   155,   160,
-     170,   166,   168,   165,     0,   132,   321,   323,     0,   296,
+      22,   145,   143,   171,   321,   170,     0,   153,   155,   160,
+     170,   166,   168,   165,     0,   132,   322,   324,     0,   297,
      176,     0,     0,    57,     0,     0,     0,     0,     0,    62,
-      64,    65,   335,   142,     0,     0,     0,     0,     0,     0,
+      64,    65,   336,   142,     0,     0,     0,     0,     0,     0,
        0,     0,     0,   202,     0,   201,     0,     0,     0,     0,
        0,   203,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,   117,     0,     0,   122,   121,   109,     0,
        0,     0,     0,     0,     0,    47,    36,     0,    20,     0,
-       0,   148,   144,     0,   318,     0,   319,   182,   125,   129,
-       0,   159,   158,   161,   322,     0,     0,   327,     0,   329,
-       0,   333,   324,     0,     0,     0,    83,    77,     0,    79,
+       0,   148,   144,     0,   319,     0,   320,   182,   125,   129,
+       0,   159,   158,   161,   323,     0,     0,   328,     0,   330,
+       0,   334,   325,     0,     0,     0,    83,    77,     0,    79,
       89,    80,    67,     0,    74,    75,     0,    71,    72,    78,
       81,    86,    76,    68,    91,     0,     0,     0,    56,     0,
-      59,   243,     0,   277,   279,     0,     0,     0,     0,     0,
+      59,   243,     0,   277,   280,     0,     0,     0,     0,     0,
        0,     0,   225,     0,     0,     0,   198,   188,   217,   218,
        0,   213,     0,     0,     0,   204,     0,   216,   215,   231,
      232,   233,   234,   235,   236,   237,   208,   207,   210,   209,
-     211,   212,     0,    35,   357,     0,     0,     0,    48,    45,
-      43,    49,    40,     0,     0,    23,   335,   146,   299,   301,
-       0,   303,   316,   302,   150,   172,   317,   156,     0,   157,
-     133,   169,   167,     0,   330,     0,   332,     0,   325,     0,
+     211,   212,     0,    35,   358,     0,     0,     0,    48,    45,
+      43,    49,    40,     0,     0,    23,   336,   146,   300,   302,
+       0,   304,   317,   303,   150,   172,   318,   156,     0,   157,
+     133,   169,   167,     0,   331,     0,   333,     0,   326,     0,
        0,    55,     0,     0,    73,     0,     0,     0,    82,    98,
        0,    97,     0,     0,    66,    90,    92,    94,     0,     0,
-       0,    63,     0,   238,     0,   142,   229,     0,     0,     0,
-       0,   223,     0,     0,     0,   273,     0,   214,     0,     0,
-       0,   205,   274,   115,   112,    39,     0,     0,    46,    25,
-       0,     0,   351,   343,   349,   347,   350,   345,     0,     0,
-       0,   315,   307,   313,     0,   140,   162,   328,   333,   331,
-     178,    58,     0,     0,     0,     0,     0,    99,    96,   118,
-      93,    95,   101,     0,     0,   245,   243,   243,     0,     0,
-       0,   227,     0,   226,     0,   230,   275,     0,     0,   221,
-     219,    44,    42,   316,     0,   346,   348,   344,     0,   300,
-     317,     0,   326,    70,    88,     0,    84,    69,    85,   103,
-     100,     0,     0,   154,   239,   240,     0,   257,   258,   224,
-     228,   222,   220,   304,   340,   352,     0,   152,     0,   102,
-       0,   248,   243,     0,     0,     0,     0,   149,    87,   244,
-     249,   250,   251,     0,     0,   241,     0,   353,   341,   314,
-     151,   242,     0,     0,     0,   256,   246,     0,   255,   253,
-       0,   254,   252,   342,     0,   247
+       0,    63,     0,   238,     0,   142,     0,   229,     0,     0,
+       0,     0,   223,     0,     0,     0,   273,     0,   214,     0,
+       0,     0,   205,   274,   115,   112,    39,     0,     0,    46,
+      25,     0,     0,   352,   344,   350,   348,   351,   346,     0,
+       0,     0,   316,   308,   314,     0,   140,   162,   329,   334,
+     332,   178,    58,     0,     0,     0,     0,     0,    99,    96,
+     118,    93,    95,   101,     0,     0,   245,   243,   243,     0,
+     278,     0,     0,   227,     0,   226,     0,   230,   275,     0,
+       0,   221,   219,    44,    42,   317,     0,   347,   349,   345,
+       0,   301,   318,     0,   327,    70,    88,     0,    84,    69,
+      85,   103,   100,     0,     0,   154,   239,   240,     0,   257,
+     258,   224,   228,   222,   220,   305,   341,   353,     0,   152,
+       0,   102,     0,   248,   243,     0,     0,     0,     0,   149,
+      87,   244,   249,   250,   251,     0,     0,   241,     0,   354,
+     342,   315,   151,   242,     0,     0,     0,   256,   246,     0,
+     255,   253,     0,   254,   252,   343,     0,   247
 };
 
-  /* YYPGOTO[NTERM-NUM].  */
+/* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-    -529,  -529,  -529,   673,  -529,   720,  -529,   399,  -529,   428,
-    -529,  -529,  -529,  -529,  -325,   -79,   290,   422,   296,  -529,
-    -529,  -529,   453,  -529,   354,  -529,  -338,  -529,  -529,  -529,
-    -529,   260,  -529,  -429,  -529,   -45,  -529,  -529,  -529,  -529,
-    -529,  -529,  -142,  -529,  -529,   514,  -202,   -87,  -529,   204,
-     -49,    -5,  -529,  -529,   -85,  -278,  -529,  -529,  -529,  -139,
-    -529,  -529,  -171,  -529,   403,  -529,  -529,  -529,   127,  -297,
-    -529,   -67,   559,   563,   405,  -147,  -188,  -529,  -529,  -529,
-    -529,  -529,  -529,   469,  -529,  -529,  -529,  -514,  -529,  -529,
-    -529,  -528,  -529,  -529,  -148,  -529,  -529,  -529,  -529,  -529,
-    -529,   -58,  -529,  -529,   632,  -106,  -529,  -529,   633,  -529,
-    -529,  -496,   181,  -529,  -529,  -529,    -2,  -529,  -529,   186,
-     509,  -529,   406,  -529,   496,  -529,   229,  -529,  -529,  -529,
-     675,  -529,  -529,  -529,  -529,  -354
+    -480,  -480,  -480,   640,  -480,   688,  -480,   366,  -480,   306,
+    -480,  -480,  -480,  -480,  -323,   -76,   243,   378,   265,  -480,
+    -480,  -480,   381,  -480,   322,  -480,  -344,  -480,  -480,  -480,
+    -480,   225,  -480,  -455,  -480,   -41,  -480,  -480,  -480,  -480,
+    -480,  -480,  -143,  -480,  -480,   475,  -210,   -92,  -480,   186,
+     -48,   -29,  -480,  -480,   -71,  -279,  -480,  -480,  -480,  -131,
+    -480,  -480,  -171,  -480,   364,  -480,  -480,  -480,    21,  -295,
+    -480,   -53,   526,   527,   372,  -147,  -206,  -480,  -480,  -480,
+    -480,  -480,  -480,   432,  -480,  -480,  -480,  -324,  -480,  -480,
+    -480,  -479,  -480,  -480,  -153,  -480,  -480,  -480,  -480,  -480,
+    -480,   -74,  -480,  -480,   600,   -95,  -480,  -480,   608,  -480,
+    -480,  -454,   144,  -480,  -480,  -480,    -2,  -480,  -480,   147,
+     470,  -480,   376,  -480,   460,  -480,   188,  -480,  -480,  -480,
+     634,  -480,  -480,  -480,  -480,  -343
 };
 
-  /* YYDEFGOTO[NTERM-NUM].  */
+/* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
-      -1,    19,    20,    21,    22,    73,   259,   260,    23,    66,
+       0,    19,    20,    21,    22,    73,   259,   260,    23,    66,
       24,   143,    25,    26,    89,   162,   255,   344,   345,    27,
       28,    29,    84,   288,   289,   290,   394,   488,   484,   494,
      495,   496,   291,   497,    30,    93,    31,   251,   252,    32,
       33,    34,   153,    35,   155,   156,    36,   175,   176,   177,
       77,   112,   113,   180,    78,   174,   261,   351,   352,   150,
-     545,   627,   116,   267,   268,   363,   469,   108,   185,   262,
+     546,   629,   116,   267,   268,   363,   469,   108,   185,   262,
      129,   130,   131,   132,   263,   264,   225,   226,   227,   228,
-     229,   230,   231,   300,   232,   233,   234,   503,   603,   633,
-     634,   646,   235,   236,   198,   199,   200,   237,   238,   239,
+     229,   230,   231,   300,   232,   233,   234,   503,   605,   635,
+     636,   648,   235,   236,   198,   199,   200,   237,   238,   239,
      240,   241,   134,   135,   136,   137,   138,   139,   140,   141,
-     457,   458,   459,   460,   461,    51,   462,   146,   541,   542,
-     543,   357,   275,   276,   277,   371,   478,    37,    38,    63,
-      64,   463,   538,   638,    71,   244
+     457,   458,   459,   460,   461,    51,   462,   146,   542,   543,
+     544,   357,   275,   276,   277,   371,   478,    37,    38,    63,
+      64,   463,   539,   640,    71,   244
 };
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      41,   172,   224,    44,   265,    95,   213,   415,    52,   283,
-      56,   270,    99,   100,   101,   402,   249,   450,   163,   164,
-     480,   173,   284,   133,    40,    40,   173,   178,   182,   626,
-     178,   303,    75,   305,   269,   479,   271,   273,   253,   403,
-     316,   498,   354,   589,   109,   149,    87,   354,    90,   410,
-     119,   120,   604,   605,    39,   279,    60,    97,   102,   361,
-     475,   642,   214,   118,   119,   120,   561,   642,    40,   411,
-     183,   299,   242,   115,    42,   412,   307,   425,   643,   210,
-     110,   476,   477,   147,   148,   308,   362,   184,   476,   477,
-     400,   158,   615,   308,   426,   331,    98,    61,   166,   167,
-     336,   309,    43,   308,   246,   504,   216,   217,   635,   309,
-     211,   114,   508,   531,   303,   650,   111,   346,   254,   309,
-     334,   548,   420,   366,   421,   422,   655,   520,   427,   428,
-     429,   430,   431,   432,   433,   434,   435,   436,   437,   438,
-     439,   440,   441,   133,   218,   563,   564,   122,   406,   133,
-     407,   408,   423,   532,   214,   118,   119,   120,   533,   248,
-     308,   418,   419,   123,   540,   534,   535,    54,   367,   355,
-     570,   417,   619,   266,   306,   353,   309,    48,   212,   359,
-     302,   178,   536,    45,   308,   308,  -352,   537,   285,   286,
-     287,   648,   649,    46,   220,   124,   340,   215,   216,   217,
-     309,   309,   582,   401,   118,   119,   120,   281,   567,   124,
-     125,   126,   464,   269,    54,   456,    55,   341,   471,   472,
-     644,   578,   404,   645,    47,   442,   644,   568,   316,   645,
-     340,    49,   333,   109,   517,   334,   218,   308,    50,   122,
-     368,    76,   342,   489,   221,   222,   405,   214,   118,   119,
-     120,   526,   223,   309,   530,   123,    75,   128,    94,   510,
-     490,   245,   625,   512,   513,    57,   272,   369,   445,   110,
-      53,   606,   219,   531,    65,    58,   527,   133,   370,   411,
-     454,   330,   647,   331,  -305,   511,   220,    69,   122,   133,
-     215,   216,   217,   446,   617,    62,   481,   343,   308,    70,
-     573,   124,   125,   126,   123,   111,    59,   168,   491,   492,
-     509,   515,   493,   532,   309,   607,   353,   308,   533,   308,
-     574,   609,   293,   629,   294,   534,   535,   308,   576,   218,
-     443,   343,   122,   309,    72,   309,   221,   222,   214,   118,
-     119,   120,   536,   309,   223,    79,  -352,   537,   123,   128,
-     124,   125,   126,   316,   651,   652,   298,   118,   119,   120,
-     569,    80,   571,   572,   514,   219,   214,   118,   119,   120,
-     214,   118,   119,   120,   348,   519,    81,   349,    83,   220,
-     298,   215,   216,   217,   308,   127,   186,   187,   188,   189,
-     190,   191,   358,    75,   124,   125,   126,   364,   128,   398,
-     309,   121,   399,   327,   328,   329,   330,    82,   331,   215,
-     216,   217,   310,   301,   216,   217,   452,   599,    88,   453,
-     218,    91,   523,   122,    92,   207,    96,   610,   525,   221,
-     222,   453,   621,   529,   103,   551,   207,   223,   334,   123,
-     562,   122,   128,   334,  -306,    67,    68,   566,   218,   311,
-     353,   122,   218,   256,   257,   122,   219,   123,   580,   594,
-     600,   353,   595,   334,   104,   601,   106,   123,   334,   577,
-     220,   123,   612,   622,   107,   353,   353,   637,   639,   640,
-     653,   334,   117,   334,   219,   124,   125,   126,   302,   531,
-     142,   559,   630,   631,   632,   144,   312,   145,   220,    85,
-      86,   149,   220,   124,   125,   126,   151,   152,   154,   159,
-     157,   160,   161,   124,   125,   126,   313,   124,   125,   126,
-     221,   222,   165,   314,   315,    54,   170,   171,   223,   532,
-     173,   316,   317,   128,   533,   179,   181,   201,   127,   202,
-     203,   534,   535,   206,   207,   623,   208,   209,   221,   222,
-     243,   128,   221,   222,   247,   258,   223,   250,   536,   114,
-     223,   128,   274,   537,   282,   128,   292,    15,   295,   318,
-     319,   320,   321,   322,   296,   297,   323,   324,  -354,   325,
-     326,   327,   328,   329,   330,     1,   331,   304,   332,   338,
-     335,   339,   311,     2,   624,   347,   350,   353,   360,   365,
-       3,   373,     1,   375,   374,     4,   396,   395,   397,    75,
-       2,   416,   413,   444,   424,     5,   448,     3,     6,     7,
-     449,   451,     4,   466,   468,   482,   474,   473,   483,   422,
-       8,     9,     5,   485,   502,     6,     7,   486,   487,   312,
-      10,   499,   500,    11,   505,   308,   506,     8,     9,   507,
-     518,   331,   521,   522,   516,   524,   539,    10,   544,   414,
-      11,   546,   547,   311,   549,    12,   550,   315,   552,    13,
-     553,   554,   555,   556,   316,   317,   557,   565,   558,   376,
-     581,   575,    12,   579,   584,    14,    13,   583,   590,   585,
-     588,    15,   311,   377,   591,   593,   586,   378,   379,   380,
-     381,   382,    14,   383,   587,   596,   597,   311,    15,   598,
-     312,   384,   318,   319,   320,   321,   322,   608,   602,   323,
-     324,   611,   325,   326,   327,   328,   329,   330,   618,   331,
-     414,   493,   616,    16,    17,    18,   385,   628,   315,  -355,
-     620,   654,   636,   105,    74,   316,   317,   641,   455,   528,
-      16,    17,    18,   501,   386,   560,   387,   388,   465,   204,
-     205,   447,   337,   467,   278,   614,   280,   315,   409,   613,
-     470,   389,   372,   356,   316,  -355,   390,   592,   391,   169,
-       0,     0,   315,   318,   319,   320,   321,   322,   392,   316,
-     323,   324,     0,   325,   326,   327,   328,   329,   330,     0,
-     331,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,  -355,  -355,  -355,   321,   322,     0,     0,   323,
-     324,   393,   325,   326,   327,   328,   329,   330,     0,   331,
-    -355,  -355,     0,     0,  -355,  -355,     0,   325,   326,   327,
-     328,   329,   330,     0,   331,   186,   187,   188,   189,   190,
-     191,   192,   193,   194,   195,   196,   197
+      41,   283,   224,    44,   265,   213,    95,   133,    52,   415,
+      56,   270,   172,   303,   402,   305,    99,   100,   101,   450,
+     403,   163,   164,   182,   249,    40,   284,    40,   532,   479,
+     173,   480,   173,   628,   269,    75,   271,   273,   119,   120,
+     562,   178,   354,   340,   178,   149,    87,   354,    90,   115,
+     279,   253,   498,   316,   118,   119,   120,   293,   102,   294,
+     183,   210,   308,   644,   341,   298,   422,    40,   533,   308,
+     425,   299,   644,   534,   645,   242,   307,   184,   309,   308,
+     535,   536,   400,   147,   148,   309,   591,   426,   509,   342,
+      39,   158,   211,   423,   532,   309,   303,   537,   166,   167,
+     336,  -353,   538,    48,   420,   246,   421,   504,   331,   109,
+     427,   428,   429,   430,   431,   432,   433,   434,   435,   436,
+     437,   438,   439,   440,   441,   346,   308,   133,    42,   521,
+      75,   254,   549,   133,   533,   245,   617,    60,   122,   534,
+     417,    97,   309,   406,   343,   110,   535,   536,   621,   266,
+     407,   408,   476,   477,   123,   308,   564,   565,   367,   248,
+     212,   418,   419,   537,   355,   572,   652,  -353,   538,   541,
+      54,   309,   366,    43,   359,   306,   114,   657,    61,   353,
+      98,   111,    49,   124,   214,   118,   119,   120,   118,   119,
+     120,   334,   285,   286,   287,   178,   650,   651,    55,  -306,
+     124,   125,   126,   404,   609,   584,    50,   281,   214,   118,
+     119,   120,   401,   269,   568,    54,   518,   456,   471,   472,
+     464,    53,   646,    76,   580,   647,   569,   215,   216,   217,
+     368,   646,   121,   308,   647,   127,   442,   340,   308,   333,
+      94,    62,   334,   606,   607,    65,   531,   405,   128,   309,
+     410,   215,   216,   217,   309,   316,   109,   369,   527,   653,
+     654,   133,   516,   513,   514,  -307,   218,   353,   370,   122,
+     411,    45,   122,   133,   608,   627,   412,   214,   118,   119,
+     120,    46,   445,   528,   489,   123,   358,   361,   123,   168,
+     218,   364,   110,   122,   454,   649,   272,   446,   619,   481,
+     637,   490,   219,   214,   118,   119,   120,    69,   330,   123,
+     331,   578,    47,   308,   362,   475,   220,   298,   510,   511,
+     215,   216,   217,    67,    68,   308,   219,   631,   111,   309,
+     443,   124,   125,   126,   124,   125,   126,    72,   343,   411,
+     220,   309,    57,   476,   477,   512,   215,   216,   217,   491,
+     492,   348,    58,   493,   349,   124,   125,   126,    75,   218,
+      70,   571,   122,   573,   574,   515,   221,   222,    79,   127,
+     576,   308,   398,   575,   223,   399,   520,   308,   123,   128,
+      82,   452,   128,    59,   453,   218,   316,   309,   122,    80,
+     221,   222,   308,   309,   611,   219,   524,   526,   223,   207,
+     453,    88,   530,   128,   123,   207,   256,   257,   309,   220,
+     214,   118,   119,   120,    83,   552,   563,   601,   334,   334,
+     567,   219,    81,   353,   124,   125,   126,    85,    86,   612,
+     214,   118,   119,   120,   623,   220,   327,   328,   329,   330,
+      91,   331,   186,   187,   188,   189,   190,   191,    92,    96,
+     124,   125,   126,   301,   216,   217,   103,   104,   582,   221,
+     222,   353,   596,   602,   532,   597,   334,   223,   505,   310,
+     506,   579,   128,   603,   216,   217,   334,   614,   107,   639,
+     353,   642,   106,   117,   624,   221,   222,   353,   632,   633,
+     634,   560,   218,   223,   142,   122,   641,   655,   128,   334,
+     334,   144,   145,  -355,   533,   149,   311,   151,   152,   534,
+       1,   123,   218,   154,   157,   122,   535,   536,     2,   159,
+     625,   160,   161,   165,   173,     3,    54,   170,   302,   171,
+       4,   123,   179,   537,   181,   201,   202,   203,   538,   206,
+       5,   207,   220,     6,     7,   243,   208,   209,   302,   247,
+     250,   258,   114,   312,   274,     8,     9,   124,   125,   126,
+     282,    15,   220,   295,   292,    10,   296,   297,    11,   626,
+     304,   332,   350,   313,   338,   335,   339,   124,   125,   126,
+     314,   315,   347,   353,   360,   365,   373,   374,   316,   317,
+      12,   375,   221,   222,    13,   395,   396,   397,    75,   413,
+     223,   444,   466,   416,   424,   128,   448,   449,   451,   468,
+      14,   474,   221,   222,   473,   502,    15,   507,   508,   482,
+     223,   483,   485,   486,   487,   128,   318,   319,   320,   321,
+     322,   308,   422,   323,   324,   331,   325,   326,   327,   328,
+     329,   330,     1,   331,   499,   522,   500,   519,   523,   525,
+       2,   545,   540,   547,   548,   550,   551,     3,    16,    17,
+      18,   553,     4,   554,   555,   558,   556,   557,   559,   570,
+     566,   583,     5,   577,   586,     6,     7,   581,   585,   587,
+     590,   592,   311,   588,   376,   589,   593,     8,     9,   604,
+     620,   595,   493,   622,   656,   598,   599,    10,   377,   600,
+      11,   610,   378,   379,   380,   381,   382,   613,   383,   618,
+     105,   630,    74,   311,   638,   455,   384,   447,   529,   643,
+     561,   501,    12,   337,   467,   465,    13,   204,   278,   312,
+     616,   409,   615,   280,   356,   205,   372,   594,   169,     0,
+     470,   385,    14,     0,   517,     0,     0,   311,    15,   414,
+       0,     0,     0,     0,     0,     0,     0,   315,     0,   386,
+     312,   387,   388,     0,   316,   317,     0,   311,     0,     0,
+       0,     0,     0,     0,     0,     0,   389,     0,     0,     0,
+     414,   390,     0,   391,     0,     0,     0,     0,   315,     0,
+      16,    17,    18,   392,  -356,   316,   317,     0,     0,     0,
+       0,     0,   318,   319,   320,   321,   322,     0,     0,   323,
+     324,     0,   325,   326,   327,   328,   329,   330,     0,   331,
+       0,     0,   315,     0,     0,     0,   393,     0,     0,   316,
+    -356,     0,     0,   318,   319,   320,   321,   322,     0,     0,
+     323,   324,   315,   325,   326,   327,   328,   329,   330,   316,
+     331,     0,   186,   187,   188,   189,   190,   191,   192,   193,
+     194,   195,   196,   197,     0,     0,     0,  -356,  -356,  -356,
+     321,   322,     0,     0,   323,   324,     0,   325,   326,   327,
+     328,   329,   330,     0,   331,     0,     0,     0,     0,     0,
+    -356,  -356,     0,     0,  -356,  -356,     0,   325,   326,   327,
+     328,   329,   330,     0,   331
 };
 
 static const yytype_int16 yycheck[] =
 {
-       2,   107,   149,     5,   175,    54,   148,   304,    10,   211,
-      12,   182,    57,    58,    59,   293,   155,   342,    97,    98,
-     374,    12,     3,    81,     3,     3,    12,   112,   115,    51,
-     115,   219,    58,   221,   181,   373,   183,   184,   113,     3,
-     136,   395,     3,   539,     9,    83,    48,     3,    50,    92,
-       5,     6,   566,   567,    27,   203,    19,    94,    60,    90,
-     130,     6,     3,     4,     5,     6,   495,     6,     3,   112,
-      55,   218,   151,    78,     3,   118,   223,   104,    17,    94,
-      45,   158,   159,    85,    86,   116,   117,    72,   158,   159,
-     292,    93,   588,   116,   121,   191,   133,    60,   100,   101,
-     247,   132,     3,   116,   153,   402,    47,    48,   622,   132,
-     125,    76,   125,    26,   302,   643,    81,   256,   193,   132,
-     197,   475,   310,    55,   312,   101,   654,   424,   316,   317,
-     318,   319,   320,   321,   322,   323,   324,   325,   326,   327,
-     328,   329,   330,   201,    85,   499,   500,    88,   296,   207,
-     297,   298,   128,    66,     3,     4,     5,     6,    71,   197,
-     116,   308,   309,   104,   125,    78,    79,   193,    62,   125,
-     508,   194,   601,   178,   223,   197,   132,    94,   193,   266,
-     121,   266,    95,    70,   116,   116,    99,   100,   169,   170,
-     171,   166,   167,    80,   135,   150,     3,    46,    47,    48,
-     132,   132,   527,   194,     4,     5,     6,   209,   194,   150,
-     151,   152,   351,   360,   193,   193,    12,    24,   365,   366,
-     165,   518,   186,   168,   111,   331,   165,   505,   136,   168,
-       3,    94,   194,     9,   422,   197,    85,   116,    98,    88,
-     134,    37,    49,   104,   185,   186,   295,     3,     4,     5,
-       6,    24,   193,   132,   456,   104,    58,   198,    54,    92,
-     121,    63,   616,   410,   411,    70,   115,   161,   335,    45,
-      80,   568,   121,    26,   154,    80,    49,   335,   172,   112,
-     347,   189,   636,   191,   197,   118,   135,     0,    88,   347,
-      46,    47,    48,   338,   591,     3,   375,   104,   116,   196,
-     118,   150,   151,   152,   104,    81,   111,   103,   169,   170,
-     109,   192,   173,    66,   132,   194,   197,   116,    71,   116,
-     109,   118,   193,   620,   195,    78,    79,   116,   516,    85,
-     332,   104,    88,   132,   113,   132,   185,   186,     3,     4,
-       5,     6,    95,   132,   193,     3,    99,   100,   104,   198,
-     150,   151,   152,   136,   166,   167,   112,     4,     5,     6,
-     507,   195,   509,   510,   413,   121,     3,     4,     5,     6,
-       3,     4,     5,     6,   194,   424,   193,   197,   127,   135,
-     112,    46,    47,    48,   116,   185,   138,   139,   140,   141,
-     142,   143,   265,    58,   150,   151,   152,   270,   198,   194,
-     132,    48,   197,   186,   187,   188,   189,    94,   191,    46,
-      47,    48,    17,    46,    47,    48,   194,   559,     3,   197,
-      85,   123,   194,    88,   127,   197,   133,   574,   194,   185,
-     186,   197,   603,   194,   125,   194,   197,   193,   197,   104,
-     194,    88,   198,   197,   197,    17,    18,   194,    85,    54,
-     197,    88,    85,   163,   164,    88,   121,   104,   194,   194,
-     194,   197,   197,   197,   197,   194,    97,   104,   197,   518,
-     135,   104,   194,   194,   124,   197,   197,   624,   194,   626,
-     194,   197,     3,   197,   121,   150,   151,   152,   121,    26,
-       4,   493,   162,   163,   164,   121,   101,     3,   135,    46,
-      47,    83,   135,   150,   151,   152,    93,   193,     3,   194,
-      46,   194,     4,   150,   151,   152,   121,   150,   151,   152,
-     185,   186,     3,   128,   129,   193,   193,     6,   193,    66,
-      12,   136,   137,   198,    71,   115,   126,   193,   185,     4,
-       4,    78,    79,   194,   197,    82,    46,   131,   185,   186,
-       3,   198,   185,   186,   174,     3,   193,    91,    95,    76,
-     193,   198,   119,   100,     3,   198,   125,   113,   193,   174,
-     175,   176,   177,   178,   193,   193,   181,   182,     0,   184,
-     185,   186,   187,   188,   189,     7,   191,   191,    98,    39,
-     193,   193,    54,    15,   131,   193,    94,   197,   197,    55,
-      22,   125,     7,    93,   193,    27,   172,   193,   172,    58,
-      15,   194,   193,     3,   193,    37,     4,    22,    40,    41,
-       4,     4,    27,     3,     3,   193,   161,   172,   193,   101,
-      52,    53,    37,   193,    77,    40,    41,   193,   193,   101,
-      62,   193,   193,    65,   193,   116,   194,    52,    53,    94,
-     193,   191,   104,   192,   116,     3,   197,    62,    69,   121,
-      65,     3,    62,    54,   160,    87,   194,   129,     6,    91,
-       6,     6,     6,     6,   136,   137,   104,   193,   172,    11,
-       4,   194,    87,   194,    99,   107,    91,   194,     3,    78,
-      99,   113,    54,    25,   126,   194,    78,    29,    30,    31,
-      32,    33,   107,    35,    78,   194,   194,    54,   113,   194,
-     101,    43,   174,   175,   176,   177,   178,   194,   105,   181,
-     182,   194,   184,   185,   186,   187,   188,   189,     6,   191,
-     121,   173,   193,   155,   156,   157,    68,   194,   129,   101,
-     126,   116,   193,    70,    24,   136,   137,   194,   349,   453,
-     155,   156,   157,   399,    86,   495,    88,    89,   353,   127,
-     127,   339,   248,   360,   201,   584,   207,   129,   299,   583,
-     364,   103,   276,   264,   136,   137,   108,   548,   110,   104,
-      -1,    -1,   129,   174,   175,   176,   177,   178,   120,   136,
-     181,   182,    -1,   184,   185,   186,   187,   188,   189,    -1,
-     191,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+       2,   211,   149,     5,   175,   148,    54,    81,    10,   304,
+      12,   182,   107,   219,   293,   221,    57,    58,    59,   342,
+       3,    97,    98,   115,   155,     3,     3,     3,    26,   373,
+      12,   374,    12,    51,   181,    58,   183,   184,     5,     6,
+     495,   112,     3,     3,   115,    83,    48,     3,    50,    78,
+     203,   113,   395,   136,     4,     5,     6,   193,    60,   195,
+      55,    94,   116,     6,    24,   112,   101,     3,    66,   116,
+     104,   218,     6,    71,    17,   151,   223,    72,   132,   116,
+      78,    79,   292,    85,    86,   132,   540,   121,   125,    49,
+      27,    93,   125,   128,    26,   132,   302,    95,   100,   101,
+     247,    99,   100,    94,   310,   153,   312,   402,   191,     9,
+     316,   317,   318,   319,   320,   321,   322,   323,   324,   325,
+     326,   327,   328,   329,   330,   256,   116,   201,     3,   424,
+      58,   193,   475,   207,    66,    63,   590,    19,    88,    71,
+     194,    94,   132,   296,   104,    45,    78,    79,   603,   178,
+     297,   298,   158,   159,   104,   116,   499,   500,    62,   197,
+     193,   308,   309,    95,   125,   509,   645,    99,   100,   125,
+     193,   132,    55,     3,   266,   223,    76,   656,    60,   197,
+     133,    81,    94,   150,     3,     4,     5,     6,     4,     5,
+       6,   197,   169,   170,   171,   266,   166,   167,    12,   197,
+     150,   151,   152,   186,   194,   528,    98,   209,     3,     4,
+       5,     6,   194,   360,   194,   193,   422,   193,   365,   366,
+     351,    80,   165,    37,   519,   168,   505,    46,    47,    48,
+     134,   165,    48,   116,   168,   185,   331,     3,   116,   194,
+      54,     3,   197,   567,   568,   154,   456,   295,   198,   132,
+      92,    46,    47,    48,   132,   136,     9,   161,    24,   166,
+     167,   335,   192,   410,   411,   197,    85,   197,   172,    88,
+     112,    70,    88,   347,   569,   618,   118,     3,     4,     5,
+       6,    80,   335,    49,   104,   104,   265,    90,   104,   103,
+      85,   270,    45,    88,   347,   638,   115,   338,   593,   375,
+     624,   121,   121,     3,     4,     5,     6,     0,   189,   104,
+     191,   517,   111,   116,   117,   130,   135,   112,   109,    92,
+      46,    47,    48,    17,    18,   116,   121,   622,    81,   132,
+     332,   150,   151,   152,   150,   151,   152,   113,   104,   112,
+     135,   132,    70,   158,   159,   118,    46,    47,    48,   169,
+     170,   194,    80,   173,   197,   150,   151,   152,    58,    85,
+     196,   508,    88,   510,   511,   413,   185,   186,     3,   185,
+     109,   116,   194,   118,   193,   197,   424,   116,   104,   198,
+      94,   194,   198,   111,   197,    85,   136,   132,    88,   195,
+     185,   186,   116,   132,   118,   121,   194,   194,   193,   197,
+     197,     3,   194,   198,   104,   197,   163,   164,   132,   135,
+       3,     4,     5,     6,   127,   194,   194,   560,   197,   197,
+     194,   121,   193,   197,   150,   151,   152,    46,    47,   576,
+       3,     4,     5,     6,   605,   135,   186,   187,   188,   189,
+     123,   191,   138,   139,   140,   141,   142,   143,   127,   133,
+     150,   151,   152,    46,    47,    48,   125,   197,   194,   185,
+     186,   197,   194,   194,    26,   197,   197,   193,   193,    17,
+     195,   519,   198,   194,    47,    48,   197,   194,   124,   626,
+     197,   628,    97,     3,   194,   185,   186,   197,   162,   163,
+     164,   493,    85,   193,     4,    88,   194,   194,   198,   197,
+     197,   121,     3,     0,    66,    83,    54,    93,   193,    71,
+       7,   104,    85,     3,    46,    88,    78,    79,    15,   194,
+      82,   194,     4,     3,    12,    22,   193,   193,   121,     6,
+      27,   104,   115,    95,   126,   193,     4,     4,   100,   194,
+      37,   197,   135,    40,    41,     3,    46,   131,   121,   174,
+      91,     3,    76,   101,   119,    52,    53,   150,   151,   152,
+       3,   113,   135,   193,   125,    62,   193,   193,    65,   131,
+     191,    98,    94,   121,    39,   193,   193,   150,   151,   152,
+     128,   129,   193,   197,   197,    55,   125,   193,   136,   137,
+      87,    93,   185,   186,    91,   193,   172,   172,    58,   193,
+     193,     3,     3,   194,   193,   198,     4,     4,     4,     3,
+     107,   161,   185,   186,   172,    77,   113,   194,    94,   193,
+     193,   193,   193,   193,   193,   198,   174,   175,   176,   177,
+     178,   116,   101,   181,   182,   191,   184,   185,   186,   187,
+     188,   189,     7,   191,   193,   104,   193,   193,   192,     3,
+      15,    69,   197,     3,    62,   160,   194,    22,   155,   156,
+     157,     6,    27,     6,     6,   104,     6,     6,   172,     3,
+     193,     4,    37,   194,    99,    40,    41,   194,   194,    78,
+      99,     3,    54,    78,    11,    78,   126,    52,    53,   105,
+       6,   194,   173,   126,   116,   194,   194,    62,    25,   194,
+      65,   194,    29,    30,    31,    32,    33,   194,    35,   193,
+      70,   194,    24,    54,   193,   349,    43,   339,   453,   194,
+     495,   399,    87,   248,   360,   353,    91,   127,   201,   101,
+     586,   299,   585,   207,   264,   127,   276,   549,   104,    -1,
+     364,    68,   107,    -1,   116,    -1,    -1,    54,   113,   121,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   129,    -1,    86,
+     101,    88,    89,    -1,   136,   137,    -1,    54,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   103,    -1,    -1,    -1,
+     121,   108,    -1,   110,    -1,    -1,    -1,    -1,   129,    -1,
+     155,   156,   157,   120,   101,   136,   137,    -1,    -1,    -1,
       -1,    -1,   174,   175,   176,   177,   178,    -1,    -1,   181,
-     182,   153,   184,   185,   186,   187,   188,   189,    -1,   191,
+     182,    -1,   184,   185,   186,   187,   188,   189,    -1,   191,
+      -1,    -1,   129,    -1,    -1,    -1,   153,    -1,    -1,   136,
+     137,    -1,    -1,   174,   175,   176,   177,   178,    -1,    -1,
+     181,   182,   129,   184,   185,   186,   187,   188,   189,   136,
+     191,    -1,   138,   139,   140,   141,   142,   143,   144,   145,
+     146,   147,   148,   149,    -1,    -1,    -1,   174,   175,   176,
      177,   178,    -1,    -1,   181,   182,    -1,   184,   185,   186,
-     187,   188,   189,    -1,   191,   138,   139,   140,   141,   142,
-     143,   144,   145,   146,   147,   148,   149
+     187,   188,   189,    -1,   191,    -1,    -1,    -1,    -1,    -1,
+     177,   178,    -1,    -1,   181,   182,    -1,   184,   185,   186,
+     187,   188,   189,    -1,   191
 };
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
-static const yytype_uint16 yystos[] =
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int16 yystos[] =
 {
        0,     7,    15,    22,    27,    37,    40,    41,    52,    53,
       62,    65,    87,    91,   107,   113,   155,   156,   157,   200,
@@ -1347,26 +1439,26 @@ static const yytype_uint16 yystos[] =
      321,   274,   274,   172,   161,   130,   158,   159,   325,   225,
      334,   214,   193,   193,   227,   193,   193,   193,   226,   104,
      121,   169,   170,   173,   228,   229,   230,   232,   334,   193,
-     193,   223,    77,   286,   268,   193,   194,    94,   125,   109,
-      92,   118,   274,   274,   249,   192,   116,   275,   193,   249,
-     268,   104,   192,   194,     3,   194,    24,    49,   217,   194,
-     245,    26,    66,    71,    78,    79,    95,   100,   331,   197,
-     125,   317,   318,   319,    69,   259,     3,    62,   334,   160,
-     194,   194,     6,     6,     6,     6,     6,   104,   172,   315,
-     230,   232,   194,   334,   334,   193,   194,   194,   254,   274,
-     225,   274,   274,   118,   109,   194,   275,   249,   268,   194,
-     194,     4,   213,   194,    99,    78,    78,    78,    99,   310,
-       3,   126,   325,   194,   194,   197,   194,   194,   194,   241,
-     194,   194,   105,   287,   286,   286,   268,   194,   194,   118,
-     274,   194,   194,   318,   311,   310,   193,   268,     6,   232,
-     126,   261,   194,    82,   131,   334,    51,   260,   194,   268,
-     162,   163,   164,   288,   289,   286,   193,   274,   332,   194,
-     274,   194,     6,    17,   165,   168,   290,   334,   166,   167,
-     290,   166,   167,   194,   116,   290
+     193,   223,    77,   286,   268,   193,   195,   194,    94,   125,
+     109,    92,   118,   274,   274,   249,   192,   116,   275,   193,
+     249,   268,   104,   192,   194,     3,   194,    24,    49,   217,
+     194,   245,    26,    66,    71,    78,    79,    95,   100,   331,
+     197,   125,   317,   318,   319,    69,   259,     3,    62,   334,
+     160,   194,   194,     6,     6,     6,     6,     6,   104,   172,
+     315,   230,   232,   194,   334,   334,   193,   194,   194,   254,
+       3,   274,   225,   274,   274,   118,   109,   194,   275,   249,
+     268,   194,   194,     4,   213,   194,    99,    78,    78,    78,
+      99,   310,     3,   126,   325,   194,   194,   197,   194,   194,
+     194,   241,   194,   194,   105,   287,   286,   286,   268,   194,
+     194,   118,   274,   194,   194,   318,   311,   310,   193,   268,
+       6,   232,   126,   261,   194,    82,   131,   334,    51,   260,
+     194,   268,   162,   163,   164,   288,   289,   286,   193,   274,
+     332,   194,   274,   194,     6,    17,   165,   168,   290,   334,
+     166,   167,   290,   166,   167,   194,   116,   290
 };
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint16 yyr1[] =
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int16 yyr1[] =
 {
        0,   199,   200,   201,   201,   202,   202,   202,   202,   202,
      203,   203,   203,   203,   203,   203,   203,   203,   203,   203,
@@ -1396,18 +1488,18 @@ static const yytype_uint16 yyr1[] =
      289,   289,   290,   290,   290,   290,   290,   291,   292,   293,
      293,   293,   293,   293,   293,   294,   294,   294,   294,   294,
      294,   295,   295,   296,   297,   298,   299,   299,   299,   299,
-     300,   300,   300,   300,   300,   300,   300,   301,   302,   302,
-     303,   303,   304,   305,   306,   307,   307,   307,   308,   309,
-     309,   310,   310,   311,   311,   312,   312,   313,   314,   315,
-     315,   316,   316,   317,   317,   318,   318,   319,   319,   320,
-     320,   321,   321,   322,   322,   323,   323,   324,   324,   324,
-     324,   325,   325,   325,   326,   326,   327,   328,   328,   329,
-     330,   330,   330,   331,   331,   331,   331,   331,   331,   331,
-     331,   331,   331,   332,   333,   333,   334,   334
+     299,   300,   300,   300,   300,   300,   300,   300,   301,   302,
+     302,   303,   303,   304,   305,   306,   307,   307,   307,   308,
+     309,   309,   310,   310,   311,   311,   312,   312,   313,   314,
+     315,   315,   316,   316,   317,   317,   318,   318,   319,   319,
+     320,   320,   321,   321,   322,   322,   323,   323,   324,   324,
+     324,   324,   325,   325,   325,   326,   326,   327,   328,   328,
+     329,   330,   330,   330,   331,   331,   331,   331,   331,   331,
+     331,   331,   331,   331,   332,   333,   333,   334,   334
 };
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
 {
        0,     2,     2,     1,     3,     2,     2,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
@@ -1436,51 +1528,51 @@ static const yytype_uint8 yyr2[] =
        6,     8,     6,     0,     3,     0,     2,     5,     0,     1,
        1,     1,     2,     2,     2,     2,     1,     6,     6,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     4,     4,     5,     1,     3,     1,     3,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     2,     2,     3,     2,     1,     1,
-       3,     1,     1,     1,     4,     1,     3,     2,     1,     1,
-       3,     1,     0,     1,     5,     1,     0,     2,     1,     1,
-       0,     1,     0,     1,     2,     3,     5,     1,     3,     1,
-       2,     2,     1,     0,     1,     0,     2,     1,     3,     3,
-       4,     6,     8,     1,     2,     1,     2,     1,     2,     1,
-       1,     1,     0,     1,     1,     0,     1,     3
+       1,     1,     1,     4,     4,     5,     1,     3,     5,     1,
+       3,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     2,     2,     3,     2,     1,
+       1,     3,     1,     1,     1,     4,     1,     3,     2,     1,
+       1,     3,     1,     0,     1,     5,     1,     0,     2,     1,
+       1,     0,     1,     0,     1,     2,     3,     5,     1,     3,
+       1,     2,     2,     1,     0,     1,     0,     2,     1,     3,
+       3,     4,     6,     8,     1,     2,     1,     2,     1,     2,
+       1,     1,     1,     0,     1,     1,     0,     1,     3
 };
 
 
+enum { YYENOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
-#define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
+#define yyclearin       (yychar = SQL_HSQL_EMPTY)
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
 #define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
 
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      yyerror (&yylloc, result, scanner, YY_("syntax error: cannot back up")); \
-      YYERROR;                                                  \
-    }                                                           \
-while (0)
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == SQL_HSQL_EMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (&yylloc, result, scanner, YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
+/* Backward compatibility with an undocumented macro.
+   Use SQL_HSQL_error or SQL_HSQL_UNDEF. */
+#define YYERRCODE SQL_HSQL_UNDEF
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
    If N is 0, then set CURRENT to the empty location which ends
@@ -1524,20 +1616,27 @@ do {                                            \
 } while (0)
 
 
-/* YY_LOCATION_PRINT -- Print the location on the stream.
+/* YYLOCATION_PRINT -- Print the location on the stream.
    This macro was not mandated originally: define only if we know
    we won't break user code: when these are the locations we know.  */
 
-#ifndef YY_LOCATION_PRINT
-# if defined HSQL_LTYPE_IS_TRIVIAL && HSQL_LTYPE_IS_TRIVIAL
+# ifndef YYLOCATION_PRINT
+
+#  if defined YY_LOCATION_PRINT
+
+   /* Temporary convenience wrapper in case some people defined the
+      undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YYLOCATION_PRINT(File, Loc)  YY_LOCATION_PRINT(File, *(Loc))
+
+#  elif defined HSQL_LTYPE_IS_TRIVIAL && HSQL_LTYPE_IS_TRIVIAL
 
 /* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
 
 YY_ATTRIBUTE_UNUSED
-static unsigned
+static int
 yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
 {
-  unsigned res = 0;
+  int res = 0;
   int end_col = 0 != yylocp->last_column ? yylocp->last_column - 1 : 0;
   if (0 <= yylocp->first_line)
     {
@@ -1557,65 +1656,73 @@ yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
         res += YYFPRINTF (yyo, "-%d", end_col);
     }
   return res;
- }
+}
 
-#  define YY_LOCATION_PRINT(File, Loc)          \
-  yy_location_print_ (File, &(Loc))
+#   define YYLOCATION_PRINT  yy_location_print_
 
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT(File, Loc)  YYLOCATION_PRINT(File, &(Loc))
+
+#  else
+
+#   define YYLOCATION_PRINT(File, Loc) ((void) 0)
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT  YYLOCATION_PRINT
+
+#  endif
+# endif /* !defined YYLOCATION_PRINT */
 
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
 do {                                                                      \
   if (yydebug)                                                            \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, Location, result, scanner); \
+                  Kind, Value, Location, result, scanner); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
 
 
-/*----------------------------------------.
-| Print this symbol's value on YYOUTPUT.  |
-`----------------------------------------*/
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
-  YYUSE (yylocationp);
-  YYUSE (result);
-  YYUSE (scanner);
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
+  YY_USE (yylocationp);
+  YY_USE (result);
+  YY_USE (scanner);
   if (!yyvaluep)
     return;
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# endif
-  YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
 {
-  YYFPRINTF (yyoutput, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  YY_LOCATION_PRINT (yyoutput, *yylocationp);
-  YYFPRINTF (yyoutput, ": ");
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp, result, scanner);
-  YYFPRINTF (yyoutput, ")");
+  YYLOCATION_PRINT (yyo, yylocationp);
+  YYFPRINTF (yyo, ": ");
+  yy_symbol_value_print (yyo, yykind, yyvaluep, yylocationp, result, scanner);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -1624,7 +1731,7 @@ yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYL
 `------------------------------------------------------------------*/
 
 static void
-yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -1647,21 +1754,22 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, hsql::SQLParserResult* result, yyscan_t scanner)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
+                 int yyrule, hsql::SQLParserResult* result, yyscan_t scanner)
 {
-  unsigned long int yylno = yyrline[yyrule];
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
              yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[yyssp[yyi + 1 - yynrhs]],
-                       &(yyvsp[(yyi + 1) - (yynrhs)])
-                       , &(yylsp[(yyi + 1) - (yynrhs)])                       , result, scanner);
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)],
+                       &(yylsp[(yyi + 1) - (yynrhs)]), result, scanner);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -1676,8 +1784,8 @@ do {                                    \
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !HSQL_DEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !HSQL_DEBUG */
@@ -1700,28 +1808,77 @@ int yydebug;
 #endif
 
 
-#if YYERROR_VERBOSE
+/* Context of a parse error.  */
+typedef struct
+{
+  yy_state_t *yyssp;
+  yysymbol_kind_t yytoken;
+  YYLTYPE *yylloc;
+} yypcontext_t;
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
-#  else
+/* Put in YYARG at most YYARGN of the expected tokens given the
+   current YYCTX, and return the number of tokens stored in YYARG.  If
+   YYARG is null, return the number of expected tokens (guaranteed to
+   be less than YYNTOKENS).  Return YYENOMEM on memory exhaustion.
+   Return 0 if there are more than YYARGN expected tokens, yet fill
+   YYARG up to YYARGN. */
+static int
+yypcontext_expected_tokens (const yypcontext_t *yyctx,
+                            yysymbol_kind_t yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  int yyn = yypact[+*yyctx->yyssp];
+  if (!yypact_value_is_default (yyn))
+    {
+      /* Start YYX at -YYN if negative to avoid negative indexes in
+         YYCHECK.  In other words, skip the first -YYN actions for
+         this state because they are default actions.  */
+      int yyxbegin = yyn < 0 ? -yyn : 0;
+      /* Stay within bounds of both yycheck and yytname.  */
+      int yychecklim = YYLAST - yyn + 1;
+      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+      int yyx;
+      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYerror
+            && !yytable_value_is_error (yytable[yyx + yyn]))
+          {
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = YY_CAST (yysymbol_kind_t, yyx);
+          }
+    }
+  if (yyarg && yycount == 0 && 0 < yyargn)
+    yyarg[0] = YYSYMBOL_YYEMPTY;
+  return yycount;
+}
+
+
+
+
+#ifndef yystrlen
+# if defined __GLIBC__ && defined _STRING_H
+#  define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
+# else
 /* Return the length of YYSTR.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yystrlen (const char *yystr)
 {
-  YYSIZE_T yylen;
+  YYPTRDIFF_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
     continue;
   return yylen;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
+#ifndef yystpcpy
+# if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
+#  define yystpcpy stpcpy
+# else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
 static char *
@@ -1735,10 +1892,10 @@ yystpcpy (char *yydest, const char *yysrc)
 
   return yyd - 1;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yytnamerr
+#ifndef yytnamerr
 /* Copy to YYRES the contents of YYSTR after stripping away unnecessary
    quotes and backslashes, so that it's suitable for yyerror.  The
    heuristic is that double-quoting is unnecessary unless the string
@@ -1746,14 +1903,13 @@ yystpcpy (char *yydest, const char *yysrc)
    backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
    null, do not copy; instead, return the length of what the result
    would have been.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yytnamerr (char *yyres, const char *yystr)
 {
   if (*yystr == '"')
     {
-      YYSIZE_T yyn = 0;
+      YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
-
       for (;;)
         switch (*++yyp)
           {
@@ -1764,7 +1920,10 @@ yytnamerr (char *yyres, const char *yystr)
           case '\\':
             if (*++yyp != '\\')
               goto do_not_strip_quotes;
-            /* Fall through.  */
+            else
+              goto append;
+
+          append:
           default:
             if (yyres)
               yyres[yyn] = *yyp;
@@ -1779,36 +1938,20 @@ yytnamerr (char *yyres, const char *yystr)
     do_not_strip_quotes: ;
     }
 
-  if (! yyres)
+  if (yyres)
+    return yystpcpy (yyres, yystr) - yyres;
+  else
     return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
 }
-# endif
+#endif
 
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
 
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
 static int
-yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
-                yytype_int16 *yyssp, int yytoken)
+yy_syntax_error_arguments (const yypcontext_t *yyctx,
+                           yysymbol_kind_t yyarg[], int yyargn)
 {
-  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-  YYSIZE_T yysize = yysize0;
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat. */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Number of reported tokens (one for the "unexpected", one per
-     "expected"). */
+  /* Actual size of YYARG. */
   int yycount = 0;
-
   /* There are many possibilities here to consider:
      - If this state is a consistent state with a default action, then
        the only way this function was invoked is if the default action
@@ -1832,63 +1975,78 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
        one exception: it will still contain any token that will not be
        accepted due to an error action in a later state.
   */
-  if (yytoken != YYEMPTY)
+  if (yyctx->yytoken != YYSYMBOL_YYEMPTY)
     {
-      int yyn = yypact[*yyssp];
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-                    return 2;
-                  yysize = yysize1;
-                }
-              }
-        }
+      int yyn;
+      if (yyarg)
+        yyarg[yycount] = yyctx->yytoken;
+      ++yycount;
+      yyn = yypcontext_expected_tokens (yyctx,
+                                        yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == YYENOMEM)
+        return YYENOMEM;
+      else
+        yycount += yyn;
     }
+  return yycount;
+}
+
+/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
+   about the unexpected token YYTOKEN for the state stack whose top is
+   YYSSP.
+
+   Return 0 if *YYMSG was successfully written.  Return -1 if *YYMSG is
+   not large enough to hold the message.  In that case, also set
+   *YYMSG_ALLOC to the required number of bytes.  Return YYENOMEM if the
+   required number of bytes is too large to store.  */
+static int
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                const yypcontext_t *yyctx)
+{
+  enum { YYARGS_MAX = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
+  yysymbol_kind_t yyarg[YYARGS_MAX];
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
+
+  /* Actual size of YYARG. */
+  int yycount = yy_syntax_error_arguments (yyctx, yyarg, YYARGS_MAX);
+  if (yycount == YYENOMEM)
+    return YYENOMEM;
 
   switch (yycount)
     {
-# define YYCASE_(N, S)                      \
+#define YYCASE_(N, S)                       \
       case N:                               \
         yyformat = S;                       \
-      break
+        break
+    default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
       YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
       YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
       YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
       YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
+#undef YYCASE_
     }
 
+  /* Compute error message size.  Don't count the "%s"s, but reserve
+     room for the terminator.  */
+  yysize = yystrlen (yyformat) - 2 * yycount + 1;
   {
-    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-      return 2;
-    yysize = yysize1;
+    int yyi;
+    for (yyi = 0; yyi < yycount; ++yyi)
+      {
+        YYPTRDIFF_T yysize1
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
+        if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+          yysize = yysize1;
+        else
+          return YYENOMEM;
+      }
   }
 
   if (*yymsg_alloc < yysize)
@@ -1897,7 +2055,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
       if (! (yysize <= *yymsg_alloc
              && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
         *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
+      return -1;
     }
 
   /* Avoid sprintf, as that infringes on the user's name space.
@@ -1909,64 +2067,65 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
     while ((*yyp = *yyformat) != '\0')
       if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
         {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
           yyformat += 2;
         }
       else
         {
-          yyp++;
-          yyformat++;
+          ++yyp;
+          ++yyformat;
         }
   }
   return 0;
 }
-#endif /* YYERROR_VERBOSE */
+
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, hsql::SQLParserResult* result, yyscan_t scanner)
 {
-  YYUSE (yyvaluep);
-  YYUSE (yylocationp);
-  YYUSE (result);
-  YYUSE (scanner);
+  YY_USE (yyvaluep);
+  YY_USE (yylocationp);
+  YY_USE (result);
+  YY_USE (scanner);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  switch (yytype)
+  switch (yykind)
     {
-          case 3: /* IDENTIFIER  */
-#line 194 "bison_parser.y" /* yacc.c:1257  */
-      { free(((*yyvaluep).sval)); }
-#line 1947 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_IDENTIFIER: /* IDENTIFIER  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2106 "bison_parser.cpp"
         break;
 
-    case 4: /* STRING  */
-#line 194 "bison_parser.y" /* yacc.c:1257  */
-      { free(((*yyvaluep).sval)); }
-#line 1953 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_STRING: /* STRING  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2112 "bison_parser.cpp"
         break;
 
-    case 5: /* FLOATVAL  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 1959 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_FLOATVAL: /* FLOATVAL  */
+#line 181 "bison_parser.y"
+            { }
+#line 2118 "bison_parser.cpp"
         break;
 
-    case 6: /* INTVAL  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 1965 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_INTVAL: /* INTVAL  */
+#line 181 "bison_parser.y"
+            { }
+#line 2124 "bison_parser.cpp"
         break;
 
-    case 201: /* statement_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_statement_list: /* statement_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).stmt_vec)) {
     for (auto ptr : *(((*yyvaluep).stmt_vec))) {
       delete ptr;
@@ -1974,24 +2133,24 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).stmt_vec));
 }
-#line 1978 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2137 "bison_parser.cpp"
         break;
 
-    case 202: /* statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).statement)); }
-#line 1984 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_statement: /* statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).statement)); }
+#line 2143 "bison_parser.cpp"
         break;
 
-    case 203: /* preparable_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).statement)); }
-#line 1990 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_preparable_statement: /* preparable_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).statement)); }
+#line 2149 "bison_parser.cpp"
         break;
 
-    case 204: /* opt_hints  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_opt_hints: /* opt_hints  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -1999,12 +2158,12 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2003 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2162 "bison_parser.cpp"
         break;
 
-    case 205: /* hint_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_hint_list: /* hint_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2012,105 +2171,105 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2016 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2175 "bison_parser.cpp"
         break;
 
-    case 206: /* hint  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2022 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_hint: /* hint  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2181 "bison_parser.cpp"
         break;
 
-    case 207: /* transaction_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).transaction_stmt)); }
-#line 2028 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_transaction_statement: /* transaction_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).transaction_stmt)); }
+#line 2187 "bison_parser.cpp"
         break;
 
-    case 209: /* prepare_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).prep_stmt)); }
-#line 2034 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_prepare_statement: /* prepare_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).prep_stmt)); }
+#line 2193 "bison_parser.cpp"
         break;
 
-    case 210: /* prepare_target_query  */
-#line 194 "bison_parser.y" /* yacc.c:1257  */
-      { free(((*yyvaluep).sval)); }
-#line 2040 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_prepare_target_query: /* prepare_target_query  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2199 "bison_parser.cpp"
         break;
 
-    case 211: /* execute_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).exec_stmt)); }
-#line 2046 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_execute_statement: /* execute_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).exec_stmt)); }
+#line 2205 "bison_parser.cpp"
         break;
 
-    case 212: /* import_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).import_stmt)); }
-#line 2052 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_import_statement: /* import_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).import_stmt)); }
+#line 2211 "bison_parser.cpp"
         break;
 
-    case 213: /* file_type  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2058 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_file_type: /* file_type  */
+#line 181 "bison_parser.y"
+            { }
+#line 2217 "bison_parser.cpp"
         break;
 
-    case 214: /* file_path  */
-#line 194 "bison_parser.y" /* yacc.c:1257  */
-      { free(((*yyvaluep).sval)); }
-#line 2064 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_file_path: /* file_path  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2223 "bison_parser.cpp"
         break;
 
-    case 215: /* opt_import_export_options  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).import_export_option_t)); }
-#line 2070 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_import_export_options: /* opt_import_export_options  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).import_export_option_t)); }
+#line 2229 "bison_parser.cpp"
         break;
 
-    case 216: /* import_export_options  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).import_export_option_t)); }
-#line 2076 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_import_export_options: /* import_export_options  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).import_export_option_t)); }
+#line 2235 "bison_parser.cpp"
         break;
 
-    case 217: /* csv_option  */
-#line 203 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_csv_option: /* csv_option  */
+#line 203 "bison_parser.y"
+            {
   free(((*yyvaluep).csv_option_t)->second);
   delete (((*yyvaluep).csv_option_t));
 }
-#line 2085 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2244 "bison_parser.cpp"
         break;
 
-    case 218: /* export_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).export_stmt)); }
-#line 2091 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_export_statement: /* export_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).export_stmt)); }
+#line 2250 "bison_parser.cpp"
         break;
 
-    case 219: /* show_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).show_stmt)); }
-#line 2097 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_show_statement: /* show_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).show_stmt)); }
+#line 2256 "bison_parser.cpp"
         break;
 
-    case 220: /* create_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).create_stmt)); }
-#line 2103 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_create_statement: /* create_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).create_stmt)); }
+#line 2262 "bison_parser.cpp"
         break;
 
-    case 221: /* opt_not_exists  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2109 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_not_exists: /* opt_not_exists  */
+#line 181 "bison_parser.y"
+            { }
+#line 2268 "bison_parser.cpp"
         break;
 
-    case 222: /* table_elem_commalist  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_table_elem_commalist: /* table_elem_commalist  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).table_element_vec)) {
     for (auto ptr : *(((*yyvaluep).table_element_vec))) {
       delete ptr;
@@ -2118,120 +2277,120 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).table_element_vec));
 }
-#line 2122 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2281 "bison_parser.cpp"
         break;
 
-    case 223: /* table_elem  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table_element_t)); }
-#line 2128 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_elem: /* table_elem  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table_element_t)); }
+#line 2287 "bison_parser.cpp"
         break;
 
-    case 224: /* column_def  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).column_t)); }
-#line 2134 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_column_def: /* column_def  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).column_t)); }
+#line 2293 "bison_parser.cpp"
         break;
 
-    case 225: /* column_type  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2140 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_column_type: /* column_type  */
+#line 181 "bison_parser.y"
+            { }
+#line 2299 "bison_parser.cpp"
         break;
 
-    case 226: /* opt_time_precision  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2146 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_time_precision: /* opt_time_precision  */
+#line 181 "bison_parser.y"
+            { }
+#line 2305 "bison_parser.cpp"
         break;
 
-    case 227: /* opt_decimal_specification  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).ival_pair)); }
-#line 2152 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_decimal_specification: /* opt_decimal_specification  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).ival_pair)); }
+#line 2311 "bison_parser.cpp"
         break;
 
-    case 228: /* opt_column_constraints  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).column_constraints_t)); }
-#line 2158 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_column_constraints: /* opt_column_constraints  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).column_constraints_t)); }
+#line 2317 "bison_parser.cpp"
         break;
 
-    case 229: /* column_constraints  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).column_constraints_t)); }
-#line 2164 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_column_constraints: /* column_constraints  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).column_constraints_t)); }
+#line 2323 "bison_parser.cpp"
         break;
 
-    case 230: /* column_constraint  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2170 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_column_constraint: /* column_constraint  */
+#line 181 "bison_parser.y"
+            { }
+#line 2329 "bison_parser.cpp"
         break;
 
-    case 231: /* table_constraint  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table_constraint_t)); }
-#line 2176 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_constraint: /* table_constraint  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table_constraint_t)); }
+#line 2335 "bison_parser.cpp"
         break;
 
-    case 232: /* references_spec  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).references_spec_t)); }
-#line 2182 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_references_spec: /* references_spec  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).references_spec_t)); }
+#line 2341 "bison_parser.cpp"
         break;
 
-    case 233: /* drop_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).drop_stmt)); }
-#line 2188 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_drop_statement: /* drop_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).drop_stmt)); }
+#line 2347 "bison_parser.cpp"
         break;
 
-    case 234: /* opt_exists  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2194 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_exists: /* opt_exists  */
+#line 181 "bison_parser.y"
+            { }
+#line 2353 "bison_parser.cpp"
         break;
 
-    case 235: /* alter_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alter_stmt)); }
-#line 2200 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_alter_statement: /* alter_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alter_stmt)); }
+#line 2359 "bison_parser.cpp"
         break;
 
-    case 236: /* alter_action  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alter_action_t)); }
-#line 2206 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_alter_action: /* alter_action  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alter_action_t)); }
+#line 2365 "bison_parser.cpp"
         break;
 
-    case 237: /* drop_action  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).drop_action_t)); }
-#line 2212 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_drop_action: /* drop_action  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).drop_action_t)); }
+#line 2371 "bison_parser.cpp"
         break;
 
-    case 238: /* delete_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).delete_stmt)); }
-#line 2218 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_delete_statement: /* delete_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).delete_stmt)); }
+#line 2377 "bison_parser.cpp"
         break;
 
-    case 239: /* truncate_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).delete_stmt)); }
-#line 2224 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_truncate_statement: /* truncate_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).delete_stmt)); }
+#line 2383 "bison_parser.cpp"
         break;
 
-    case 240: /* insert_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).insert_stmt)); }
-#line 2230 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_insert_statement: /* insert_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).insert_stmt)); }
+#line 2389 "bison_parser.cpp"
         break;
 
-    case 241: /* opt_column_list  */
-#line 186 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_opt_column_list: /* opt_column_list  */
+#line 186 "bison_parser.y"
+            {
   if (((*yyvaluep).str_vec)) {
     for (auto ptr : *(((*yyvaluep).str_vec))) {
       free(ptr);
@@ -2239,18 +2398,18 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).str_vec));
 }
-#line 2243 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2402 "bison_parser.cpp"
         break;
 
-    case 242: /* update_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).update_stmt)); }
-#line 2249 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_update_statement: /* update_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).update_stmt)); }
+#line 2408 "bison_parser.cpp"
         break;
 
-    case 243: /* update_clause_commalist  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_update_clause_commalist: /* update_clause_commalist  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).update_vec)) {
     for (auto ptr : *(((*yyvaluep).update_vec))) {
       delete ptr;
@@ -2258,78 +2417,78 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).update_vec));
 }
-#line 2262 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2421 "bison_parser.cpp"
         break;
 
-    case 244: /* update_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).update_t)); }
-#line 2268 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_update_clause: /* update_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).update_t)); }
+#line 2427 "bison_parser.cpp"
         break;
 
-    case 245: /* select_statement  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2274 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_statement: /* select_statement  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2433 "bison_parser.cpp"
         break;
 
-    case 246: /* select_within_set_operation  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2280 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_within_set_operation: /* select_within_set_operation  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2439 "bison_parser.cpp"
         break;
 
-    case 247: /* select_within_set_operation_no_parentheses  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2286 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_within_set_operation_no_parentheses: /* select_within_set_operation_no_parentheses  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2445 "bison_parser.cpp"
         break;
 
-    case 248: /* select_with_paren  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2292 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_with_paren: /* select_with_paren  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2451 "bison_parser.cpp"
         break;
 
-    case 249: /* select_no_paren  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2298 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_no_paren: /* select_no_paren  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2457 "bison_parser.cpp"
         break;
 
-    case 250: /* set_operator  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).set_operator_t)); }
-#line 2304 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_set_operator: /* set_operator  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).set_operator_t)); }
+#line 2463 "bison_parser.cpp"
         break;
 
-    case 251: /* set_type  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).set_operator_t)); }
-#line 2310 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_set_type: /* set_type  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).set_operator_t)); }
+#line 2469 "bison_parser.cpp"
         break;
 
-    case 252: /* opt_all  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2316 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_all: /* opt_all  */
+#line 181 "bison_parser.y"
+            { }
+#line 2475 "bison_parser.cpp"
         break;
 
-    case 253: /* select_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).select_stmt)); }
-#line 2322 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_select_clause: /* select_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).select_stmt)); }
+#line 2481 "bison_parser.cpp"
         break;
 
-    case 254: /* opt_distinct  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2328 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_distinct: /* opt_distinct  */
+#line 181 "bison_parser.y"
+            { }
+#line 2487 "bison_parser.cpp"
         break;
 
-    case 255: /* select_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_select_list: /* select_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2337,42 +2496,42 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2341 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2500 "bison_parser.cpp"
         break;
 
-    case 256: /* opt_from_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2347 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_from_clause: /* opt_from_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2506 "bison_parser.cpp"
         break;
 
-    case 257: /* from_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2353 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_from_clause: /* from_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2512 "bison_parser.cpp"
         break;
 
-    case 258: /* opt_where  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2359 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_where: /* opt_where  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2518 "bison_parser.cpp"
         break;
 
-    case 259: /* opt_group  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).group_t)); }
-#line 2365 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_group: /* opt_group  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).group_t)); }
+#line 2524 "bison_parser.cpp"
         break;
 
-    case 260: /* opt_having  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2371 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_having: /* opt_having  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2530 "bison_parser.cpp"
         break;
 
-    case 261: /* opt_order  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_opt_order: /* opt_order  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).order_vec)) {
     for (auto ptr : *(((*yyvaluep).order_vec))) {
       delete ptr;
@@ -2380,12 +2539,12 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).order_vec));
 }
-#line 2384 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2543 "bison_parser.cpp"
         break;
 
-    case 262: /* order_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_order_list: /* order_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).order_vec)) {
     for (auto ptr : *(((*yyvaluep).order_vec))) {
       delete ptr;
@@ -2393,42 +2552,42 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).order_vec));
 }
-#line 2397 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2556 "bison_parser.cpp"
         break;
 
-    case 263: /* order_desc  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).order)); }
-#line 2403 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_order_desc: /* order_desc  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).order)); }
+#line 2562 "bison_parser.cpp"
         break;
 
-    case 264: /* opt_order_type  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2409 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_order_type: /* opt_order_type  */
+#line 181 "bison_parser.y"
+            { }
+#line 2568 "bison_parser.cpp"
         break;
 
-    case 265: /* opt_null_ordering  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2415 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_null_ordering: /* opt_null_ordering  */
+#line 181 "bison_parser.y"
+            { }
+#line 2574 "bison_parser.cpp"
         break;
 
-    case 266: /* opt_top  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).limit)); }
-#line 2421 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_top: /* opt_top  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).limit)); }
+#line 2580 "bison_parser.cpp"
         break;
 
-    case 267: /* opt_limit  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).limit)); }
-#line 2427 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_limit: /* opt_limit  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).limit)); }
+#line 2586 "bison_parser.cpp"
         break;
 
-    case 268: /* expr_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_expr_list: /* expr_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2436,12 +2595,12 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2440 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2599 "bison_parser.cpp"
         break;
 
-    case 269: /* opt_extended_literal_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_opt_extended_literal_list: /* opt_extended_literal_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2449,12 +2608,12 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2453 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2612 "bison_parser.cpp"
         break;
 
-    case 270: /* extended_literal_list  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_extended_literal_list: /* extended_literal_list  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2462,108 +2621,108 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2466 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2625 "bison_parser.cpp"
         break;
 
-    case 271: /* casted_extended_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2472 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_casted_extended_literal: /* casted_extended_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2631 "bison_parser.cpp"
         break;
 
-    case 272: /* extended_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2478 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_extended_literal: /* extended_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2637 "bison_parser.cpp"
         break;
 
-    case 273: /* expr_alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2484 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_expr_alias: /* expr_alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2643 "bison_parser.cpp"
         break;
 
-    case 274: /* expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2490 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_expr: /* expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2649 "bison_parser.cpp"
         break;
 
-    case 275: /* operand  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2496 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_operand: /* operand  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2655 "bison_parser.cpp"
         break;
 
-    case 276: /* scalar_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2502 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_scalar_expr: /* scalar_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2661 "bison_parser.cpp"
         break;
 
-    case 277: /* unary_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2508 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_unary_expr: /* unary_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2667 "bison_parser.cpp"
         break;
 
-    case 278: /* binary_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2514 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_binary_expr: /* binary_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2673 "bison_parser.cpp"
         break;
 
-    case 279: /* logic_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2520 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_logic_expr: /* logic_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2679 "bison_parser.cpp"
         break;
 
-    case 280: /* in_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2526 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_in_expr: /* in_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2685 "bison_parser.cpp"
         break;
 
-    case 281: /* case_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2532 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_case_expr: /* case_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2691 "bison_parser.cpp"
         break;
 
-    case 282: /* case_list  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2538 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_case_list: /* case_list  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2697 "bison_parser.cpp"
         break;
 
-    case 283: /* exists_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2544 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_exists_expr: /* exists_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2703 "bison_parser.cpp"
         break;
 
-    case 284: /* comp_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2550 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_comp_expr: /* comp_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2709 "bison_parser.cpp"
         break;
 
-    case 285: /* function_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2556 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_function_expr: /* function_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2715 "bison_parser.cpp"
         break;
 
-    case 286: /* opt_window  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).window_description)); }
-#line 2562 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_window: /* opt_window  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).window_description)); }
+#line 2721 "bison_parser.cpp"
         break;
 
-    case 287: /* opt_partition  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_opt_partition: /* opt_partition  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).expr_vec)) {
     for (auto ptr : *(((*yyvaluep).expr_vec))) {
       delete ptr;
@@ -2571,156 +2730,156 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).expr_vec));
 }
-#line 2575 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2734 "bison_parser.cpp"
         break;
 
-    case 288: /* opt_frame_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).frame_description)); }
-#line 2581 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_frame_clause: /* opt_frame_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).frame_description)); }
+#line 2740 "bison_parser.cpp"
         break;
 
-    case 289: /* frame_type  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2587 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_frame_type: /* frame_type  */
+#line 181 "bison_parser.y"
+            { }
+#line 2746 "bison_parser.cpp"
         break;
 
-    case 290: /* frame_bound  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).frame_bound)); }
-#line 2593 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_frame_bound: /* frame_bound  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).frame_bound)); }
+#line 2752 "bison_parser.cpp"
         break;
 
-    case 291: /* extract_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2599 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_extract_expr: /* extract_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2758 "bison_parser.cpp"
         break;
 
-    case 292: /* cast_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2605 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_cast_expr: /* cast_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2764 "bison_parser.cpp"
         break;
 
-    case 293: /* datetime_field  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2611 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_datetime_field: /* datetime_field  */
+#line 181 "bison_parser.y"
+            { }
+#line 2770 "bison_parser.cpp"
         break;
 
-    case 294: /* datetime_field_plural  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2617 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_datetime_field_plural: /* datetime_field_plural  */
+#line 181 "bison_parser.y"
+            { }
+#line 2776 "bison_parser.cpp"
         break;
 
-    case 295: /* duration_field  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2623 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_duration_field: /* duration_field  */
+#line 181 "bison_parser.y"
+            { }
+#line 2782 "bison_parser.cpp"
         break;
 
-    case 296: /* array_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2629 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_array_expr: /* array_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2788 "bison_parser.cpp"
         break;
 
-    case 297: /* array_index  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2635 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_array_index: /* array_index  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2794 "bison_parser.cpp"
         break;
 
-    case 298: /* between_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2641 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_between_expr: /* between_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2800 "bison_parser.cpp"
         break;
 
-    case 299: /* column_name  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2647 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_column_name: /* column_name  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2806 "bison_parser.cpp"
         break;
 
-    case 300: /* literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2653 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_literal: /* literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2812 "bison_parser.cpp"
         break;
 
-    case 301: /* string_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2659 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_string_literal: /* string_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2818 "bison_parser.cpp"
         break;
 
-    case 302: /* bool_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2665 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_bool_literal: /* bool_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2824 "bison_parser.cpp"
         break;
 
-    case 303: /* num_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2671 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_num_literal: /* num_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2830 "bison_parser.cpp"
         break;
 
-    case 304: /* int_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2677 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_int_literal: /* int_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2836 "bison_parser.cpp"
         break;
 
-    case 305: /* null_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2683 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_null_literal: /* null_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2842 "bison_parser.cpp"
         break;
 
-    case 306: /* date_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2689 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_date_literal: /* date_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2848 "bison_parser.cpp"
         break;
 
-    case 307: /* interval_literal  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2695 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_interval_literal: /* interval_literal  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2854 "bison_parser.cpp"
         break;
 
-    case 308: /* param_expr  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2701 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_param_expr: /* param_expr  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 2860 "bison_parser.cpp"
         break;
 
-    case 309: /* table_ref  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2707 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_ref: /* table_ref  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2866 "bison_parser.cpp"
         break;
 
-    case 310: /* table_ref_atomic  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2713 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_ref_atomic: /* table_ref_atomic  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2872 "bison_parser.cpp"
         break;
 
-    case 311: /* nonjoin_table_ref_atomic  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2719 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_nonjoin_table_ref_atomic: /* nonjoin_table_ref_atomic  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2878 "bison_parser.cpp"
         break;
 
-    case 312: /* table_ref_commalist  */
-#line 195 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_table_ref_commalist: /* table_ref_commalist  */
+#line 195 "bison_parser.y"
+            {
   if (((*yyvaluep).table_vec)) {
     for (auto ptr : *(((*yyvaluep).table_vec))) {
       delete ptr;
@@ -2728,135 +2887,135 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).table_vec));
 }
-#line 2732 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2891 "bison_parser.cpp"
         break;
 
-    case 313: /* table_ref_name  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2738 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_ref_name: /* table_ref_name  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2897 "bison_parser.cpp"
         break;
 
-    case 314: /* table_ref_name_no_alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2744 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_ref_name_no_alias: /* table_ref_name_no_alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 2903 "bison_parser.cpp"
         break;
 
-    case 315: /* table_name  */
-#line 182 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_table_name: /* table_name  */
+#line 182 "bison_parser.y"
+            {
   free(((*yyvaluep).table_name).name);
   free(((*yyvaluep).table_name).schema);
 }
-#line 2753 "bison_parser.cpp" /* yacc.c:1257  */
+#line 2912 "bison_parser.cpp"
         break;
 
-    case 316: /* opt_index_name  */
-#line 194 "bison_parser.y" /* yacc.c:1257  */
-      { free(((*yyvaluep).sval)); }
-#line 2759 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_index_name: /* opt_index_name  */
+#line 194 "bison_parser.y"
+            { free(((*yyvaluep).sval)); }
+#line 2918 "bison_parser.cpp"
         break;
 
-    case 317: /* table_alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alias_t)); }
-#line 2765 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_table_alias: /* table_alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alias_t)); }
+#line 2924 "bison_parser.cpp"
         break;
 
-    case 318: /* opt_table_alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alias_t)); }
-#line 2771 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_table_alias: /* opt_table_alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alias_t)); }
+#line 2930 "bison_parser.cpp"
         break;
 
-    case 319: /* alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alias_t)); }
-#line 2777 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_alias: /* alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alias_t)); }
+#line 2936 "bison_parser.cpp"
         break;
 
-    case 320: /* opt_alias  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).alias_t)); }
-#line 2783 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_alias: /* opt_alias  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).alias_t)); }
+#line 2942 "bison_parser.cpp"
         break;
 
-    case 321: /* opt_locking_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).locking_clause_vec)); }
-#line 2789 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_locking_clause: /* opt_locking_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).locking_clause_vec)); }
+#line 2948 "bison_parser.cpp"
         break;
 
-    case 322: /* opt_locking_clause_list  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).locking_clause_vec)); }
-#line 2795 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_locking_clause_list: /* opt_locking_clause_list  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).locking_clause_vec)); }
+#line 2954 "bison_parser.cpp"
         break;
 
-    case 323: /* locking_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).locking_t)); }
-#line 2801 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_locking_clause: /* locking_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).locking_t)); }
+#line 2960 "bison_parser.cpp"
         break;
 
-    case 324: /* row_lock_mode  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2807 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_row_lock_mode: /* row_lock_mode  */
+#line 181 "bison_parser.y"
+            { }
+#line 2966 "bison_parser.cpp"
         break;
 
-    case 325: /* opt_row_lock_policy  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2813 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_row_lock_policy: /* opt_row_lock_policy  */
+#line 181 "bison_parser.y"
+            { }
+#line 2972 "bison_parser.cpp"
         break;
 
-    case 326: /* opt_with_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).with_description_vec)); }
-#line 2819 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_with_clause: /* opt_with_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).with_description_vec)); }
+#line 2978 "bison_parser.cpp"
         break;
 
-    case 327: /* with_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).with_description_vec)); }
-#line 2825 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_with_clause: /* with_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).with_description_vec)); }
+#line 2984 "bison_parser.cpp"
         break;
 
-    case 328: /* with_description_list  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).with_description_vec)); }
-#line 2831 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_with_description_list: /* with_description_list  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).with_description_vec)); }
+#line 2990 "bison_parser.cpp"
         break;
 
-    case 329: /* with_description  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).with_description_t)); }
-#line 2837 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_with_description: /* with_description  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).with_description_t)); }
+#line 2996 "bison_parser.cpp"
         break;
 
-    case 330: /* join_clause  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).table)); }
-#line 2843 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_join_clause: /* join_clause  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).table)); }
+#line 3002 "bison_parser.cpp"
         break;
 
-    case 331: /* opt_join_type  */
-#line 181 "bison_parser.y" /* yacc.c:1257  */
-      { }
-#line 2849 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_opt_join_type: /* opt_join_type  */
+#line 181 "bison_parser.y"
+            { }
+#line 3008 "bison_parser.cpp"
         break;
 
-    case 332: /* join_condition  */
-#line 207 "bison_parser.y" /* yacc.c:1257  */
-      { delete (((*yyvaluep).expr)); }
-#line 2855 "bison_parser.cpp" /* yacc.c:1257  */
+    case YYSYMBOL_join_condition: /* join_condition  */
+#line 207 "bison_parser.y"
+            { delete (((*yyvaluep).expr)); }
+#line 3014 "bison_parser.cpp"
         break;
 
-    case 334: /* ident_commalist  */
-#line 186 "bison_parser.y" /* yacc.c:1257  */
-      {
+    case YYSYMBOL_ident_commalist: /* ident_commalist  */
+#line 186 "bison_parser.y"
+            {
   if (((*yyvaluep).str_vec)) {
     for (auto ptr : *(((*yyvaluep).str_vec))) {
       free(ptr);
@@ -2864,15 +3023,16 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   }
   delete (((*yyvaluep).str_vec));
 }
-#line 2868 "bison_parser.cpp" /* yacc.c:1257  */
+#line 3027 "bison_parser.cpp"
         break;
-
 
       default:
         break;
     }
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
+
+
 
 
 
@@ -2884,7 +3044,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
 int
 yyparse (hsql::SQLParserResult* result, yyscan_t scanner)
 {
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
 
@@ -2903,55 +3063,50 @@ static YYLTYPE yyloc_default
 YYLTYPE yylloc = yyloc_default;
 
     /* Number of syntax errors so far.  */
-    int yynerrs;
+    int yynerrs = 0;
 
-    int yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-       'yyls': related to locations.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
-    yytype_int16 yyssa[YYINITDEPTH];
-    yytype_int16 *yyss;
-    yytype_int16 *yyssp;
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
 
-    /* The semantic value stack.  */
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
+
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
-    /* The location stack.  */
+    /* The location stack: array, bottom, top.  */
     YYLTYPE yylsa[YYINITDEPTH];
-    YYLTYPE *yyls;
-    YYLTYPE *yylsp;
-
-    /* The locations where the error started and ended.  */
-    YYLTYPE yyerror_range[3];
-
-    YYSIZE_T yystacksize;
+    YYLTYPE *yyls = yylsa;
+    YYLTYPE *yylsp = yyls;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
   YYLTYPE yyloc;
 
-#if YYERROR_VERBOSE
+  /* The locations where the error started and ended.  */
+  YYLTYPE yyerror_range[3];
+
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N), yylsp -= (N))
 
@@ -2959,20 +3114,13 @@ YYLTYPE yylloc = yyloc_default;
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yylsp = yyls = yylsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
-  yychar = YYEMPTY; /* Cause a token to be read.  */
+  yychar = SQL_HSQL_EMPTY; /* Cause a token to be read.  */
+
 
 /* User initialization code.  */
-#line 81 "bison_parser.y" /* yacc.c:1429  */
+#line 81 "bison_parser.y"
 {
   // Initialize
   yylloc.first_column = 0;
@@ -2983,33 +3131,47 @@ YYLTYPE yylloc = yyloc_default;
   yylloc.string_length = 0;
 }
 
-#line 2987 "bison_parser.cpp" /* yacc.c:1429  */
+#line 3135 "bison_parser.cpp"
+
   yylsp[0] = yylloc;
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    YYNOMEM;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
         /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
            memory.  */
+        yy_state_t *yyss1 = yyss;
         YYSTYPE *yyvs1 = yyvs;
-        yytype_int16 *yyss1 = yyss;
         YYLTYPE *yyls1 = yyls;
 
         /* Each stack pointer address is followed by the size of the
@@ -3017,32 +3179,29 @@ YYLTYPE yylloc = yyloc_default;
            conditional around just the two extra args, but that might
            be undefined if yyoverflow is a macro.  */
         yyoverflow (YY_("memory exhausted"),
-                    &yyss1, yysize * sizeof (*yyssp),
-                    &yyvs1, yysize * sizeof (*yyvsp),
-                    &yyls1, yysize * sizeof (*yylsp),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
+                    &yyls1, yysize * YYSIZEOF (*yylsp),
                     &yystacksize);
-
-        yyls = yyls1;
         yyss = yyss1;
         yyvs = yyvs1;
+        yyls = yyls1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
         yystacksize = YYMAXDEPTH;
 
       {
-        yytype_int16 *yyss1 = yyss;
+        yy_state_t *yyss1 = yyss;
         union yyalloc *yyptr =
-          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
-          goto yyexhaustedlab;
+          YYNOMEM;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
         YYSTACK_RELOCATE (yyls_alloc, yyls);
@@ -3051,31 +3210,32 @@ YYLTYPE yylloc = yyloc_default;
           YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
       yylsp = yyls + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
 
   if (yystate == YYFINAL)
     YYACCEPT;
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -3086,17 +3246,29 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
-  if (yychar == YYEMPTY)
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
+  if (yychar == SQL_HSQL_EMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
+      YYDPRINTF ((stderr, "Reading a token\n"));
       yychar = yylex (&yylval, &yylloc, scanner);
     }
 
-  if (yychar <= YYEOF)
+  if (yychar <= SQL_YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = SQL_YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == SQL_HSQL_error)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = SQL_HSQL_UNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      yyerror_range[1] = yylloc;
+      goto yyerrlab1;
     }
   else
     {
@@ -3125,15 +3297,14 @@ yybackup:
 
   /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-
-  /* Discard the shifted token.  */
-  yychar = YYEMPTY;
-
   yystate = yyn;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
   YY_IGNORE_MAYBE_UNINITIALIZED_END
   *++yylsp = yylloc;
+
+  /* Discard the shifted token.  */
+  yychar = SQL_HSQL_EMPTY;
   goto yynewstate;
 
 
@@ -3148,7 +3319,7 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
@@ -3164,14 +3335,15 @@ yyreduce:
      GCC warning that YYVAL may be used uninitialized.  */
   yyval = yyvsp[1-yylen];
 
-  /* Default location.  */
+  /* Default location. */
   YYLLOC_DEFAULT (yyloc, (yylsp - yylen), yylen);
+  yyerror_range[1] = yyloc;
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 2:
-#line 343 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 2: /* input: statement_list opt_semicolon  */
+#line 343 "bison_parser.y"
+                                     {
   for (SQLStatement* stmt : *(yyvsp[-1].stmt_vec)) {
     // Transfers ownership of the statement.
     result->addStatement(stmt);
@@ -3188,237 +3360,237 @@ yyreduce:
   }
     delete (yyvsp[-1].stmt_vec);
   }
-#line 3192 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3364 "bison_parser.cpp"
     break;
 
-  case 3:
-#line 362 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 3: /* statement_list: statement  */
+#line 362 "bison_parser.y"
+                           {
   (yyvsp[0].statement)->stringLength = yylloc.string_length;
   yylloc.string_length = 0;
   (yyval.stmt_vec) = new std::vector<SQLStatement*>();
   (yyval.stmt_vec)->push_back((yyvsp[0].statement));
 }
-#line 3203 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3375 "bison_parser.cpp"
     break;
 
-  case 4:
-#line 368 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 4: /* statement_list: statement_list ';' statement  */
+#line 368 "bison_parser.y"
+                               {
   (yyvsp[0].statement)->stringLength = yylloc.string_length;
   yylloc.string_length = 0;
   (yyvsp[-2].stmt_vec)->push_back((yyvsp[0].statement));
   (yyval.stmt_vec) = (yyvsp[-2].stmt_vec);
 }
-#line 3214 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3386 "bison_parser.cpp"
     break;
 
-  case 5:
-#line 375 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 5: /* statement: prepare_statement opt_hints  */
+#line 375 "bison_parser.y"
+                                        {
   (yyval.statement) = (yyvsp[-1].prep_stmt);
   (yyval.statement)->hints = (yyvsp[0].expr_vec);
 }
-#line 3223 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3395 "bison_parser.cpp"
     break;
 
-  case 6:
-#line 379 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 6: /* statement: preparable_statement opt_hints  */
+#line 379 "bison_parser.y"
+                                 {
   (yyval.statement) = (yyvsp[-1].statement);
   (yyval.statement)->hints = (yyvsp[0].expr_vec);
 }
-#line 3232 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3404 "bison_parser.cpp"
     break;
 
-  case 7:
-#line 383 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].show_stmt); }
-#line 3238 "bison_parser.cpp" /* yacc.c:1646  */
+  case 7: /* statement: show_statement  */
+#line 383 "bison_parser.y"
+                 { (yyval.statement) = (yyvsp[0].show_stmt); }
+#line 3410 "bison_parser.cpp"
     break;
 
-  case 8:
-#line 384 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].import_stmt); }
-#line 3244 "bison_parser.cpp" /* yacc.c:1646  */
+  case 8: /* statement: import_statement  */
+#line 384 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].import_stmt); }
+#line 3416 "bison_parser.cpp"
     break;
 
-  case 9:
-#line 385 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].export_stmt); }
-#line 3250 "bison_parser.cpp" /* yacc.c:1646  */
+  case 9: /* statement: export_statement  */
+#line 385 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].export_stmt); }
+#line 3422 "bison_parser.cpp"
     break;
 
-  case 10:
-#line 387 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].select_stmt); }
-#line 3256 "bison_parser.cpp" /* yacc.c:1646  */
+  case 10: /* preparable_statement: select_statement  */
+#line 387 "bison_parser.y"
+                                        { (yyval.statement) = (yyvsp[0].select_stmt); }
+#line 3428 "bison_parser.cpp"
     break;
 
-  case 11:
-#line 388 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].create_stmt); }
-#line 3262 "bison_parser.cpp" /* yacc.c:1646  */
+  case 11: /* preparable_statement: create_statement  */
+#line 388 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].create_stmt); }
+#line 3434 "bison_parser.cpp"
     break;
 
-  case 12:
-#line 389 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].insert_stmt); }
-#line 3268 "bison_parser.cpp" /* yacc.c:1646  */
+  case 12: /* preparable_statement: insert_statement  */
+#line 389 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].insert_stmt); }
+#line 3440 "bison_parser.cpp"
     break;
 
-  case 13:
-#line 390 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 3274 "bison_parser.cpp" /* yacc.c:1646  */
+  case 13: /* preparable_statement: delete_statement  */
+#line 390 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].delete_stmt); }
+#line 3446 "bison_parser.cpp"
     break;
 
-  case 14:
-#line 391 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].delete_stmt); }
-#line 3280 "bison_parser.cpp" /* yacc.c:1646  */
+  case 14: /* preparable_statement: truncate_statement  */
+#line 391 "bison_parser.y"
+                     { (yyval.statement) = (yyvsp[0].delete_stmt); }
+#line 3452 "bison_parser.cpp"
     break;
 
-  case 15:
-#line 392 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].update_stmt); }
-#line 3286 "bison_parser.cpp" /* yacc.c:1646  */
+  case 15: /* preparable_statement: update_statement  */
+#line 392 "bison_parser.y"
+                   { (yyval.statement) = (yyvsp[0].update_stmt); }
+#line 3458 "bison_parser.cpp"
     break;
 
-  case 16:
-#line 393 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].drop_stmt); }
-#line 3292 "bison_parser.cpp" /* yacc.c:1646  */
+  case 16: /* preparable_statement: drop_statement  */
+#line 393 "bison_parser.y"
+                 { (yyval.statement) = (yyvsp[0].drop_stmt); }
+#line 3464 "bison_parser.cpp"
     break;
 
-  case 17:
-#line 394 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].alter_stmt); }
-#line 3298 "bison_parser.cpp" /* yacc.c:1646  */
+  case 17: /* preparable_statement: alter_statement  */
+#line 394 "bison_parser.y"
+                  { (yyval.statement) = (yyvsp[0].alter_stmt); }
+#line 3470 "bison_parser.cpp"
     break;
 
-  case 18:
-#line 395 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].exec_stmt); }
-#line 3304 "bison_parser.cpp" /* yacc.c:1646  */
+  case 18: /* preparable_statement: execute_statement  */
+#line 395 "bison_parser.y"
+                    { (yyval.statement) = (yyvsp[0].exec_stmt); }
+#line 3476 "bison_parser.cpp"
     break;
 
-  case 19:
-#line 396 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.statement) = (yyvsp[0].transaction_stmt); }
-#line 3310 "bison_parser.cpp" /* yacc.c:1646  */
+  case 19: /* preparable_statement: transaction_statement  */
+#line 396 "bison_parser.y"
+                        { (yyval.statement) = (yyvsp[0].transaction_stmt); }
+#line 3482 "bison_parser.cpp"
     break;
 
-  case 20:
-#line 402 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = (yyvsp[-1].expr_vec); }
-#line 3316 "bison_parser.cpp" /* yacc.c:1646  */
+  case 20: /* opt_hints: WITH HINT '(' hint_list ')'  */
+#line 402 "bison_parser.y"
+                                        { (yyval.expr_vec) = (yyvsp[-1].expr_vec); }
+#line 3488 "bison_parser.cpp"
     break;
 
-  case 21:
-#line 403 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = nullptr; }
-#line 3322 "bison_parser.cpp" /* yacc.c:1646  */
+  case 21: /* opt_hints: %empty  */
+#line 403 "bison_parser.y"
+              { (yyval.expr_vec) = nullptr; }
+#line 3494 "bison_parser.cpp"
     break;
 
-  case 22:
-#line 405 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 22: /* hint_list: hint  */
+#line 405 "bison_parser.y"
+                 {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 3331 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3503 "bison_parser.cpp"
     break;
 
-  case 23:
-#line 409 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 23: /* hint_list: hint_list ',' hint  */
+#line 409 "bison_parser.y"
+                     {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 3340 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3512 "bison_parser.cpp"
     break;
 
-  case 24:
-#line 414 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 24: /* hint: IDENTIFIER  */
+#line 414 "bison_parser.y"
+                  {
   (yyval.expr) = Expr::make(kExprHint);
   (yyval.expr)->name = (yyvsp[0].sval);
 }
-#line 3349 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3521 "bison_parser.cpp"
     break;
 
-  case 25:
-#line 418 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 25: /* hint: IDENTIFIER '(' extended_literal_list ')'  */
+#line 418 "bison_parser.y"
+                                           {
   (yyval.expr) = Expr::make(kExprHint);
   (yyval.expr)->name = (yyvsp[-3].sval);
   (yyval.expr)->exprList = (yyvsp[-1].expr_vec);
 }
-#line 3359 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3531 "bison_parser.cpp"
     break;
 
-  case 26:
-#line 428 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.transaction_stmt) = new TransactionStatement(kBeginTransaction); }
-#line 3365 "bison_parser.cpp" /* yacc.c:1646  */
+  case 26: /* transaction_statement: BEGIN opt_transaction_keyword  */
+#line 428 "bison_parser.y"
+                                                      { (yyval.transaction_stmt) = new TransactionStatement(kBeginTransaction); }
+#line 3537 "bison_parser.cpp"
     break;
 
-  case 27:
-#line 429 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.transaction_stmt) = new TransactionStatement(kRollbackTransaction); }
-#line 3371 "bison_parser.cpp" /* yacc.c:1646  */
+  case 27: /* transaction_statement: ROLLBACK opt_transaction_keyword  */
+#line 429 "bison_parser.y"
+                                   { (yyval.transaction_stmt) = new TransactionStatement(kRollbackTransaction); }
+#line 3543 "bison_parser.cpp"
     break;
 
-  case 28:
-#line 430 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.transaction_stmt) = new TransactionStatement(kCommitTransaction); }
-#line 3377 "bison_parser.cpp" /* yacc.c:1646  */
+  case 28: /* transaction_statement: COMMIT opt_transaction_keyword  */
+#line 430 "bison_parser.y"
+                                 { (yyval.transaction_stmt) = new TransactionStatement(kCommitTransaction); }
+#line 3549 "bison_parser.cpp"
     break;
 
-  case 31:
-#line 438 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 31: /* prepare_statement: PREPARE IDENTIFIER FROM prepare_target_query  */
+#line 438 "bison_parser.y"
+                                                                 {
   (yyval.prep_stmt) = new PrepareStatement();
   (yyval.prep_stmt)->name = (yyvsp[-2].sval);
   (yyval.prep_stmt)->query = (yyvsp[0].sval);
 }
-#line 3387 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3559 "bison_parser.cpp"
     break;
 
-  case 33:
-#line 446 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 33: /* execute_statement: EXECUTE IDENTIFIER  */
+#line 446 "bison_parser.y"
+                                       {
   (yyval.exec_stmt) = new ExecuteStatement();
   (yyval.exec_stmt)->name = (yyvsp[0].sval);
 }
-#line 3396 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3568 "bison_parser.cpp"
     break;
 
-  case 34:
-#line 450 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 34: /* execute_statement: EXECUTE IDENTIFIER '(' opt_extended_literal_list ')'  */
+#line 450 "bison_parser.y"
+                                                       {
   (yyval.exec_stmt) = new ExecuteStatement();
   (yyval.exec_stmt)->name = (yyvsp[-3].sval);
   (yyval.exec_stmt)->parameters = (yyvsp[-1].expr_vec);
 }
-#line 3406 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3578 "bison_parser.cpp"
     break;
 
-  case 35:
-#line 462 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 35: /* import_statement: IMPORT FROM file_type FILE file_path INTO table_name  */
+#line 462 "bison_parser.y"
+                                                                        {
   (yyval.import_stmt) = new ImportStatement((yyvsp[-4].import_type_t));
   (yyval.import_stmt)->filePath = (yyvsp[-2].sval);
   (yyval.import_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.import_stmt)->tableName = (yyvsp[0].table_name).name;
 }
-#line 3417 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3589 "bison_parser.cpp"
     break;
 
-  case 36:
-#line 468 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 36: /* import_statement: COPY table_name FROM file_path opt_import_export_options opt_where  */
+#line 468 "bison_parser.y"
+                                                                     {
   (yyval.import_stmt) = new ImportStatement((yyvsp[-1].import_export_option_t)->format);
   (yyval.import_stmt)->filePath = (yyvsp[-2].sval);
   (yyval.import_stmt)->schema = (yyvsp[-4].table_name).schema;
@@ -3434,12 +3606,12 @@ yyreduce:
   }
   delete (yyvsp[-1].import_export_option_t);
 }
-#line 3438 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3610 "bison_parser.cpp"
     break;
 
-  case 37:
-#line 485 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 37: /* file_type: IDENTIFIER  */
+#line 485 "bison_parser.y"
+                       {
   if (strcasecmp((yyvsp[0].sval), "csv") == 0) {
     (yyval.import_type_t) = kImportCSV;
   } else if (strcasecmp((yyvsp[0].sval), "tbl") == 0) {
@@ -3453,36 +3625,36 @@ yyreduce:
   }
   free((yyvsp[0].sval));
 }
-#line 3457 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3629 "bison_parser.cpp"
     break;
 
-  case 38:
-#line 500 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.sval) = (yyvsp[0].sval); }
-#line 3463 "bison_parser.cpp" /* yacc.c:1646  */
+  case 38: /* file_path: STRING  */
+#line 500 "bison_parser.y"
+                   { (yyval.sval) = (yyvsp[0].sval); }
+#line 3635 "bison_parser.cpp"
     break;
 
-  case 39:
-#line 502 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
-#line 3469 "bison_parser.cpp" /* yacc.c:1646  */
+  case 39: /* opt_import_export_options: WITH '(' import_export_options ')'  */
+#line 502 "bison_parser.y"
+                                                               { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
+#line 3641 "bison_parser.cpp"
     break;
 
-  case 40:
-#line 503 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
-#line 3475 "bison_parser.cpp" /* yacc.c:1646  */
+  case 40: /* opt_import_export_options: '(' import_export_options ')'  */
+#line 503 "bison_parser.y"
+                                { (yyval.import_export_option_t) = (yyvsp[-1].import_export_option_t); }
+#line 3647 "bison_parser.cpp"
     break;
 
-  case 41:
-#line 504 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.import_export_option_t) = new ImportExportOptions{}; }
-#line 3481 "bison_parser.cpp" /* yacc.c:1646  */
+  case 41: /* opt_import_export_options: %empty  */
+#line 504 "bison_parser.y"
+              { (yyval.import_export_option_t) = new ImportExportOptions{}; }
+#line 3653 "bison_parser.cpp"
     break;
 
-  case 42:
-#line 506 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 42: /* import_export_options: import_export_options ',' FORMAT file_type  */
+#line 506 "bison_parser.y"
+                                                                   {
   if ((yyvsp[-3].import_export_option_t)->format != kImportAuto) {
     delete (yyvsp[-3].import_export_option_t);
     yyerror(&yyloc, result, scanner, "File type must only be provided once.");
@@ -3496,21 +3668,21 @@ yyreduce:
   (yyvsp[-3].import_export_option_t)->format = (yyvsp[0].import_type_t);
   (yyval.import_export_option_t) = (yyvsp[-3].import_export_option_t);
 }
-#line 3500 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3672 "bison_parser.cpp"
     break;
 
-  case 43:
-#line 520 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 43: /* import_export_options: FORMAT file_type  */
+#line 520 "bison_parser.y"
+                   {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->format = (yyvsp[0].import_type_t);
 }
-#line 3509 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3681 "bison_parser.cpp"
     break;
 
-  case 44:
-#line 524 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 44: /* import_export_options: import_export_options ',' ENCODING STRING  */
+#line 524 "bison_parser.y"
+                                            {
   if ((yyvsp[-3].import_export_option_t)->encoding) {
     delete (yyvsp[-3].import_export_option_t);
     free((yyvsp[0].sval));
@@ -3520,21 +3692,21 @@ yyreduce:
   (yyvsp[-3].import_export_option_t)->encoding = (yyvsp[0].sval);
   (yyval.import_export_option_t) = (yyvsp[-3].import_export_option_t);
 }
-#line 3524 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3696 "bison_parser.cpp"
     break;
 
-  case 45:
-#line 534 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 45: /* import_export_options: ENCODING STRING  */
+#line 534 "bison_parser.y"
+                  {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->encoding = (yyvsp[0].sval);
 }
-#line 3533 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3705 "bison_parser.cpp"
     break;
 
-  case 46:
-#line 538 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 46: /* import_export_options: import_export_options ',' csv_option  */
+#line 538 "bison_parser.y"
+                                       {
   if ((yyvsp[-2].import_export_option_t)->format != kImportAuto && (yyvsp[-2].import_export_option_t)->format != kImportCSV) {
     delete (yyvsp[-2].import_export_option_t);
     free((yyvsp[0].csv_option_t)->second);
@@ -3558,24 +3730,24 @@ yyreduce:
   delete (yyvsp[0].csv_option_t);
   (yyval.import_export_option_t) = (yyvsp[-2].import_export_option_t);
 }
-#line 3562 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3734 "bison_parser.cpp"
     break;
 
-  case 47:
-#line 562 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 47: /* import_export_options: csv_option  */
+#line 562 "bison_parser.y"
+             {
   (yyval.import_export_option_t) = new ImportExportOptions{};
   (yyval.import_export_option_t)->csv_options = new CsvOptions{};
   (yyval.import_export_option_t)->csv_options->accept_csv_option((yyvsp[0].csv_option_t));
 
   delete (yyvsp[0].csv_option_t);
 }
-#line 3574 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3746 "bison_parser.cpp"
     break;
 
-  case 48:
-#line 570 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 48: /* csv_option: IDENTIFIER STRING  */
+#line 570 "bison_parser.y"
+                               {
   if (strcasecmp((yyvsp[-1].sval), "DELIMITER") == 0) {
     (yyval.csv_option_t) = new std::pair<CsvOptionType, char*>(CsvOptionType::Delimiter, (yyvsp[0].sval));
   } else if (strcasecmp((yyvsp[-1].sval), "QUOTE") == 0) {
@@ -3588,18 +3760,18 @@ yyreduce:
   }
   free((yyvsp[-1].sval));
 }
-#line 3592 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3764 "bison_parser.cpp"
     break;
 
-  case 49:
-#line 583 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.csv_option_t) = new std::pair<CsvOptionType, char*>(CsvOptionType::Null, (yyvsp[0].sval)); }
-#line 3598 "bison_parser.cpp" /* yacc.c:1646  */
+  case 49: /* csv_option: NULL STRING  */
+#line 583 "bison_parser.y"
+              { (yyval.csv_option_t) = new std::pair<CsvOptionType, char*>(CsvOptionType::Null, (yyvsp[0].sval)); }
+#line 3770 "bison_parser.cpp"
     break;
 
-  case 50:
-#line 590 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 50: /* export_statement: COPY table_name TO file_path opt_import_export_options  */
+#line 590 "bison_parser.y"
+                                                                          {
   (yyval.export_stmt) = new ExportStatement((yyvsp[0].import_export_option_t)->format);
   (yyval.export_stmt)->filePath = (yyvsp[-1].sval);
   (yyval.export_stmt)->schema = (yyvsp[-3].table_name).schema;
@@ -3614,12 +3786,12 @@ yyreduce:
   }
   delete (yyvsp[0].import_export_option_t);
 }
-#line 3618 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3790 "bison_parser.cpp"
     break;
 
-  case 51:
-#line 605 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 51: /* export_statement: COPY select_with_paren TO file_path opt_import_export_options  */
+#line 605 "bison_parser.y"
+                                                                {
   (yyval.export_stmt) = new ExportStatement((yyvsp[0].import_export_option_t)->format);
   (yyval.export_stmt)->filePath = (yyvsp[-1].sval);
   (yyval.export_stmt)->select = (yyvsp[-3].select_stmt);
@@ -3633,38 +3805,38 @@ yyreduce:
   }
   delete (yyvsp[0].import_export_option_t);
 }
-#line 3637 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3809 "bison_parser.cpp"
     break;
 
-  case 52:
-#line 625 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.show_stmt) = new ShowStatement(kShowTables); }
-#line 3643 "bison_parser.cpp" /* yacc.c:1646  */
+  case 52: /* show_statement: SHOW TABLES  */
+#line 625 "bison_parser.y"
+                             { (yyval.show_stmt) = new ShowStatement(kShowTables); }
+#line 3815 "bison_parser.cpp"
     break;
 
-  case 53:
-#line 626 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 53: /* show_statement: SHOW COLUMNS table_name  */
+#line 626 "bison_parser.y"
+                          {
   (yyval.show_stmt) = new ShowStatement(kShowColumns);
   (yyval.show_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.show_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 3653 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3825 "bison_parser.cpp"
     break;
 
-  case 54:
-#line 631 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 54: /* show_statement: DESCRIBE table_name  */
+#line 631 "bison_parser.y"
+                      {
   (yyval.show_stmt) = new ShowStatement(kShowColumns);
   (yyval.show_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.show_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 3663 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3835 "bison_parser.cpp"
     break;
 
-  case 55:
-#line 642 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 55: /* create_statement: CREATE TABLE opt_not_exists table_name FROM IDENTIFIER FILE file_path  */
+#line 642 "bison_parser.y"
+                                                                                         {
   (yyval.create_stmt) = new CreateStatement(kCreateTableFromTbl);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-5].bval);
   (yyval.create_stmt)->schema = (yyvsp[-4].table_name).schema;
@@ -3677,12 +3849,12 @@ yyreduce:
   free((yyvsp[-2].sval));
   (yyval.create_stmt)->filePath = (yyvsp[0].sval);
 }
-#line 3681 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3853 "bison_parser.cpp"
     break;
 
-  case 56:
-#line 655 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 56: /* create_statement: CREATE TABLE opt_not_exists table_name '(' table_elem_commalist ')'  */
+#line 655 "bison_parser.y"
+                                                                      {
   (yyval.create_stmt) = new CreateStatement(kCreateTable);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
   (yyval.create_stmt)->schema = (yyvsp[-3].table_name).schema;
@@ -3694,36 +3866,36 @@ yyreduce:
     YYERROR;
   }
 }
-#line 3698 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3870 "bison_parser.cpp"
     break;
 
-  case 57:
-#line 667 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 57: /* create_statement: CREATE TABLE opt_not_exists table_name AS select_statement  */
+#line 667 "bison_parser.y"
+                                                             {
   (yyval.create_stmt) = new CreateStatement(kCreateTable);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-3].bval);
   (yyval.create_stmt)->schema = (yyvsp[-2].table_name).schema;
   (yyval.create_stmt)->tableName = (yyvsp[-2].table_name).name;
   (yyval.create_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 3710 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3882 "bison_parser.cpp"
     break;
 
-  case 58:
-#line 674 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 58: /* create_statement: CREATE INDEX opt_not_exists opt_index_name ON table_name '(' ident_commalist ')'  */
+#line 674 "bison_parser.y"
+                                                                                   {
   (yyval.create_stmt) = new CreateStatement(kCreateIndex);
   (yyval.create_stmt)->indexName = (yyvsp[-5].sval);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-6].bval);
   (yyval.create_stmt)->tableName = (yyvsp[-3].table_name).name;
   (yyval.create_stmt)->indexColumns = (yyvsp[-1].str_vec);
 }
-#line 3722 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3894 "bison_parser.cpp"
     break;
 
-  case 59:
-#line 681 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 59: /* create_statement: CREATE VIEW opt_not_exists table_name opt_column_list AS select_statement  */
+#line 681 "bison_parser.y"
+                                                                            {
   (yyval.create_stmt) = new CreateStatement(kCreateView);
   (yyval.create_stmt)->ifNotExists = (yyvsp[-4].bval);
   (yyval.create_stmt)->schema = (yyvsp[-3].table_name).schema;
@@ -3731,500 +3903,500 @@ yyreduce:
   (yyval.create_stmt)->viewColumns = (yyvsp[-2].str_vec);
   (yyval.create_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 3735 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3907 "bison_parser.cpp"
     break;
 
-  case 60:
-#line 690 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = true; }
-#line 3741 "bison_parser.cpp" /* yacc.c:1646  */
+  case 60: /* opt_not_exists: IF NOT EXISTS  */
+#line 690 "bison_parser.y"
+                               { (yyval.bval) = true; }
+#line 3913 "bison_parser.cpp"
     break;
 
-  case 61:
-#line 691 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = false; }
-#line 3747 "bison_parser.cpp" /* yacc.c:1646  */
+  case 61: /* opt_not_exists: %empty  */
+#line 691 "bison_parser.y"
+              { (yyval.bval) = false; }
+#line 3919 "bison_parser.cpp"
     break;
 
-  case 62:
-#line 693 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 62: /* table_elem_commalist: table_elem  */
+#line 693 "bison_parser.y"
+                                  {
   (yyval.table_element_vec) = new std::vector<TableElement*>();
   (yyval.table_element_vec)->push_back((yyvsp[0].table_element_t));
 }
-#line 3756 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3928 "bison_parser.cpp"
     break;
 
-  case 63:
-#line 697 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 63: /* table_elem_commalist: table_elem_commalist ',' table_elem  */
+#line 697 "bison_parser.y"
+                                      {
   (yyvsp[-2].table_element_vec)->push_back((yyvsp[0].table_element_t));
   (yyval.table_element_vec) = (yyvsp[-2].table_element_vec);
 }
-#line 3765 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3937 "bison_parser.cpp"
     break;
 
-  case 64:
-#line 702 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table_element_t) = (yyvsp[0].column_t); }
-#line 3771 "bison_parser.cpp" /* yacc.c:1646  */
+  case 64: /* table_elem: column_def  */
+#line 702 "bison_parser.y"
+                        { (yyval.table_element_t) = (yyvsp[0].column_t); }
+#line 3943 "bison_parser.cpp"
     break;
 
-  case 65:
-#line 703 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table_element_t) = (yyvsp[0].table_constraint_t); }
-#line 3777 "bison_parser.cpp" /* yacc.c:1646  */
+  case 65: /* table_elem: table_constraint  */
+#line 703 "bison_parser.y"
+                   { (yyval.table_element_t) = (yyvsp[0].table_constraint_t); }
+#line 3949 "bison_parser.cpp"
     break;
 
-  case 66:
-#line 705 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 66: /* column_def: IDENTIFIER column_type opt_column_constraints  */
+#line 705 "bison_parser.y"
+                                                           {
   (yyval.column_t) = new ColumnDefinition((yyvsp[-2].sval), (yyvsp[-1].column_type_t), (yyvsp[0].column_constraints_t)->constraints, (yyvsp[0].column_constraints_t)->references);
   if (!(yyval.column_t)->trySetNullableExplicit()) {
     yyerror(&yyloc, result, scanner, ("Conflicting nullability constraints for " + std::string{(yyvsp[-2].sval)}).c_str());
   }
   delete (yyvsp[0].column_constraints_t);
 }
-#line 3789 "bison_parser.cpp" /* yacc.c:1646  */
+#line 3961 "bison_parser.cpp"
     break;
 
-  case 67:
-#line 713 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::BIGINT}; }
-#line 3795 "bison_parser.cpp" /* yacc.c:1646  */
+  case 67: /* column_type: BIGINT  */
+#line 713 "bison_parser.y"
+                     { (yyval.column_type_t) = ColumnType{DataType::BIGINT}; }
+#line 3967 "bison_parser.cpp"
     break;
 
-  case 68:
-#line 714 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::BOOLEAN}; }
-#line 3801 "bison_parser.cpp" /* yacc.c:1646  */
+  case 68: /* column_type: BOOLEAN  */
+#line 714 "bison_parser.y"
+          { (yyval.column_type_t) = ColumnType{DataType::BOOLEAN}; }
+#line 3973 "bison_parser.cpp"
     break;
 
-  case 69:
-#line 715 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::CHAR, (yyvsp[-1].ival)}; }
-#line 3807 "bison_parser.cpp" /* yacc.c:1646  */
+  case 69: /* column_type: CHAR '(' INTVAL ')'  */
+#line 715 "bison_parser.y"
+                      { (yyval.column_type_t) = ColumnType{DataType::CHAR, (yyvsp[-1].ival)}; }
+#line 3979 "bison_parser.cpp"
     break;
 
-  case 70:
-#line 716 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
-#line 3813 "bison_parser.cpp" /* yacc.c:1646  */
+  case 70: /* column_type: CHARACTER_VARYING '(' INTVAL ')'  */
+#line 716 "bison_parser.y"
+                                   { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
+#line 3985 "bison_parser.cpp"
     break;
 
-  case 71:
-#line 717 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::DATE}; }
-#line 3819 "bison_parser.cpp" /* yacc.c:1646  */
+  case 71: /* column_type: DATE  */
+#line 717 "bison_parser.y"
+       { (yyval.column_type_t) = ColumnType{DataType::DATE}; }
+#line 3991 "bison_parser.cpp"
     break;
 
-  case 72:
-#line 718 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
-#line 3825 "bison_parser.cpp" /* yacc.c:1646  */
+  case 72: /* column_type: DATETIME  */
+#line 718 "bison_parser.y"
+           { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
+#line 3997 "bison_parser.cpp"
     break;
 
-  case 73:
-#line 719 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 73: /* column_type: DECIMAL opt_decimal_specification  */
+#line 719 "bison_parser.y"
+                                    {
   (yyval.column_type_t) = ColumnType{DataType::DECIMAL, 0, (yyvsp[0].ival_pair)->first, (yyvsp[0].ival_pair)->second};
   delete (yyvsp[0].ival_pair);
 }
-#line 3834 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4006 "bison_parser.cpp"
     break;
 
-  case 74:
-#line 723 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::DOUBLE}; }
-#line 3840 "bison_parser.cpp" /* yacc.c:1646  */
+  case 74: /* column_type: DOUBLE  */
+#line 723 "bison_parser.y"
+         { (yyval.column_type_t) = ColumnType{DataType::DOUBLE}; }
+#line 4012 "bison_parser.cpp"
     break;
 
-  case 75:
-#line 724 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::FLOAT}; }
-#line 3846 "bison_parser.cpp" /* yacc.c:1646  */
+  case 75: /* column_type: FLOAT  */
+#line 724 "bison_parser.y"
+        { (yyval.column_type_t) = ColumnType{DataType::FLOAT}; }
+#line 4018 "bison_parser.cpp"
     break;
 
-  case 76:
-#line 725 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::INT}; }
-#line 3852 "bison_parser.cpp" /* yacc.c:1646  */
+  case 76: /* column_type: INT  */
+#line 725 "bison_parser.y"
+      { (yyval.column_type_t) = ColumnType{DataType::INT}; }
+#line 4024 "bison_parser.cpp"
     break;
 
-  case 77:
-#line 726 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::INT}; }
-#line 3858 "bison_parser.cpp" /* yacc.c:1646  */
+  case 77: /* column_type: INTEGER  */
+#line 726 "bison_parser.y"
+          { (yyval.column_type_t) = ColumnType{DataType::INT}; }
+#line 4030 "bison_parser.cpp"
     break;
 
-  case 78:
-#line 727 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::LONG}; }
-#line 3864 "bison_parser.cpp" /* yacc.c:1646  */
+  case 78: /* column_type: LONG  */
+#line 727 "bison_parser.y"
+       { (yyval.column_type_t) = ColumnType{DataType::LONG}; }
+#line 4036 "bison_parser.cpp"
     break;
 
-  case 79:
-#line 728 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::REAL}; }
-#line 3870 "bison_parser.cpp" /* yacc.c:1646  */
+  case 79: /* column_type: REAL  */
+#line 728 "bison_parser.y"
+       { (yyval.column_type_t) = ColumnType{DataType::REAL}; }
+#line 4042 "bison_parser.cpp"
     break;
 
-  case 80:
-#line 729 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::SMALLINT}; }
-#line 3876 "bison_parser.cpp" /* yacc.c:1646  */
+  case 80: /* column_type: SMALLINT  */
+#line 729 "bison_parser.y"
+           { (yyval.column_type_t) = ColumnType{DataType::SMALLINT}; }
+#line 4048 "bison_parser.cpp"
     break;
 
-  case 81:
-#line 730 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::TEXT}; }
-#line 3882 "bison_parser.cpp" /* yacc.c:1646  */
+  case 81: /* column_type: TEXT  */
+#line 730 "bison_parser.y"
+       { (yyval.column_type_t) = ColumnType{DataType::TEXT}; }
+#line 4054 "bison_parser.cpp"
     break;
 
-  case 82:
-#line 731 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::TIME, 0, (yyvsp[0].ival)}; }
-#line 3888 "bison_parser.cpp" /* yacc.c:1646  */
+  case 82: /* column_type: TIME opt_time_precision  */
+#line 731 "bison_parser.y"
+                          { (yyval.column_type_t) = ColumnType{DataType::TIME, 0, (yyvsp[0].ival)}; }
+#line 4060 "bison_parser.cpp"
     break;
 
-  case 83:
-#line 732 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
-#line 3894 "bison_parser.cpp" /* yacc.c:1646  */
+  case 83: /* column_type: TIMESTAMP  */
+#line 732 "bison_parser.y"
+            { (yyval.column_type_t) = ColumnType{DataType::DATETIME}; }
+#line 4066 "bison_parser.cpp"
     break;
 
-  case 84:
-#line 733 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
-#line 3900 "bison_parser.cpp" /* yacc.c:1646  */
+  case 84: /* column_type: VARCHAR '(' INTVAL ')'  */
+#line 733 "bison_parser.y"
+                         { (yyval.column_type_t) = ColumnType{DataType::VARCHAR, (yyvsp[-1].ival)}; }
+#line 4072 "bison_parser.cpp"
     break;
 
-  case 85:
-#line 735 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-1].ival); }
-#line 3906 "bison_parser.cpp" /* yacc.c:1646  */
+  case 85: /* opt_time_precision: '(' INTVAL ')'  */
+#line 735 "bison_parser.y"
+                                    { (yyval.ival) = (yyvsp[-1].ival); }
+#line 4078 "bison_parser.cpp"
     break;
 
-  case 86:
-#line 736 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.ival) = 0; }
-#line 3912 "bison_parser.cpp" /* yacc.c:1646  */
+  case 86: /* opt_time_precision: %empty  */
+#line 736 "bison_parser.y"
+              { (yyval.ival) = 0; }
+#line 4084 "bison_parser.cpp"
     break;
 
-  case 87:
-#line 738 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-3].ival), (yyvsp[-1].ival)}; }
-#line 3918 "bison_parser.cpp" /* yacc.c:1646  */
+  case 87: /* opt_decimal_specification: '(' INTVAL ',' INTVAL ')'  */
+#line 738 "bison_parser.y"
+                                                      { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-3].ival), (yyvsp[-1].ival)}; }
+#line 4090 "bison_parser.cpp"
     break;
 
-  case 88:
-#line 739 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-1].ival), 0}; }
-#line 3924 "bison_parser.cpp" /* yacc.c:1646  */
+  case 88: /* opt_decimal_specification: '(' INTVAL ')'  */
+#line 739 "bison_parser.y"
+                 { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{(yyvsp[-1].ival), 0}; }
+#line 4096 "bison_parser.cpp"
     break;
 
-  case 89:
-#line 740 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{0, 0}; }
-#line 3930 "bison_parser.cpp" /* yacc.c:1646  */
+  case 89: /* opt_decimal_specification: %empty  */
+#line 740 "bison_parser.y"
+              { (yyval.ival_pair) = new std::pair<int64_t, int64_t>{0, 0}; }
+#line 4102 "bison_parser.cpp"
     break;
 
-  case 90:
-#line 742 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraints_t) = (yyvsp[0].column_constraints_t); }
-#line 3936 "bison_parser.cpp" /* yacc.c:1646  */
+  case 90: /* opt_column_constraints: column_constraints  */
+#line 742 "bison_parser.y"
+                                            { (yyval.column_constraints_t) = (yyvsp[0].column_constraints_t); }
+#line 4108 "bison_parser.cpp"
     break;
 
-  case 91:
-#line 743 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraints_t) = new ColumnConstraints(); }
-#line 3942 "bison_parser.cpp" /* yacc.c:1646  */
+  case 91: /* opt_column_constraints: %empty  */
+#line 743 "bison_parser.y"
+              { (yyval.column_constraints_t) = new ColumnConstraints(); }
+#line 4114 "bison_parser.cpp"
     break;
 
-  case 92:
-#line 745 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 92: /* column_constraints: column_constraint  */
+#line 745 "bison_parser.y"
+                                       {
   (yyval.column_constraints_t) = new ColumnConstraints();
   (yyval.column_constraints_t)->constraints->insert((yyvsp[0].column_constraint_t));
 }
-#line 3951 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4123 "bison_parser.cpp"
     break;
 
-  case 93:
-#line 749 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 93: /* column_constraints: column_constraints column_constraint  */
+#line 749 "bison_parser.y"
+                                       {
   (yyvsp[-1].column_constraints_t)->constraints->insert((yyvsp[0].column_constraint_t));
   (yyval.column_constraints_t) = (yyvsp[-1].column_constraints_t);
 }
-#line 3960 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4132 "bison_parser.cpp"
     break;
 
-  case 94:
-#line 753 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 94: /* column_constraints: references_spec  */
+#line 753 "bison_parser.y"
+                  {
   (yyval.column_constraints_t) = new ColumnConstraints();
   (yyval.column_constraints_t)->constraints->insert(ConstraintType::ForeignKey);
   (yyval.column_constraints_t)->references->emplace_back((yyvsp[0].references_spec_t));
 }
-#line 3970 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4142 "bison_parser.cpp"
     break;
 
-  case 95:
-#line 758 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 95: /* column_constraints: column_constraints references_spec  */
+#line 758 "bison_parser.y"
+                                     {
   // Multiple foreign keys for the same column could be possible, so we do not raise an error in that case.
   // Think of foreign keys referenced on multiple levels (returned item references sold item references items).
   (yyvsp[-1].column_constraints_t)->constraints->insert(ConstraintType::ForeignKey);
   (yyvsp[-1].column_constraints_t)->references->emplace_back((yyvsp[0].references_spec_t));
   (yyval.column_constraints_t) = (yyvsp[-1].column_constraints_t);
 }
-#line 3982 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4154 "bison_parser.cpp"
     break;
 
-  case 96:
-#line 766 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraint_t) = ConstraintType::PrimaryKey; }
-#line 3988 "bison_parser.cpp" /* yacc.c:1646  */
+  case 96: /* column_constraint: PRIMARY KEY  */
+#line 766 "bison_parser.y"
+                                { (yyval.column_constraint_t) = ConstraintType::PrimaryKey; }
+#line 4160 "bison_parser.cpp"
     break;
 
-  case 97:
-#line 767 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraint_t) = ConstraintType::Unique; }
-#line 3994 "bison_parser.cpp" /* yacc.c:1646  */
+  case 97: /* column_constraint: UNIQUE  */
+#line 767 "bison_parser.y"
+         { (yyval.column_constraint_t) = ConstraintType::Unique; }
+#line 4166 "bison_parser.cpp"
     break;
 
-  case 98:
-#line 768 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraint_t) = ConstraintType::Null; }
-#line 4000 "bison_parser.cpp" /* yacc.c:1646  */
+  case 98: /* column_constraint: NULL  */
+#line 768 "bison_parser.y"
+       { (yyval.column_constraint_t) = ConstraintType::Null; }
+#line 4172 "bison_parser.cpp"
     break;
 
-  case 99:
-#line 769 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.column_constraint_t) = ConstraintType::NotNull; }
-#line 4006 "bison_parser.cpp" /* yacc.c:1646  */
+  case 99: /* column_constraint: NOT NULL  */
+#line 769 "bison_parser.y"
+           { (yyval.column_constraint_t) = ConstraintType::NotNull; }
+#line 4178 "bison_parser.cpp"
     break;
 
-  case 100:
-#line 771 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::PrimaryKey, (yyvsp[-1].str_vec)); }
-#line 4012 "bison_parser.cpp" /* yacc.c:1646  */
+  case 100: /* table_constraint: PRIMARY KEY '(' ident_commalist ')'  */
+#line 771 "bison_parser.y"
+                                                       { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::PrimaryKey, (yyvsp[-1].str_vec)); }
+#line 4184 "bison_parser.cpp"
     break;
 
-  case 101:
-#line 772 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::Unique, (yyvsp[-1].str_vec)); }
-#line 4018 "bison_parser.cpp" /* yacc.c:1646  */
+  case 101: /* table_constraint: UNIQUE '(' ident_commalist ')'  */
+#line 772 "bison_parser.y"
+                                 { (yyval.table_constraint_t) = new TableConstraint(ConstraintType::Unique, (yyvsp[-1].str_vec)); }
+#line 4190 "bison_parser.cpp"
     break;
 
-  case 102:
-#line 773 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table_constraint_t) = new ForeignKeyConstraint((yyvsp[-2].str_vec), (yyvsp[0].references_spec_t)); }
-#line 4024 "bison_parser.cpp" /* yacc.c:1646  */
+  case 102: /* table_constraint: FOREIGN KEY '(' ident_commalist ')' references_spec  */
+#line 773 "bison_parser.y"
+                                                      { (yyval.table_constraint_t) = new ForeignKeyConstraint((yyvsp[-2].str_vec), (yyvsp[0].references_spec_t)); }
+#line 4196 "bison_parser.cpp"
     break;
 
-  case 103:
-#line 775 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.references_spec_t) = new ReferencesSpecification((yyvsp[-1].table_name).schema, (yyvsp[-1].table_name).name, (yyvsp[0].str_vec)); }
-#line 4030 "bison_parser.cpp" /* yacc.c:1646  */
+  case 103: /* references_spec: REFERENCES table_name opt_column_list  */
+#line 775 "bison_parser.y"
+                                                        { (yyval.references_spec_t) = new ReferencesSpecification((yyvsp[-1].table_name).schema, (yyvsp[-1].table_name).name, (yyvsp[0].str_vec)); }
+#line 4202 "bison_parser.cpp"
     break;
 
-  case 104:
-#line 783 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 104: /* drop_statement: DROP TABLE opt_exists table_name  */
+#line 783 "bison_parser.y"
+                                                  {
   (yyval.drop_stmt) = new DropStatement(kDropTable);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.drop_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 4041 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4213 "bison_parser.cpp"
     break;
 
-  case 105:
-#line 789 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 105: /* drop_statement: DROP VIEW opt_exists table_name  */
+#line 789 "bison_parser.y"
+                                  {
   (yyval.drop_stmt) = new DropStatement(kDropView);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.drop_stmt)->name = (yyvsp[0].table_name).name;
 }
-#line 4052 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4224 "bison_parser.cpp"
     break;
 
-  case 106:
-#line 795 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 106: /* drop_statement: DEALLOCATE PREPARE IDENTIFIER  */
+#line 795 "bison_parser.y"
+                                {
   (yyval.drop_stmt) = new DropStatement(kDropPreparedStatement);
   (yyval.drop_stmt)->ifExists = false;
   (yyval.drop_stmt)->name = (yyvsp[0].sval);
 }
-#line 4062 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4234 "bison_parser.cpp"
     break;
 
-  case 107:
-#line 801 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 107: /* drop_statement: DROP INDEX opt_exists IDENTIFIER  */
+#line 801 "bison_parser.y"
+                                   {
   (yyval.drop_stmt) = new DropStatement(kDropIndex);
   (yyval.drop_stmt)->ifExists = (yyvsp[-1].bval);
   (yyval.drop_stmt)->indexName = (yyvsp[0].sval);
 }
-#line 4072 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4244 "bison_parser.cpp"
     break;
 
-  case 108:
-#line 807 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = true; }
-#line 4078 "bison_parser.cpp" /* yacc.c:1646  */
+  case 108: /* opt_exists: IF EXISTS  */
+#line 807 "bison_parser.y"
+                       { (yyval.bval) = true; }
+#line 4250 "bison_parser.cpp"
     break;
 
-  case 109:
-#line 808 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = false; }
-#line 4084 "bison_parser.cpp" /* yacc.c:1646  */
+  case 109: /* opt_exists: %empty  */
+#line 808 "bison_parser.y"
+              { (yyval.bval) = false; }
+#line 4256 "bison_parser.cpp"
     break;
 
-  case 110:
-#line 815 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 110: /* alter_statement: ALTER TABLE opt_exists table_name alter_action  */
+#line 815 "bison_parser.y"
+                                                                 {
   (yyval.alter_stmt) = new AlterStatement((yyvsp[-1].table_name).name, (yyvsp[0].alter_action_t));
   (yyval.alter_stmt)->ifTableExists = (yyvsp[-2].bval);
   (yyval.alter_stmt)->schema = (yyvsp[-1].table_name).schema;
 }
-#line 4094 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4266 "bison_parser.cpp"
     break;
 
-  case 111:
-#line 821 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alter_action_t) = (yyvsp[0].drop_action_t); }
-#line 4100 "bison_parser.cpp" /* yacc.c:1646  */
+  case 111: /* alter_action: drop_action  */
+#line 821 "bison_parser.y"
+                           { (yyval.alter_action_t) = (yyvsp[0].drop_action_t); }
+#line 4272 "bison_parser.cpp"
     break;
 
-  case 112:
-#line 823 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 112: /* drop_action: DROP COLUMN opt_exists IDENTIFIER  */
+#line 823 "bison_parser.y"
+                                                {
   (yyval.drop_action_t) = new DropColumnAction((yyvsp[0].sval));
   (yyval.drop_action_t)->ifExists = (yyvsp[-1].bval);
 }
-#line 4109 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4281 "bison_parser.cpp"
     break;
 
-  case 113:
-#line 833 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 113: /* delete_statement: DELETE FROM table_name opt_where  */
+#line 833 "bison_parser.y"
+                                                    {
   (yyval.delete_stmt) = new DeleteStatement();
   (yyval.delete_stmt)->schema = (yyvsp[-1].table_name).schema;
   (yyval.delete_stmt)->tableName = (yyvsp[-1].table_name).name;
   (yyval.delete_stmt)->expr = (yyvsp[0].expr);
 }
-#line 4120 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4292 "bison_parser.cpp"
     break;
 
-  case 114:
-#line 840 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 114: /* truncate_statement: TRUNCATE table_name  */
+#line 840 "bison_parser.y"
+                                         {
   (yyval.delete_stmt) = new DeleteStatement();
   (yyval.delete_stmt)->schema = (yyvsp[0].table_name).schema;
   (yyval.delete_stmt)->tableName = (yyvsp[0].table_name).name;
 }
-#line 4130 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4302 "bison_parser.cpp"
     break;
 
-  case 115:
-#line 851 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 115: /* insert_statement: INSERT INTO table_name opt_column_list VALUES '(' extended_literal_list ')'  */
+#line 851 "bison_parser.y"
+                                                                                               {
   (yyval.insert_stmt) = new InsertStatement(kInsertValues);
   (yyval.insert_stmt)->schema = (yyvsp[-5].table_name).schema;
   (yyval.insert_stmt)->tableName = (yyvsp[-5].table_name).name;
   (yyval.insert_stmt)->columns = (yyvsp[-4].str_vec);
   (yyval.insert_stmt)->values = (yyvsp[-1].expr_vec);
 }
-#line 4142 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4314 "bison_parser.cpp"
     break;
 
-  case 116:
-#line 858 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 116: /* insert_statement: INSERT INTO table_name opt_column_list select_no_paren  */
+#line 858 "bison_parser.y"
+                                                         {
   (yyval.insert_stmt) = new InsertStatement(kInsertSelect);
   (yyval.insert_stmt)->schema = (yyvsp[-2].table_name).schema;
   (yyval.insert_stmt)->tableName = (yyvsp[-2].table_name).name;
   (yyval.insert_stmt)->columns = (yyvsp[-1].str_vec);
   (yyval.insert_stmt)->select = (yyvsp[0].select_stmt);
 }
-#line 4154 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4326 "bison_parser.cpp"
     break;
 
-  case 117:
-#line 866 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.str_vec) = (yyvsp[-1].str_vec); }
-#line 4160 "bison_parser.cpp" /* yacc.c:1646  */
+  case 117: /* opt_column_list: '(' ident_commalist ')'  */
+#line 866 "bison_parser.y"
+                                          { (yyval.str_vec) = (yyvsp[-1].str_vec); }
+#line 4332 "bison_parser.cpp"
     break;
 
-  case 118:
-#line 867 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.str_vec) = nullptr; }
-#line 4166 "bison_parser.cpp" /* yacc.c:1646  */
+  case 118: /* opt_column_list: %empty  */
+#line 867 "bison_parser.y"
+              { (yyval.str_vec) = nullptr; }
+#line 4338 "bison_parser.cpp"
     break;
 
-  case 119:
-#line 874 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 119: /* update_statement: UPDATE table_ref_name_no_alias SET update_clause_commalist opt_where  */
+#line 874 "bison_parser.y"
+                                                                                        {
   (yyval.update_stmt) = new UpdateStatement();
   (yyval.update_stmt)->table = (yyvsp[-3].table);
   (yyval.update_stmt)->updates = (yyvsp[-1].update_vec);
   (yyval.update_stmt)->where = (yyvsp[0].expr);
 }
-#line 4177 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4349 "bison_parser.cpp"
     break;
 
-  case 120:
-#line 881 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 120: /* update_clause_commalist: update_clause  */
+#line 881 "bison_parser.y"
+                                        {
   (yyval.update_vec) = new std::vector<UpdateClause*>();
   (yyval.update_vec)->push_back((yyvsp[0].update_t));
 }
-#line 4186 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4358 "bison_parser.cpp"
     break;
 
-  case 121:
-#line 885 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 121: /* update_clause_commalist: update_clause_commalist ',' update_clause  */
+#line 885 "bison_parser.y"
+                                            {
   (yyvsp[-2].update_vec)->push_back((yyvsp[0].update_t));
   (yyval.update_vec) = (yyvsp[-2].update_vec);
 }
-#line 4195 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4367 "bison_parser.cpp"
     break;
 
-  case 122:
-#line 890 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 122: /* update_clause: IDENTIFIER '=' expr  */
+#line 890 "bison_parser.y"
+                                    {
   (yyval.update_t) = new UpdateClause();
   (yyval.update_t)->column = (yyvsp[-2].sval);
   (yyval.update_t)->value = (yyvsp[0].expr);
 }
-#line 4205 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4377 "bison_parser.cpp"
     break;
 
-  case 123:
-#line 900 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 123: /* select_statement: opt_with_clause select_with_paren  */
+#line 900 "bison_parser.y"
+                                                     {
   (yyval.select_stmt) = (yyvsp[0].select_stmt);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-1].with_description_vec);
 }
-#line 4214 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4386 "bison_parser.cpp"
     break;
 
-  case 124:
-#line 904 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 124: /* select_statement: opt_with_clause select_no_paren  */
+#line 904 "bison_parser.y"
+                                  {
   (yyval.select_stmt) = (yyvsp[0].select_stmt);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-1].with_description_vec);
 }
-#line 4223 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4395 "bison_parser.cpp"
     break;
 
-  case 125:
-#line 908 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 125: /* select_statement: opt_with_clause select_with_paren set_operator select_within_set_operation opt_order opt_limit  */
+#line 908 "bison_parser.y"
+                                                                                                 {
   (yyval.select_stmt) = (yyvsp[-4].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
     (yyval.select_stmt)->setOperations = new std::vector<SetOperation*>();
@@ -4235,18 +4407,18 @@ yyreduce:
   (yyval.select_stmt)->setOperations->back()->resultLimit = (yyvsp[0].limit);
   (yyval.select_stmt)->withDescriptions = (yyvsp[-5].with_description_vec);
 }
-#line 4239 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4411 "bison_parser.cpp"
     break;
 
-  case 128:
-#line 922 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.select_stmt) = (yyvsp[0].select_stmt); }
-#line 4245 "bison_parser.cpp" /* yacc.c:1646  */
+  case 128: /* select_within_set_operation_no_parentheses: select_clause  */
+#line 922 "bison_parser.y"
+                                                           { (yyval.select_stmt) = (yyvsp[0].select_stmt); }
+#line 4417 "bison_parser.cpp"
     break;
 
-  case 129:
-#line 923 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 129: /* select_within_set_operation_no_parentheses: select_clause set_operator select_within_set_operation  */
+#line 923 "bison_parser.y"
+                                                         {
   (yyval.select_stmt) = (yyvsp[-2].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
     (yyval.select_stmt)->setOperations = new std::vector<SetOperation*>();
@@ -4254,24 +4426,24 @@ yyreduce:
   (yyval.select_stmt)->setOperations->push_back((yyvsp[-1].set_operator_t));
   (yyval.select_stmt)->setOperations->back()->nestedSelectStatement = (yyvsp[0].select_stmt);
 }
-#line 4258 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4430 "bison_parser.cpp"
     break;
 
-  case 130:
-#line 932 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 4264 "bison_parser.cpp" /* yacc.c:1646  */
+  case 130: /* select_with_paren: '(' select_no_paren ')'  */
+#line 932 "bison_parser.y"
+                                            { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
+#line 4436 "bison_parser.cpp"
     break;
 
-  case 131:
-#line 933 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
-#line 4270 "bison_parser.cpp" /* yacc.c:1646  */
+  case 131: /* select_with_paren: '(' select_with_paren ')'  */
+#line 933 "bison_parser.y"
+                            { (yyval.select_stmt) = (yyvsp[-1].select_stmt); }
+#line 4442 "bison_parser.cpp"
     break;
 
-  case 132:
-#line 935 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 132: /* select_no_paren: select_clause opt_order opt_limit opt_locking_clause  */
+#line 935 "bison_parser.y"
+                                                                       {
   (yyval.select_stmt) = (yyvsp[-3].select_stmt);
   (yyval.select_stmt)->order = (yyvsp[-2].order_vec);
 
@@ -4285,12 +4457,12 @@ yyreduce:
     (yyval.select_stmt)->lockings = (yyvsp[0].locking_clause_vec);
   }
 }
-#line 4289 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4461 "bison_parser.cpp"
     break;
 
-  case 133:
-#line 949 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 133: /* select_no_paren: select_clause set_operator select_within_set_operation opt_order opt_limit opt_locking_clause  */
+#line 949 "bison_parser.y"
+                                                                                                {
   (yyval.select_stmt) = (yyvsp[-5].select_stmt);
   if ((yyval.select_stmt)->setOperations == nullptr) {
     (yyval.select_stmt)->setOperations = new std::vector<SetOperation*>();
@@ -4301,60 +4473,60 @@ yyreduce:
   (yyval.select_stmt)->setOperations->back()->resultLimit = (yyvsp[-1].limit);
   (yyval.select_stmt)->lockings = (yyvsp[0].locking_clause_vec);
 }
-#line 4305 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4477 "bison_parser.cpp"
     break;
 
-  case 134:
-#line 961 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 134: /* set_operator: set_type opt_all  */
+#line 961 "bison_parser.y"
+                                {
   (yyval.set_operator_t) = (yyvsp[-1].set_operator_t);
   (yyval.set_operator_t)->isAll = (yyvsp[0].bval);
 }
-#line 4314 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4486 "bison_parser.cpp"
     break;
 
-  case 135:
-#line 966 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 135: /* set_type: UNION  */
+#line 966 "bison_parser.y"
+                 {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetUnion;
 }
-#line 4323 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4495 "bison_parser.cpp"
     break;
 
-  case 136:
-#line 970 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 136: /* set_type: INTERSECT  */
+#line 970 "bison_parser.y"
+            {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetIntersect;
 }
-#line 4332 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4504 "bison_parser.cpp"
     break;
 
-  case 137:
-#line 974 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 137: /* set_type: EXCEPT  */
+#line 974 "bison_parser.y"
+         {
   (yyval.set_operator_t) = new SetOperation();
   (yyval.set_operator_t)->setType = SetType::kSetExcept;
 }
-#line 4341 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4513 "bison_parser.cpp"
     break;
 
-  case 138:
-#line 979 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = true; }
-#line 4347 "bison_parser.cpp" /* yacc.c:1646  */
+  case 138: /* opt_all: ALL  */
+#line 979 "bison_parser.y"
+              { (yyval.bval) = true; }
+#line 4519 "bison_parser.cpp"
     break;
 
-  case 139:
-#line 980 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = false; }
-#line 4353 "bison_parser.cpp" /* yacc.c:1646  */
+  case 139: /* opt_all: %empty  */
+#line 980 "bison_parser.y"
+              { (yyval.bval) = false; }
+#line 4525 "bison_parser.cpp"
     break;
 
-  case 140:
-#line 982 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 140: /* select_clause: SELECT opt_top opt_distinct select_list opt_from_clause opt_where opt_group  */
+#line 982 "bison_parser.y"
+                                                                                            {
   (yyval.select_stmt) = new SelectStatement();
   (yyval.select_stmt)->limit = (yyvsp[-5].limit);
   (yyval.select_stmt)->selectDistinct = (yyvsp[-4].bval);
@@ -4363,142 +4535,142 @@ yyreduce:
   (yyval.select_stmt)->whereClause = (yyvsp[-1].expr);
   (yyval.select_stmt)->groupBy = (yyvsp[0].group_t);
 }
-#line 4367 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4539 "bison_parser.cpp"
     break;
 
-  case 141:
-#line 992 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = true; }
-#line 4373 "bison_parser.cpp" /* yacc.c:1646  */
+  case 141: /* opt_distinct: DISTINCT  */
+#line 992 "bison_parser.y"
+                        { (yyval.bval) = true; }
+#line 4545 "bison_parser.cpp"
     break;
 
-  case 142:
-#line 993 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.bval) = false; }
-#line 4379 "bison_parser.cpp" /* yacc.c:1646  */
+  case 142: /* opt_distinct: %empty  */
+#line 993 "bison_parser.y"
+              { (yyval.bval) = false; }
+#line 4551 "bison_parser.cpp"
     break;
 
-  case 144:
-#line 997 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table) = (yyvsp[0].table); }
-#line 4385 "bison_parser.cpp" /* yacc.c:1646  */
+  case 144: /* opt_from_clause: from_clause  */
+#line 997 "bison_parser.y"
+                              { (yyval.table) = (yyvsp[0].table); }
+#line 4557 "bison_parser.cpp"
     break;
 
-  case 145:
-#line 998 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table) = nullptr; }
-#line 4391 "bison_parser.cpp" /* yacc.c:1646  */
+  case 145: /* opt_from_clause: %empty  */
+#line 998 "bison_parser.y"
+              { (yyval.table) = nullptr; }
+#line 4563 "bison_parser.cpp"
     break;
 
-  case 146:
-#line 1000 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.table) = (yyvsp[0].table); }
-#line 4397 "bison_parser.cpp" /* yacc.c:1646  */
+  case 146: /* from_clause: FROM table_ref  */
+#line 1000 "bison_parser.y"
+                             { (yyval.table) = (yyvsp[0].table); }
+#line 4569 "bison_parser.cpp"
     break;
 
-  case 147:
-#line 1002 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = (yyvsp[0].expr); }
-#line 4403 "bison_parser.cpp" /* yacc.c:1646  */
+  case 147: /* opt_where: WHERE expr  */
+#line 1002 "bison_parser.y"
+                       { (yyval.expr) = (yyvsp[0].expr); }
+#line 4575 "bison_parser.cpp"
     break;
 
-  case 148:
-#line 1003 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = nullptr; }
-#line 4409 "bison_parser.cpp" /* yacc.c:1646  */
+  case 148: /* opt_where: %empty  */
+#line 1003 "bison_parser.y"
+              { (yyval.expr) = nullptr; }
+#line 4581 "bison_parser.cpp"
     break;
 
-  case 149:
-#line 1005 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 149: /* opt_group: GROUP BY expr_list opt_having  */
+#line 1005 "bison_parser.y"
+                                          {
   (yyval.group_t) = new GroupByDescription();
   (yyval.group_t)->columns = (yyvsp[-1].expr_vec);
   (yyval.group_t)->having = (yyvsp[0].expr);
 }
-#line 4419 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4591 "bison_parser.cpp"
     break;
 
-  case 150:
-#line 1010 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.group_t) = nullptr; }
-#line 4425 "bison_parser.cpp" /* yacc.c:1646  */
+  case 150: /* opt_group: %empty  */
+#line 1010 "bison_parser.y"
+              { (yyval.group_t) = nullptr; }
+#line 4597 "bison_parser.cpp"
     break;
 
-  case 151:
-#line 1012 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = (yyvsp[0].expr); }
-#line 4431 "bison_parser.cpp" /* yacc.c:1646  */
+  case 151: /* opt_having: HAVING expr  */
+#line 1012 "bison_parser.y"
+                         { (yyval.expr) = (yyvsp[0].expr); }
+#line 4603 "bison_parser.cpp"
     break;
 
-  case 152:
-#line 1013 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = nullptr; }
-#line 4437 "bison_parser.cpp" /* yacc.c:1646  */
+  case 152: /* opt_having: %empty  */
+#line 1013 "bison_parser.y"
+              { (yyval.expr) = nullptr; }
+#line 4609 "bison_parser.cpp"
     break;
 
-  case 153:
-#line 1015 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order_vec) = (yyvsp[0].order_vec); }
-#line 4443 "bison_parser.cpp" /* yacc.c:1646  */
+  case 153: /* opt_order: ORDER BY order_list  */
+#line 1015 "bison_parser.y"
+                                { (yyval.order_vec) = (yyvsp[0].order_vec); }
+#line 4615 "bison_parser.cpp"
     break;
 
-  case 154:
-#line 1016 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order_vec) = nullptr; }
-#line 4449 "bison_parser.cpp" /* yacc.c:1646  */
+  case 154: /* opt_order: %empty  */
+#line 1016 "bison_parser.y"
+              { (yyval.order_vec) = nullptr; }
+#line 4621 "bison_parser.cpp"
     break;
 
-  case 155:
-#line 1018 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 155: /* order_list: order_desc  */
+#line 1018 "bison_parser.y"
+                        {
   (yyval.order_vec) = new std::vector<OrderDescription*>();
   (yyval.order_vec)->push_back((yyvsp[0].order));
 }
-#line 4458 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4630 "bison_parser.cpp"
     break;
 
-  case 156:
-#line 1022 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 156: /* order_list: order_list ',' order_desc  */
+#line 1022 "bison_parser.y"
+                            {
   (yyvsp[-2].order_vec)->push_back((yyvsp[0].order));
   (yyval.order_vec) = (yyvsp[-2].order_vec);
 }
-#line 4467 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4639 "bison_parser.cpp"
     break;
 
-  case 157:
-#line 1027 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order) = new OrderDescription((yyvsp[-1].order_type), (yyvsp[-2].expr), (yyvsp[0].null_ordering_t)); }
-#line 4473 "bison_parser.cpp" /* yacc.c:1646  */
+  case 157: /* order_desc: expr opt_order_type opt_null_ordering  */
+#line 1027 "bison_parser.y"
+                                                   { (yyval.order) = new OrderDescription((yyvsp[-1].order_type), (yyvsp[-2].expr), (yyvsp[0].null_ordering_t)); }
+#line 4645 "bison_parser.cpp"
     break;
 
-  case 158:
-#line 1029 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order_type) = kOrderAsc; }
-#line 4479 "bison_parser.cpp" /* yacc.c:1646  */
+  case 158: /* opt_order_type: ASC  */
+#line 1029 "bison_parser.y"
+                     { (yyval.order_type) = kOrderAsc; }
+#line 4651 "bison_parser.cpp"
     break;
 
-  case 159:
-#line 1030 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order_type) = kOrderDesc; }
-#line 4485 "bison_parser.cpp" /* yacc.c:1646  */
+  case 159: /* opt_order_type: DESC  */
+#line 1030 "bison_parser.y"
+       { (yyval.order_type) = kOrderDesc; }
+#line 4657 "bison_parser.cpp"
     break;
 
-  case 160:
-#line 1031 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.order_type) = kOrderAsc; }
-#line 4491 "bison_parser.cpp" /* yacc.c:1646  */
+  case 160: /* opt_order_type: %empty  */
+#line 1031 "bison_parser.y"
+              { (yyval.order_type) = kOrderAsc; }
+#line 4663 "bison_parser.cpp"
     break;
 
-  case 161:
-#line 1033 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.null_ordering_t) = NullOrdering::Undefined; }
-#line 4497 "bison_parser.cpp" /* yacc.c:1646  */
+  case 161: /* opt_null_ordering: %empty  */
+#line 1033 "bison_parser.y"
+                                { (yyval.null_ordering_t) = NullOrdering::Undefined; }
+#line 4669 "bison_parser.cpp"
     break;
 
-  case 162:
-#line 1034 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 162: /* opt_null_ordering: IDENTIFIER IDENTIFIER  */
+#line 1034 "bison_parser.y"
+                        {
   auto null_ordering = NullOrdering::Undefined;
   if (strcasecmp((yyvsp[-1].sval), "nulls") == 0) {
     if (strcasecmp((yyvsp[0].sval), "first") == 0) {
@@ -4517,116 +4689,116 @@ yyreduce:
 
   (yyval.null_ordering_t) = null_ordering;
 }
-#line 4521 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4693 "bison_parser.cpp"
     break;
 
-  case 163:
-#line 1056 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
-#line 4527 "bison_parser.cpp" /* yacc.c:1646  */
+  case 163: /* opt_top: TOP int_literal  */
+#line 1056 "bison_parser.y"
+                          { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
+#line 4699 "bison_parser.cpp"
     break;
 
-  case 164:
-#line 1057 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = nullptr; }
-#line 4533 "bison_parser.cpp" /* yacc.c:1646  */
+  case 164: /* opt_top: %empty  */
+#line 1057 "bison_parser.y"
+              { (yyval.limit) = nullptr; }
+#line 4705 "bison_parser.cpp"
     break;
 
-  case 165:
-#line 1059 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
-#line 4539 "bison_parser.cpp" /* yacc.c:1646  */
+  case 165: /* opt_limit: LIMIT expr  */
+#line 1059 "bison_parser.y"
+                       { (yyval.limit) = new LimitDescription((yyvsp[0].expr), nullptr); }
+#line 4711 "bison_parser.cpp"
     break;
 
-  case 166:
-#line 1060 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
-#line 4545 "bison_parser.cpp" /* yacc.c:1646  */
+  case 166: /* opt_limit: OFFSET expr  */
+#line 1060 "bison_parser.y"
+              { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
+#line 4717 "bison_parser.cpp"
     break;
 
-  case 167:
-#line 1061 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription((yyvsp[-2].expr), (yyvsp[0].expr)); }
-#line 4551 "bison_parser.cpp" /* yacc.c:1646  */
+  case 167: /* opt_limit: LIMIT expr OFFSET expr  */
+#line 1061 "bison_parser.y"
+                         { (yyval.limit) = new LimitDescription((yyvsp[-2].expr), (yyvsp[0].expr)); }
+#line 4723 "bison_parser.cpp"
     break;
 
-  case 168:
-#line 1062 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription(nullptr, nullptr); }
-#line 4557 "bison_parser.cpp" /* yacc.c:1646  */
+  case 168: /* opt_limit: LIMIT ALL  */
+#line 1062 "bison_parser.y"
+            { (yyval.limit) = new LimitDescription(nullptr, nullptr); }
+#line 4729 "bison_parser.cpp"
     break;
 
-  case 169:
-#line 1063 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
-#line 4563 "bison_parser.cpp" /* yacc.c:1646  */
+  case 169: /* opt_limit: LIMIT ALL OFFSET expr  */
+#line 1063 "bison_parser.y"
+                        { (yyval.limit) = new LimitDescription(nullptr, (yyvsp[0].expr)); }
+#line 4735 "bison_parser.cpp"
     break;
 
-  case 170:
-#line 1064 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.limit) = nullptr; }
-#line 4569 "bison_parser.cpp" /* yacc.c:1646  */
+  case 170: /* opt_limit: %empty  */
+#line 1064 "bison_parser.y"
+              { (yyval.limit) = nullptr; }
+#line 4741 "bison_parser.cpp"
     break;
 
-  case 171:
-#line 1069 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 171: /* expr_list: expr_alias  */
+#line 1069 "bison_parser.y"
+                       {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 4578 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4750 "bison_parser.cpp"
     break;
 
-  case 172:
-#line 1073 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 172: /* expr_list: expr_list ',' expr_alias  */
+#line 1073 "bison_parser.y"
+                           {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 4587 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4759 "bison_parser.cpp"
     break;
 
-  case 173:
-#line 1079 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
-#line 4593 "bison_parser.cpp" /* yacc.c:1646  */
+  case 173: /* opt_extended_literal_list: extended_literal_list  */
+#line 1079 "bison_parser.y"
+                                                  { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
+#line 4765 "bison_parser.cpp"
     break;
 
-  case 174:
-#line 1080 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = nullptr; }
-#line 4599 "bison_parser.cpp" /* yacc.c:1646  */
+  case 174: /* opt_extended_literal_list: %empty  */
+#line 1080 "bison_parser.y"
+              { (yyval.expr_vec) = nullptr; }
+#line 4771 "bison_parser.cpp"
     break;
 
-  case 175:
-#line 1082 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 175: /* extended_literal_list: casted_extended_literal  */
+#line 1082 "bison_parser.y"
+                                                {
   (yyval.expr_vec) = new std::vector<Expr*>();
   (yyval.expr_vec)->push_back((yyvsp[0].expr));
 }
-#line 4608 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4780 "bison_parser.cpp"
     break;
 
-  case 176:
-#line 1086 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 176: /* extended_literal_list: extended_literal_list ',' casted_extended_literal  */
+#line 1086 "bison_parser.y"
+                                                    {
   (yyvsp[-2].expr_vec)->push_back((yyvsp[0].expr));
   (yyval.expr_vec) = (yyvsp[-2].expr_vec);
 }
-#line 4617 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4789 "bison_parser.cpp"
     break;
 
-  case 178:
-#line 1091 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 178: /* casted_extended_literal: CAST '(' extended_literal AS column_type ')'  */
+#line 1091 "bison_parser.y"
+                                                                                          {
   (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t));
 }
-#line 4625 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4797 "bison_parser.cpp"
     break;
 
-  case 179:
-#line 1095 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 179: /* extended_literal: literal  */
+#line 1095 "bison_parser.y"
+                           {
   if ((yyvsp[0].expr)->type == ExprType::kExprParameter) {
     delete (yyvsp[0].expr);
     yyerror(&yyloc, result, scanner, "Parameter ? is not a valid literal.");
@@ -4634,24 +4806,24 @@ yyreduce:
   }
   (yyval.expr) = (yyvsp[0].expr);
 }
-#line 4638 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4810 "bison_parser.cpp"
     break;
 
-  case 180:
-#line 1103 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4644 "bison_parser.cpp" /* yacc.c:1646  */
+  case 180: /* extended_literal: '-' num_literal  */
+#line 1103 "bison_parser.y"
+                  { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
+#line 4816 "bison_parser.cpp"
     break;
 
-  case 181:
-#line 1104 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4650 "bison_parser.cpp" /* yacc.c:1646  */
+  case 181: /* extended_literal: '-' interval_literal  */
+#line 1104 "bison_parser.y"
+                       { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
+#line 4822 "bison_parser.cpp"
     break;
 
-  case 182:
-#line 1106 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 182: /* expr_alias: expr opt_alias  */
+#line 1106 "bison_parser.y"
+                            {
   (yyval.expr) = (yyvsp[-1].expr);
   if ((yyvsp[0].alias_t)) {
     (yyval.expr)->alias = (yyvsp[0].alias_t)->name;
@@ -4659,520 +4831,526 @@ yyreduce:
     delete (yyvsp[0].alias_t);
   }
 }
-#line 4663 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4835 "bison_parser.cpp"
     break;
 
-  case 188:
-#line 1117 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = (yyvsp[-1].expr); }
-#line 4669 "bison_parser.cpp" /* yacc.c:1646  */
+  case 188: /* operand: '(' expr ')'  */
+#line 1117 "bison_parser.y"
+                       { (yyval.expr) = (yyvsp[-1].expr); }
+#line 4841 "bison_parser.cpp"
     break;
 
-  case 198:
-#line 1119 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 198: /* operand: '(' select_no_paren ')'  */
+#line 1119 "bison_parser.y"
+                                         {
   (yyval.expr) = Expr::makeSelect((yyvsp[-1].select_stmt));
 }
-#line 4677 "bison_parser.cpp" /* yacc.c:1646  */
+#line 4849 "bison_parser.cpp"
     break;
 
-  case 201:
-#line 1125 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
-#line 4683 "bison_parser.cpp" /* yacc.c:1646  */
+  case 201: /* unary_expr: '-' operand  */
+#line 1125 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeOpUnary(kOpUnaryMinus, (yyvsp[0].expr)); }
+#line 4855 "bison_parser.cpp"
     break;
 
-  case 202:
-#line 1126 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpNot, (yyvsp[0].expr)); }
-#line 4689 "bison_parser.cpp" /* yacc.c:1646  */
+  case 202: /* unary_expr: NOT operand  */
+#line 1126 "bison_parser.y"
+              { (yyval.expr) = Expr::makeOpUnary(kOpNot, (yyvsp[0].expr)); }
+#line 4861 "bison_parser.cpp"
     break;
 
-  case 203:
-#line 1127 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-1].expr)); }
-#line 4695 "bison_parser.cpp" /* yacc.c:1646  */
+  case 203: /* unary_expr: operand ISNULL  */
+#line 1127 "bison_parser.y"
+                 { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-1].expr)); }
+#line 4867 "bison_parser.cpp"
     break;
 
-  case 204:
-#line 1128 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-2].expr)); }
-#line 4701 "bison_parser.cpp" /* yacc.c:1646  */
+  case 204: /* unary_expr: operand IS NULL  */
+#line 1128 "bison_parser.y"
+                  { (yyval.expr) = Expr::makeOpUnary(kOpIsNull, (yyvsp[-2].expr)); }
+#line 4873 "bison_parser.cpp"
     break;
 
-  case 205:
-#line 1129 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeOpUnary(kOpIsNull, (yyvsp[-3].expr))); }
-#line 4707 "bison_parser.cpp" /* yacc.c:1646  */
+  case 205: /* unary_expr: operand IS NOT NULL  */
+#line 1129 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeOpUnary(kOpIsNull, (yyvsp[-3].expr))); }
+#line 4879 "bison_parser.cpp"
     break;
 
-  case 207:
-#line 1131 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpMinus, (yyvsp[0].expr)); }
-#line 4713 "bison_parser.cpp" /* yacc.c:1646  */
+  case 207: /* binary_expr: operand '-' operand  */
+#line 1131 "bison_parser.y"
+                                              { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpMinus, (yyvsp[0].expr)); }
+#line 4885 "bison_parser.cpp"
     break;
 
-  case 208:
-#line 1132 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPlus, (yyvsp[0].expr)); }
-#line 4719 "bison_parser.cpp" /* yacc.c:1646  */
+  case 208: /* binary_expr: operand '+' operand  */
+#line 1132 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPlus, (yyvsp[0].expr)); }
+#line 4891 "bison_parser.cpp"
     break;
 
-  case 209:
-#line 1133 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpSlash, (yyvsp[0].expr)); }
-#line 4725 "bison_parser.cpp" /* yacc.c:1646  */
+  case 209: /* binary_expr: operand '/' operand  */
+#line 1133 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpSlash, (yyvsp[0].expr)); }
+#line 4897 "bison_parser.cpp"
     break;
 
-  case 210:
-#line 1134 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAsterisk, (yyvsp[0].expr)); }
-#line 4731 "bison_parser.cpp" /* yacc.c:1646  */
+  case 210: /* binary_expr: operand '*' operand  */
+#line 1134 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAsterisk, (yyvsp[0].expr)); }
+#line 4903 "bison_parser.cpp"
     break;
 
-  case 211:
-#line 1135 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPercentage, (yyvsp[0].expr)); }
-#line 4737 "bison_parser.cpp" /* yacc.c:1646  */
+  case 211: /* binary_expr: operand '%' operand  */
+#line 1135 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpPercentage, (yyvsp[0].expr)); }
+#line 4909 "bison_parser.cpp"
     break;
 
-  case 212:
-#line 1136 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpCaret, (yyvsp[0].expr)); }
-#line 4743 "bison_parser.cpp" /* yacc.c:1646  */
+  case 212: /* binary_expr: operand '^' operand  */
+#line 1136 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpCaret, (yyvsp[0].expr)); }
+#line 4915 "bison_parser.cpp"
     break;
 
-  case 213:
-#line 1137 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLike, (yyvsp[0].expr)); }
-#line 4749 "bison_parser.cpp" /* yacc.c:1646  */
+  case 213: /* binary_expr: operand LIKE operand  */
+#line 1137 "bison_parser.y"
+                       { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLike, (yyvsp[0].expr)); }
+#line 4921 "bison_parser.cpp"
     break;
 
-  case 214:
-#line 1138 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-3].expr), kOpNotLike, (yyvsp[0].expr)); }
-#line 4755 "bison_parser.cpp" /* yacc.c:1646  */
+  case 214: /* binary_expr: operand NOT LIKE operand  */
+#line 1138 "bison_parser.y"
+                           { (yyval.expr) = Expr::makeOpBinary((yyvsp[-3].expr), kOpNotLike, (yyvsp[0].expr)); }
+#line 4927 "bison_parser.cpp"
     break;
 
-  case 215:
-#line 1139 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpILike, (yyvsp[0].expr)); }
-#line 4761 "bison_parser.cpp" /* yacc.c:1646  */
+  case 215: /* binary_expr: operand ILIKE operand  */
+#line 1139 "bison_parser.y"
+                        { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpILike, (yyvsp[0].expr)); }
+#line 4933 "bison_parser.cpp"
     break;
 
-  case 216:
-#line 1140 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpConcat, (yyvsp[0].expr)); }
-#line 4767 "bison_parser.cpp" /* yacc.c:1646  */
+  case 216: /* binary_expr: operand CONCAT operand  */
+#line 1140 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpConcat, (yyvsp[0].expr)); }
+#line 4939 "bison_parser.cpp"
     break;
 
-  case 217:
-#line 1142 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAnd, (yyvsp[0].expr)); }
-#line 4773 "bison_parser.cpp" /* yacc.c:1646  */
+  case 217: /* logic_expr: expr AND expr  */
+#line 1142 "bison_parser.y"
+                           { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpAnd, (yyvsp[0].expr)); }
+#line 4945 "bison_parser.cpp"
     break;
 
-  case 218:
-#line 1143 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpOr, (yyvsp[0].expr)); }
-#line 4779 "bison_parser.cpp" /* yacc.c:1646  */
+  case 218: /* logic_expr: expr OR expr  */
+#line 1143 "bison_parser.y"
+               { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpOr, (yyvsp[0].expr)); }
+#line 4951 "bison_parser.cpp"
     break;
 
-  case 219:
-#line 1145 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].expr_vec)); }
-#line 4785 "bison_parser.cpp" /* yacc.c:1646  */
+  case 219: /* in_expr: operand IN '(' expr_list ')'  */
+#line 1145 "bison_parser.y"
+                                       { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].expr_vec)); }
+#line 4957 "bison_parser.cpp"
     break;
 
-  case 220:
-#line 1146 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].expr_vec))); }
-#line 4791 "bison_parser.cpp" /* yacc.c:1646  */
+  case 220: /* in_expr: operand NOT IN '(' expr_list ')'  */
+#line 1146 "bison_parser.y"
+                                   { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].expr_vec))); }
+#line 4963 "bison_parser.cpp"
     break;
 
-  case 221:
-#line 1147 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].select_stmt)); }
-#line 4797 "bison_parser.cpp" /* yacc.c:1646  */
+  case 221: /* in_expr: operand IN '(' select_no_paren ')'  */
+#line 1147 "bison_parser.y"
+                                     { (yyval.expr) = Expr::makeInOperator((yyvsp[-4].expr), (yyvsp[-1].select_stmt)); }
+#line 4969 "bison_parser.cpp"
     break;
 
-  case 222:
-#line 1148 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].select_stmt))); }
-#line 4803 "bison_parser.cpp" /* yacc.c:1646  */
+  case 222: /* in_expr: operand NOT IN '(' select_no_paren ')'  */
+#line 1148 "bison_parser.y"
+                                         { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeInOperator((yyvsp[-5].expr), (yyvsp[-1].select_stmt))); }
+#line 4975 "bison_parser.cpp"
     break;
 
-  case 223:
-#line 1152 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCase((yyvsp[-2].expr), (yyvsp[-1].expr), nullptr); }
-#line 4809 "bison_parser.cpp" /* yacc.c:1646  */
+  case 223: /* case_expr: CASE expr case_list END  */
+#line 1152 "bison_parser.y"
+                                    { (yyval.expr) = Expr::makeCase((yyvsp[-2].expr), (yyvsp[-1].expr), nullptr); }
+#line 4981 "bison_parser.cpp"
     break;
 
-  case 224:
-#line 1153 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCase((yyvsp[-4].expr), (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 4815 "bison_parser.cpp" /* yacc.c:1646  */
+  case 224: /* case_expr: CASE expr case_list ELSE expr END  */
+#line 1153 "bison_parser.y"
+                                    { (yyval.expr) = Expr::makeCase((yyvsp[-4].expr), (yyvsp[-3].expr), (yyvsp[-1].expr)); }
+#line 4987 "bison_parser.cpp"
     break;
 
-  case 225:
-#line 1154 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-1].expr), nullptr); }
-#line 4821 "bison_parser.cpp" /* yacc.c:1646  */
+  case 225: /* case_expr: CASE case_list END  */
+#line 1154 "bison_parser.y"
+                     { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-1].expr), nullptr); }
+#line 4993 "bison_parser.cpp"
     break;
 
-  case 226:
-#line 1155 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-3].expr), (yyvsp[-1].expr)); }
-#line 4827 "bison_parser.cpp" /* yacc.c:1646  */
+  case 226: /* case_expr: CASE case_list ELSE expr END  */
+#line 1155 "bison_parser.y"
+                               { (yyval.expr) = Expr::makeCase(nullptr, (yyvsp[-3].expr), (yyvsp[-1].expr)); }
+#line 4999 "bison_parser.cpp"
     break;
 
-  case 227:
-#line 1157 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCaseList(Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
-#line 4833 "bison_parser.cpp" /* yacc.c:1646  */
+  case 227: /* case_list: WHEN expr THEN expr  */
+#line 1157 "bison_parser.y"
+                                { (yyval.expr) = Expr::makeCaseList(Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
+#line 5005 "bison_parser.cpp"
     break;
 
-  case 228:
-#line 1158 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::caseListAppend((yyvsp[-4].expr), Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
-#line 4839 "bison_parser.cpp" /* yacc.c:1646  */
+  case 228: /* case_list: case_list WHEN expr THEN expr  */
+#line 1158 "bison_parser.y"
+                                { (yyval.expr) = Expr::caseListAppend((yyvsp[-4].expr), Expr::makeCaseListElement((yyvsp[-2].expr), (yyvsp[0].expr))); }
+#line 5011 "bison_parser.cpp"
     break;
 
-  case 229:
-#line 1160 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeExists((yyvsp[-1].select_stmt)); }
-#line 4845 "bison_parser.cpp" /* yacc.c:1646  */
+  case 229: /* exists_expr: EXISTS '(' select_no_paren ')'  */
+#line 1160 "bison_parser.y"
+                                             { (yyval.expr) = Expr::makeExists((yyvsp[-1].select_stmt)); }
+#line 5017 "bison_parser.cpp"
     break;
 
-  case 230:
-#line 1161 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeExists((yyvsp[-1].select_stmt))); }
-#line 4851 "bison_parser.cpp" /* yacc.c:1646  */
+  case 230: /* exists_expr: NOT EXISTS '(' select_no_paren ')'  */
+#line 1161 "bison_parser.y"
+                                     { (yyval.expr) = Expr::makeOpUnary(kOpNot, Expr::makeExists((yyvsp[-1].select_stmt))); }
+#line 5023 "bison_parser.cpp"
     break;
 
-  case 231:
-#line 1163 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
-#line 4857 "bison_parser.cpp" /* yacc.c:1646  */
+  case 231: /* comp_expr: operand '=' operand  */
+#line 1163 "bison_parser.y"
+                                { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
+#line 5029 "bison_parser.cpp"
     break;
 
-  case 232:
-#line 1164 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
-#line 4863 "bison_parser.cpp" /* yacc.c:1646  */
+  case 232: /* comp_expr: operand EQUALS operand  */
+#line 1164 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpEquals, (yyvsp[0].expr)); }
+#line 5035 "bison_parser.cpp"
     break;
 
-  case 233:
-#line 1165 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpNotEquals, (yyvsp[0].expr)); }
-#line 4869 "bison_parser.cpp" /* yacc.c:1646  */
+  case 233: /* comp_expr: operand NOTEQUALS operand  */
+#line 1165 "bison_parser.y"
+                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpNotEquals, (yyvsp[0].expr)); }
+#line 5041 "bison_parser.cpp"
     break;
 
-  case 234:
-#line 1166 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLess, (yyvsp[0].expr)); }
-#line 4875 "bison_parser.cpp" /* yacc.c:1646  */
+  case 234: /* comp_expr: operand '<' operand  */
+#line 1166 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLess, (yyvsp[0].expr)); }
+#line 5047 "bison_parser.cpp"
     break;
 
-  case 235:
-#line 1167 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreater, (yyvsp[0].expr)); }
-#line 4881 "bison_parser.cpp" /* yacc.c:1646  */
+  case 235: /* comp_expr: operand '>' operand  */
+#line 1167 "bison_parser.y"
+                      { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreater, (yyvsp[0].expr)); }
+#line 5053 "bison_parser.cpp"
     break;
 
-  case 236:
-#line 1168 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLessEq, (yyvsp[0].expr)); }
-#line 4887 "bison_parser.cpp" /* yacc.c:1646  */
+  case 236: /* comp_expr: operand LESSEQ operand  */
+#line 1168 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpLessEq, (yyvsp[0].expr)); }
+#line 5059 "bison_parser.cpp"
     break;
 
-  case 237:
-#line 1169 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreaterEq, (yyvsp[0].expr)); }
-#line 4893 "bison_parser.cpp" /* yacc.c:1646  */
+  case 237: /* comp_expr: operand GREATEREQ operand  */
+#line 1169 "bison_parser.y"
+                            { (yyval.expr) = Expr::makeOpBinary((yyvsp[-2].expr), kOpGreaterEq, (yyvsp[0].expr)); }
+#line 5065 "bison_parser.cpp"
     break;
 
-  case 238:
-#line 1173 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
-#line 4899 "bison_parser.cpp" /* yacc.c:1646  */
+  case 238: /* function_expr: IDENTIFIER '(' ')' opt_window  */
+#line 1173 "bison_parser.y"
+                                              { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
+#line 5071 "bison_parser.cpp"
     break;
 
-  case 239:
-#line 1174 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
-#line 4905 "bison_parser.cpp" /* yacc.c:1646  */
+  case 239: /* function_expr: IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
+#line 1174 "bison_parser.y"
+                                                       { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
+#line 5077 "bison_parser.cpp"
     break;
 
-  case 240:
-#line 1175 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), (yyvsp[-5].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
-#line 4911 "bison_parser.cpp" /* yacc.c:1646  */
+  case 240: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' ')' opt_window  */
+#line 1175 "bison_parser.y"
+                                               { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-3].sval), (yyvsp[-5].sval), new std::vector<Expr*>(), false, (yyvsp[0].window_description)); }
+#line 5083 "bison_parser.cpp"
     break;
 
-  case 241:
-#line 1176 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-7].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
-#line 4917 "bison_parser.cpp" /* yacc.c:1646  */
+  case 241: /* function_expr: IDENTIFIER '.' IDENTIFIER '(' opt_distinct expr_list ')' opt_window  */
+#line 1176 "bison_parser.y"
+                                                                      { (yyval.expr) = Expr::makeFunctionRef((yyvsp[-5].sval), (yyvsp[-7].sval), (yyvsp[-2].expr_vec), (yyvsp[-3].bval), (yyvsp[0].window_description)); }
+#line 5089 "bison_parser.cpp"
     break;
 
-  case 242:
-#line 1180 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.window_description) = new WindowDescription((yyvsp[-3].expr_vec), (yyvsp[-2].order_vec), (yyvsp[-1].frame_description)); }
-#line 4923 "bison_parser.cpp" /* yacc.c:1646  */
+  case 242: /* opt_window: OVER '(' opt_partition opt_order opt_frame_clause ')'  */
+#line 1180 "bison_parser.y"
+                                                                   { (yyval.window_description) = new WindowDescription((yyvsp[-3].expr_vec), (yyvsp[-2].order_vec), (yyvsp[-1].frame_description)); }
+#line 5095 "bison_parser.cpp"
     break;
 
-  case 243:
-#line 1181 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.window_description) = nullptr; }
-#line 4929 "bison_parser.cpp" /* yacc.c:1646  */
+  case 243: /* opt_window: %empty  */
+#line 1181 "bison_parser.y"
+              { (yyval.window_description) = nullptr; }
+#line 5101 "bison_parser.cpp"
     break;
 
-  case 244:
-#line 1183 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
-#line 4935 "bison_parser.cpp" /* yacc.c:1646  */
+  case 244: /* opt_partition: PARTITION BY expr_list  */
+#line 1183 "bison_parser.y"
+                                       { (yyval.expr_vec) = (yyvsp[0].expr_vec); }
+#line 5107 "bison_parser.cpp"
     break;
 
-  case 245:
-#line 1184 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr_vec) = nullptr; }
-#line 4941 "bison_parser.cpp" /* yacc.c:1646  */
+  case 245: /* opt_partition: %empty  */
+#line 1184 "bison_parser.y"
+              { (yyval.expr_vec) = nullptr; }
+#line 5113 "bison_parser.cpp"
     break;
 
-  case 246:
-#line 1189 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_description) = new FrameDescription{(yyvsp[-1].frame_type), (yyvsp[0].frame_bound), new FrameBound{0, kCurrentRow, false}}; }
-#line 4947 "bison_parser.cpp" /* yacc.c:1646  */
+  case 246: /* opt_frame_clause: frame_type frame_bound  */
+#line 1189 "bison_parser.y"
+                                          { (yyval.frame_description) = new FrameDescription{(yyvsp[-1].frame_type), (yyvsp[0].frame_bound), new FrameBound{0, kCurrentRow, false}}; }
+#line 5119 "bison_parser.cpp"
     break;
 
-  case 247:
-#line 1190 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_description) = new FrameDescription{(yyvsp[-4].frame_type), (yyvsp[-2].frame_bound), (yyvsp[0].frame_bound)}; }
-#line 4953 "bison_parser.cpp" /* yacc.c:1646  */
+  case 247: /* opt_frame_clause: frame_type BETWEEN frame_bound AND frame_bound  */
+#line 1190 "bison_parser.y"
+                                                 { (yyval.frame_description) = new FrameDescription{(yyvsp[-4].frame_type), (yyvsp[-2].frame_bound), (yyvsp[0].frame_bound)}; }
+#line 5125 "bison_parser.cpp"
     break;
 
-  case 248:
-#line 1191 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 248: /* opt_frame_clause: %empty  */
+#line 1191 "bison_parser.y"
+              {
   (yyval.frame_description) = new FrameDescription{kRange, new FrameBound{0, kPreceding, true}, new FrameBound{0, kCurrentRow, false}};
 }
-#line 4961 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5133 "bison_parser.cpp"
     break;
 
-  case 249:
-#line 1195 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_type) = kRange; }
-#line 4967 "bison_parser.cpp" /* yacc.c:1646  */
+  case 249: /* frame_type: RANGE  */
+#line 1195 "bison_parser.y"
+                   { (yyval.frame_type) = kRange; }
+#line 5139 "bison_parser.cpp"
     break;
 
-  case 250:
-#line 1196 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_type) = kRows; }
-#line 4973 "bison_parser.cpp" /* yacc.c:1646  */
+  case 250: /* frame_type: ROWS  */
+#line 1196 "bison_parser.y"
+       { (yyval.frame_type) = kRows; }
+#line 5145 "bison_parser.cpp"
     break;
 
-  case 251:
-#line 1197 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_type) = kGroups; }
-#line 4979 "bison_parser.cpp" /* yacc.c:1646  */
+  case 251: /* frame_type: GROUPS  */
+#line 1197 "bison_parser.y"
+         { (yyval.frame_type) = kGroups; }
+#line 5151 "bison_parser.cpp"
     break;
 
-  case 252:
-#line 1199 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_bound) = new FrameBound{0, kPreceding, true}; }
-#line 4985 "bison_parser.cpp" /* yacc.c:1646  */
+  case 252: /* frame_bound: UNBOUNDED PRECEDING  */
+#line 1199 "bison_parser.y"
+                                  { (yyval.frame_bound) = new FrameBound{0, kPreceding, true}; }
+#line 5157 "bison_parser.cpp"
     break;
 
-  case 253:
-#line 1200 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kPreceding, false}; }
-#line 4991 "bison_parser.cpp" /* yacc.c:1646  */
+  case 253: /* frame_bound: INTVAL PRECEDING  */
+#line 1200 "bison_parser.y"
+                   { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kPreceding, false}; }
+#line 5163 "bison_parser.cpp"
     break;
 
-  case 254:
-#line 1201 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_bound) = new FrameBound{0, kFollowing, true}; }
-#line 4997 "bison_parser.cpp" /* yacc.c:1646  */
+  case 254: /* frame_bound: UNBOUNDED FOLLOWING  */
+#line 1201 "bison_parser.y"
+                      { (yyval.frame_bound) = new FrameBound{0, kFollowing, true}; }
+#line 5169 "bison_parser.cpp"
     break;
 
-  case 255:
-#line 1202 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kFollowing, false}; }
-#line 5003 "bison_parser.cpp" /* yacc.c:1646  */
+  case 255: /* frame_bound: INTVAL FOLLOWING  */
+#line 1202 "bison_parser.y"
+                   { (yyval.frame_bound) = new FrameBound{(yyvsp[-1].ival), kFollowing, false}; }
+#line 5175 "bison_parser.cpp"
     break;
 
-  case 256:
-#line 1203 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.frame_bound) = new FrameBound{0, kCurrentRow, false}; }
-#line 5009 "bison_parser.cpp" /* yacc.c:1646  */
+  case 256: /* frame_bound: CURRENT_ROW  */
+#line 1203 "bison_parser.y"
+              { (yyval.frame_bound) = new FrameBound{0, kCurrentRow, false}; }
+#line 5181 "bison_parser.cpp"
     break;
 
-  case 257:
-#line 1205 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeExtract((yyvsp[-3].datetime_field), (yyvsp[-1].expr)); }
-#line 5015 "bison_parser.cpp" /* yacc.c:1646  */
+  case 257: /* extract_expr: EXTRACT '(' datetime_field FROM expr ')'  */
+#line 1205 "bison_parser.y"
+                                                        { (yyval.expr) = Expr::makeExtract((yyvsp[-3].datetime_field), (yyvsp[-1].expr)); }
+#line 5187 "bison_parser.cpp"
     break;
 
-  case 258:
-#line 1207 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t)); }
-#line 5021 "bison_parser.cpp" /* yacc.c:1646  */
+  case 258: /* cast_expr: CAST '(' expr AS column_type ')'  */
+#line 1207 "bison_parser.y"
+                                             { (yyval.expr) = Expr::makeCast((yyvsp[-3].expr), (yyvsp[-1].column_type_t)); }
+#line 5193 "bison_parser.cpp"
     break;
 
-  case 259:
-#line 1209 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeSecond; }
-#line 5027 "bison_parser.cpp" /* yacc.c:1646  */
+  case 259: /* datetime_field: SECOND  */
+#line 1209 "bison_parser.y"
+                        { (yyval.datetime_field) = kDatetimeSecond; }
+#line 5199 "bison_parser.cpp"
     break;
 
-  case 260:
-#line 1210 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeMinute; }
-#line 5033 "bison_parser.cpp" /* yacc.c:1646  */
+  case 260: /* datetime_field: MINUTE  */
+#line 1210 "bison_parser.y"
+         { (yyval.datetime_field) = kDatetimeMinute; }
+#line 5205 "bison_parser.cpp"
     break;
 
-  case 261:
-#line 1211 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeHour; }
-#line 5039 "bison_parser.cpp" /* yacc.c:1646  */
+  case 261: /* datetime_field: HOUR  */
+#line 1211 "bison_parser.y"
+       { (yyval.datetime_field) = kDatetimeHour; }
+#line 5211 "bison_parser.cpp"
     break;
 
-  case 262:
-#line 1212 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeDay; }
-#line 5045 "bison_parser.cpp" /* yacc.c:1646  */
+  case 262: /* datetime_field: DAY  */
+#line 1212 "bison_parser.y"
+      { (yyval.datetime_field) = kDatetimeDay; }
+#line 5217 "bison_parser.cpp"
     break;
 
-  case 263:
-#line 1213 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeMonth; }
-#line 5051 "bison_parser.cpp" /* yacc.c:1646  */
+  case 263: /* datetime_field: MONTH  */
+#line 1213 "bison_parser.y"
+        { (yyval.datetime_field) = kDatetimeMonth; }
+#line 5223 "bison_parser.cpp"
     break;
 
-  case 264:
-#line 1214 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeYear; }
-#line 5057 "bison_parser.cpp" /* yacc.c:1646  */
+  case 264: /* datetime_field: YEAR  */
+#line 1214 "bison_parser.y"
+       { (yyval.datetime_field) = kDatetimeYear; }
+#line 5229 "bison_parser.cpp"
     break;
 
-  case 265:
-#line 1216 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeSecond; }
-#line 5063 "bison_parser.cpp" /* yacc.c:1646  */
+  case 265: /* datetime_field_plural: SECONDS  */
+#line 1216 "bison_parser.y"
+                                { (yyval.datetime_field) = kDatetimeSecond; }
+#line 5235 "bison_parser.cpp"
     break;
 
-  case 266:
-#line 1217 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeMinute; }
-#line 5069 "bison_parser.cpp" /* yacc.c:1646  */
+  case 266: /* datetime_field_plural: MINUTES  */
+#line 1217 "bison_parser.y"
+          { (yyval.datetime_field) = kDatetimeMinute; }
+#line 5241 "bison_parser.cpp"
     break;
 
-  case 267:
-#line 1218 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeHour; }
-#line 5075 "bison_parser.cpp" /* yacc.c:1646  */
+  case 267: /* datetime_field_plural: HOURS  */
+#line 1218 "bison_parser.y"
+        { (yyval.datetime_field) = kDatetimeHour; }
+#line 5247 "bison_parser.cpp"
     break;
 
-  case 268:
-#line 1219 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeDay; }
-#line 5081 "bison_parser.cpp" /* yacc.c:1646  */
+  case 268: /* datetime_field_plural: DAYS  */
+#line 1219 "bison_parser.y"
+       { (yyval.datetime_field) = kDatetimeDay; }
+#line 5253 "bison_parser.cpp"
     break;
 
-  case 269:
-#line 1220 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeMonth; }
-#line 5087 "bison_parser.cpp" /* yacc.c:1646  */
+  case 269: /* datetime_field_plural: MONTHS  */
+#line 1220 "bison_parser.y"
+         { (yyval.datetime_field) = kDatetimeMonth; }
+#line 5259 "bison_parser.cpp"
     break;
 
-  case 270:
-#line 1221 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.datetime_field) = kDatetimeYear; }
-#line 5093 "bison_parser.cpp" /* yacc.c:1646  */
+  case 270: /* datetime_field_plural: YEARS  */
+#line 1221 "bison_parser.y"
+        { (yyval.datetime_field) = kDatetimeYear; }
+#line 5265 "bison_parser.cpp"
     break;
 
-  case 273:
-#line 1225 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeArray((yyvsp[-1].expr_vec)); }
-#line 5099 "bison_parser.cpp" /* yacc.c:1646  */
+  case 273: /* array_expr: ARRAY '[' expr_list ']'  */
+#line 1225 "bison_parser.y"
+                                     { (yyval.expr) = Expr::makeArray((yyvsp[-1].expr_vec)); }
+#line 5271 "bison_parser.cpp"
     break;
 
-  case 274:
-#line 1227 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeArrayIndex((yyvsp[-3].expr), (yyvsp[-1].expr)->ival); }
-#line 5105 "bison_parser.cpp" /* yacc.c:1646  */
+  case 274: /* array_index: operand '[' int_literal ']'  */
+#line 1227 "bison_parser.y"
+                                          { (yyval.expr) = Expr::makeArrayIndex((yyvsp[-3].expr), (yyvsp[-1].expr)->ival); }
+#line 5277 "bison_parser.cpp"
     break;
 
-  case 275:
-#line 1229 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeBetween((yyvsp[-4].expr), (yyvsp[-2].expr), (yyvsp[0].expr)); }
-#line 5111 "bison_parser.cpp" /* yacc.c:1646  */
+  case 275: /* between_expr: operand BETWEEN operand AND operand  */
+#line 1229 "bison_parser.y"
+                                                   { (yyval.expr) = Expr::makeBetween((yyvsp[-4].expr), (yyvsp[-2].expr), (yyvsp[0].expr)); }
+#line 5283 "bison_parser.cpp"
     break;
 
-  case 276:
-#line 1231 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeColumnRef((yyvsp[0].sval)); }
-#line 5117 "bison_parser.cpp" /* yacc.c:1646  */
+  case 276: /* column_name: IDENTIFIER  */
+#line 1231 "bison_parser.y"
+                         { (yyval.expr) = Expr::makeColumnRef((yyvsp[0].sval)); }
+#line 5289 "bison_parser.cpp"
     break;
 
-  case 277:
-#line 1232 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeColumnRef((yyvsp[-2].sval), (yyvsp[0].sval)); }
-#line 5123 "bison_parser.cpp" /* yacc.c:1646  */
+  case 277: /* column_name: IDENTIFIER '.' IDENTIFIER  */
+#line 1232 "bison_parser.y"
+                            { (yyval.expr) = Expr::makeColumnRef((yyvsp[-2].sval), (yyvsp[0].sval)); }
+#line 5295 "bison_parser.cpp"
     break;
 
-  case 278:
-#line 1233 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeStar(); }
-#line 5129 "bison_parser.cpp" /* yacc.c:1646  */
+  case 278: /* column_name: IDENTIFIER '.' IDENTIFIER '.' IDENTIFIER  */
+#line 1233 "bison_parser.y"
+                                           { (yyval.expr) = Expr::makeColumnRef((yyvsp[-4].sval), (yyvsp[-2].sval), (yyvsp[0].sval)); }
+#line 5301 "bison_parser.cpp"
     break;
 
-  case 279:
-#line 1234 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeStar((yyvsp[-2].sval)); }
-#line 5135 "bison_parser.cpp" /* yacc.c:1646  */
+  case 279: /* column_name: '*'  */
+#line 1234 "bison_parser.y"
+      { (yyval.expr) = Expr::makeStar(); }
+#line 5307 "bison_parser.cpp"
     break;
 
-  case 287:
-#line 1238 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeLiteral((yyvsp[0].sval)); }
-#line 5141 "bison_parser.cpp" /* yacc.c:1646  */
+  case 280: /* column_name: IDENTIFIER '.' '*'  */
+#line 1235 "bison_parser.y"
+                     { (yyval.expr) = Expr::makeStar((yyvsp[-2].sval)); }
+#line 5313 "bison_parser.cpp"
     break;
 
-  case 288:
-#line 1240 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeLiteral(true); }
-#line 5147 "bison_parser.cpp" /* yacc.c:1646  */
+  case 288: /* string_literal: STRING  */
+#line 1239 "bison_parser.y"
+                        { (yyval.expr) = Expr::makeLiteral((yyvsp[0].sval)); }
+#line 5319 "bison_parser.cpp"
     break;
 
-  case 289:
-#line 1241 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeLiteral(false); }
-#line 5153 "bison_parser.cpp" /* yacc.c:1646  */
+  case 289: /* bool_literal: TRUE  */
+#line 1241 "bison_parser.y"
+                    { (yyval.expr) = Expr::makeLiteral(true); }
+#line 5325 "bison_parser.cpp"
     break;
 
-  case 290:
-#line 1243 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeLiteral((yyvsp[0].fval)); }
-#line 5159 "bison_parser.cpp" /* yacc.c:1646  */
+  case 290: /* bool_literal: FALSE  */
+#line 1242 "bison_parser.y"
+        { (yyval.expr) = Expr::makeLiteral(false); }
+#line 5331 "bison_parser.cpp"
     break;
 
-  case 292:
-#line 1246 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeLiteral((yyvsp[0].ival)); }
-#line 5165 "bison_parser.cpp" /* yacc.c:1646  */
+  case 291: /* num_literal: FLOATVAL  */
+#line 1244 "bison_parser.y"
+                       { (yyval.expr) = Expr::makeLiteral((yyvsp[0].fval)); }
+#line 5337 "bison_parser.cpp"
     break;
 
-  case 293:
-#line 1248 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeNullLiteral(); }
-#line 5171 "bison_parser.cpp" /* yacc.c:1646  */
+  case 293: /* int_literal: INTVAL  */
+#line 1247 "bison_parser.y"
+                     { (yyval.expr) = Expr::makeLiteral((yyvsp[0].ival)); }
+#line 5343 "bison_parser.cpp"
     break;
 
-  case 294:
-#line 1250 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 294: /* null_literal: NULL  */
+#line 1249 "bison_parser.y"
+                    { (yyval.expr) = Expr::makeNullLiteral(); }
+#line 5349 "bison_parser.cpp"
+    break;
+
+  case 295: /* date_literal: DATE STRING  */
+#line 1251 "bison_parser.y"
+                           {
   int day{0}, month{0}, year{0}, chars_parsed{0};
   // If the whole string is parsed, chars_parsed points to the terminating null byte after the last character
   if (sscanf((yyvsp[0].sval), "%4d-%2d-%2d%n", &day, &month, &year, &chars_parsed) != 3 || (yyvsp[0].sval)[chars_parsed] != 0) {
@@ -5182,18 +5360,18 @@ yyreduce:
   }
   (yyval.expr) = Expr::makeDateLiteral((yyvsp[0].sval));
 }
-#line 5186 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5364 "bison_parser.cpp"
     break;
 
-  case 295:
-#line 1261 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.expr) = Expr::makeIntervalLiteral((yyvsp[-1].ival), (yyvsp[0].datetime_field)); }
-#line 5192 "bison_parser.cpp" /* yacc.c:1646  */
+  case 296: /* interval_literal: INTVAL duration_field  */
+#line 1262 "bison_parser.y"
+                                         { (yyval.expr) = Expr::makeIntervalLiteral((yyvsp[-1].ival), (yyvsp[0].datetime_field)); }
+#line 5370 "bison_parser.cpp"
     break;
 
-  case 296:
-#line 1262 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 297: /* interval_literal: INTERVAL STRING datetime_field  */
+#line 1263 "bison_parser.y"
+                                 {
   int duration{0}, chars_parsed{0};
   // If the whole string is parsed, chars_parsed points to the terminating null byte after the last character
   if (sscanf((yyvsp[-1].sval), "%d%n", &duration, &chars_parsed) != 1 || (yyvsp[-1].sval)[chars_parsed] != 0) {
@@ -5204,12 +5382,12 @@ yyreduce:
   free((yyvsp[-1].sval));
   (yyval.expr) = Expr::makeIntervalLiteral(duration, (yyvsp[0].datetime_field));
 }
-#line 5208 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5386 "bison_parser.cpp"
     break;
 
-  case 297:
-#line 1273 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 298: /* interval_literal: INTERVAL STRING  */
+#line 1274 "bison_parser.y"
+                  {
   int duration{0}, chars_parsed{0};
   // 'seconds' and 'minutes' are the longest accepted interval qualifiers (7 chars) + null byte
   char unit_string[8];
@@ -5240,290 +5418,290 @@ yyreduce:
   }
   (yyval.expr) = Expr::makeIntervalLiteral(duration, unit);
 }
-#line 5244 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5422 "bison_parser.cpp"
     break;
 
-  case 298:
-#line 1305 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 299: /* param_expr: '?'  */
+#line 1306 "bison_parser.y"
+                 {
   (yyval.expr) = Expr::makeParameter(yylloc.total_column);
   (yyval.expr)->ival2 = yyloc.param_list.size();
   yyloc.param_list.push_back((yyval.expr));
 }
-#line 5254 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5432 "bison_parser.cpp"
     break;
 
-  case 300:
-#line 1314 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 301: /* table_ref: table_ref_commalist ',' table_ref_atomic  */
+#line 1315 "bison_parser.y"
+                                                                        {
   (yyvsp[-2].table_vec)->push_back((yyvsp[0].table));
   auto tbl = new TableRef(kTableCrossProduct);
   tbl->list = (yyvsp[-2].table_vec);
   (yyval.table) = tbl;
 }
-#line 5265 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5443 "bison_parser.cpp"
     break;
 
-  case 304:
-#line 1323 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 305: /* nonjoin_table_ref_atomic: '(' select_statement ')' opt_table_alias  */
+#line 1324 "bison_parser.y"
+                                                                                     {
   auto tbl = new TableRef(kTableSelect);
   tbl->select = (yyvsp[-2].select_stmt);
   tbl->alias = (yyvsp[0].alias_t);
   (yyval.table) = tbl;
 }
-#line 5276 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5454 "bison_parser.cpp"
     break;
 
-  case 305:
-#line 1330 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 306: /* table_ref_commalist: table_ref_atomic  */
+#line 1331 "bison_parser.y"
+                                       {
   (yyval.table_vec) = new std::vector<TableRef*>();
   (yyval.table_vec)->push_back((yyvsp[0].table));
 }
-#line 5285 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5463 "bison_parser.cpp"
     break;
 
-  case 306:
-#line 1334 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 307: /* table_ref_commalist: table_ref_commalist ',' table_ref_atomic  */
+#line 1335 "bison_parser.y"
+                                           {
   (yyvsp[-2].table_vec)->push_back((yyvsp[0].table));
   (yyval.table_vec) = (yyvsp[-2].table_vec);
 }
-#line 5294 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5472 "bison_parser.cpp"
     break;
 
-  case 307:
-#line 1339 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 308: /* table_ref_name: table_name opt_table_alias  */
+#line 1340 "bison_parser.y"
+                                            {
   auto tbl = new TableRef(kTableName);
   tbl->schema = (yyvsp[-1].table_name).schema;
   tbl->name = (yyvsp[-1].table_name).name;
   tbl->alias = (yyvsp[0].alias_t);
   (yyval.table) = tbl;
 }
-#line 5306 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5484 "bison_parser.cpp"
     break;
 
-  case 308:
-#line 1347 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 309: /* table_ref_name_no_alias: table_name  */
+#line 1348 "bison_parser.y"
+                                     {
   (yyval.table) = new TableRef(kTableName);
   (yyval.table)->schema = (yyvsp[0].table_name).schema;
   (yyval.table)->name = (yyvsp[0].table_name).name;
 }
-#line 5316 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5494 "bison_parser.cpp"
     break;
 
-  case 309:
-#line 1353 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 310: /* table_name: IDENTIFIER  */
+#line 1354 "bison_parser.y"
+                        {
   (yyval.table_name).schema = nullptr;
   (yyval.table_name).name = (yyvsp[0].sval);
 }
-#line 5325 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5503 "bison_parser.cpp"
     break;
 
-  case 310:
-#line 1357 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 311: /* table_name: IDENTIFIER '.' IDENTIFIER  */
+#line 1358 "bison_parser.y"
+                            {
   (yyval.table_name).schema = (yyvsp[-2].sval);
   (yyval.table_name).name = (yyvsp[0].sval);
 }
-#line 5334 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5512 "bison_parser.cpp"
     break;
 
-  case 311:
-#line 1362 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.sval) = (yyvsp[0].sval); }
-#line 5340 "bison_parser.cpp" /* yacc.c:1646  */
+  case 312: /* opt_index_name: IDENTIFIER  */
+#line 1363 "bison_parser.y"
+                            { (yyval.sval) = (yyvsp[0].sval); }
+#line 5518 "bison_parser.cpp"
     break;
 
-  case 312:
-#line 1363 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.sval) = nullptr; }
-#line 5346 "bison_parser.cpp" /* yacc.c:1646  */
+  case 313: /* opt_index_name: %empty  */
+#line 1364 "bison_parser.y"
+              { (yyval.sval) = nullptr; }
+#line 5524 "bison_parser.cpp"
     break;
 
-  case 314:
-#line 1365 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alias_t) = new Alias((yyvsp[-3].sval), (yyvsp[-1].str_vec)); }
-#line 5352 "bison_parser.cpp" /* yacc.c:1646  */
+  case 315: /* table_alias: AS IDENTIFIER '(' ident_commalist ')'  */
+#line 1366 "bison_parser.y"
+                                                            { (yyval.alias_t) = new Alias((yyvsp[-3].sval), (yyvsp[-1].str_vec)); }
+#line 5530 "bison_parser.cpp"
     break;
 
-  case 316:
-#line 1367 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alias_t) = nullptr; }
-#line 5358 "bison_parser.cpp" /* yacc.c:1646  */
+  case 317: /* opt_table_alias: %empty  */
+#line 1368 "bison_parser.y"
+                                            { (yyval.alias_t) = nullptr; }
+#line 5536 "bison_parser.cpp"
     break;
 
-  case 317:
-#line 1369 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
-#line 5364 "bison_parser.cpp" /* yacc.c:1646  */
+  case 318: /* alias: AS IDENTIFIER  */
+#line 1370 "bison_parser.y"
+                      { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
+#line 5542 "bison_parser.cpp"
     break;
 
-  case 318:
-#line 1370 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
-#line 5370 "bison_parser.cpp" /* yacc.c:1646  */
+  case 319: /* alias: IDENTIFIER  */
+#line 1371 "bison_parser.y"
+             { (yyval.alias_t) = new Alias((yyvsp[0].sval)); }
+#line 5548 "bison_parser.cpp"
     break;
 
-  case 320:
-#line 1372 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.alias_t) = nullptr; }
-#line 5376 "bison_parser.cpp" /* yacc.c:1646  */
+  case 321: /* opt_alias: %empty  */
+#line 1373 "bison_parser.y"
+                                { (yyval.alias_t) = nullptr; }
+#line 5554 "bison_parser.cpp"
     break;
 
-  case 321:
-#line 1378 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.locking_clause_vec) = (yyvsp[0].locking_clause_vec); }
-#line 5382 "bison_parser.cpp" /* yacc.c:1646  */
+  case 322: /* opt_locking_clause: opt_locking_clause_list  */
+#line 1379 "bison_parser.y"
+                                             { (yyval.locking_clause_vec) = (yyvsp[0].locking_clause_vec); }
+#line 5560 "bison_parser.cpp"
     break;
 
-  case 322:
-#line 1379 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.locking_clause_vec) = nullptr; }
-#line 5388 "bison_parser.cpp" /* yacc.c:1646  */
+  case 323: /* opt_locking_clause: %empty  */
+#line 1380 "bison_parser.y"
+              { (yyval.locking_clause_vec) = nullptr; }
+#line 5566 "bison_parser.cpp"
     break;
 
-  case 323:
-#line 1381 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 324: /* opt_locking_clause_list: locking_clause  */
+#line 1382 "bison_parser.y"
+                                         {
   (yyval.locking_clause_vec) = new std::vector<LockingClause*>();
   (yyval.locking_clause_vec)->push_back((yyvsp[0].locking_t));
 }
-#line 5397 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5575 "bison_parser.cpp"
     break;
 
-  case 324:
-#line 1385 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 325: /* opt_locking_clause_list: opt_locking_clause_list locking_clause  */
+#line 1386 "bison_parser.y"
+                                         {
   (yyvsp[-1].locking_clause_vec)->push_back((yyvsp[0].locking_t));
   (yyval.locking_clause_vec) = (yyvsp[-1].locking_clause_vec);
 }
-#line 5406 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5584 "bison_parser.cpp"
     break;
 
-  case 325:
-#line 1390 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 326: /* locking_clause: FOR row_lock_mode opt_row_lock_policy  */
+#line 1391 "bison_parser.y"
+                                                       {
   (yyval.locking_t) = new LockingClause();
   (yyval.locking_t)->rowLockMode = (yyvsp[-1].lock_mode_t);
   (yyval.locking_t)->rowLockWaitPolicy = (yyvsp[0].lock_wait_policy_t);
   (yyval.locking_t)->tables = nullptr;
 }
-#line 5417 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5595 "bison_parser.cpp"
     break;
 
-  case 326:
-#line 1396 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 327: /* locking_clause: FOR row_lock_mode OF ident_commalist opt_row_lock_policy  */
+#line 1397 "bison_parser.y"
+                                                           {
   (yyval.locking_t) = new LockingClause();
   (yyval.locking_t)->rowLockMode = (yyvsp[-3].lock_mode_t);
   (yyval.locking_t)->tables = (yyvsp[-1].str_vec);
   (yyval.locking_t)->rowLockWaitPolicy = (yyvsp[0].lock_wait_policy_t);
 }
-#line 5428 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5606 "bison_parser.cpp"
     break;
 
-  case 327:
-#line 1403 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_mode_t) = RowLockMode::ForUpdate; }
-#line 5434 "bison_parser.cpp" /* yacc.c:1646  */
+  case 328: /* row_lock_mode: UPDATE  */
+#line 1404 "bison_parser.y"
+                       { (yyval.lock_mode_t) = RowLockMode::ForUpdate; }
+#line 5612 "bison_parser.cpp"
     break;
 
-  case 328:
-#line 1404 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_mode_t) = RowLockMode::ForNoKeyUpdate; }
-#line 5440 "bison_parser.cpp" /* yacc.c:1646  */
+  case 329: /* row_lock_mode: NO KEY UPDATE  */
+#line 1405 "bison_parser.y"
+                { (yyval.lock_mode_t) = RowLockMode::ForNoKeyUpdate; }
+#line 5618 "bison_parser.cpp"
     break;
 
-  case 329:
-#line 1405 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_mode_t) = RowLockMode::ForShare; }
-#line 5446 "bison_parser.cpp" /* yacc.c:1646  */
+  case 330: /* row_lock_mode: SHARE  */
+#line 1406 "bison_parser.y"
+        { (yyval.lock_mode_t) = RowLockMode::ForShare; }
+#line 5624 "bison_parser.cpp"
     break;
 
-  case 330:
-#line 1406 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_mode_t) = RowLockMode::ForKeyShare; }
-#line 5452 "bison_parser.cpp" /* yacc.c:1646  */
+  case 331: /* row_lock_mode: KEY SHARE  */
+#line 1407 "bison_parser.y"
+            { (yyval.lock_mode_t) = RowLockMode::ForKeyShare; }
+#line 5630 "bison_parser.cpp"
     break;
 
-  case 331:
-#line 1408 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::SkipLocked; }
-#line 5458 "bison_parser.cpp" /* yacc.c:1646  */
+  case 332: /* opt_row_lock_policy: SKIP LOCKED  */
+#line 1409 "bison_parser.y"
+                                  { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::SkipLocked; }
+#line 5636 "bison_parser.cpp"
     break;
 
-  case 332:
-#line 1409 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::NoWait; }
-#line 5464 "bison_parser.cpp" /* yacc.c:1646  */
+  case 333: /* opt_row_lock_policy: NOWAIT  */
+#line 1410 "bison_parser.y"
+         { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::NoWait; }
+#line 5642 "bison_parser.cpp"
     break;
 
-  case 333:
-#line 1410 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::None; }
-#line 5470 "bison_parser.cpp" /* yacc.c:1646  */
+  case 334: /* opt_row_lock_policy: %empty  */
+#line 1411 "bison_parser.y"
+              { (yyval.lock_wait_policy_t) = RowLockWaitPolicy::None; }
+#line 5648 "bison_parser.cpp"
     break;
 
-  case 335:
-#line 1416 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.with_description_vec) = nullptr; }
-#line 5476 "bison_parser.cpp" /* yacc.c:1646  */
+  case 336: /* opt_with_clause: %empty  */
+#line 1417 "bison_parser.y"
+                                            { (yyval.with_description_vec) = nullptr; }
+#line 5654 "bison_parser.cpp"
     break;
 
-  case 336:
-#line 1418 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.with_description_vec) = (yyvsp[0].with_description_vec); }
-#line 5482 "bison_parser.cpp" /* yacc.c:1646  */
+  case 337: /* with_clause: WITH with_description_list  */
+#line 1419 "bison_parser.y"
+                                         { (yyval.with_description_vec) = (yyvsp[0].with_description_vec); }
+#line 5660 "bison_parser.cpp"
     break;
 
-  case 337:
-#line 1420 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 338: /* with_description_list: with_description  */
+#line 1421 "bison_parser.y"
+                                         {
   (yyval.with_description_vec) = new std::vector<WithDescription*>();
   (yyval.with_description_vec)->push_back((yyvsp[0].with_description_t));
 }
-#line 5491 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5669 "bison_parser.cpp"
     break;
 
-  case 338:
-#line 1424 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 339: /* with_description_list: with_description_list ',' with_description  */
+#line 1425 "bison_parser.y"
+                                             {
   (yyvsp[-2].with_description_vec)->push_back((yyvsp[0].with_description_t));
   (yyval.with_description_vec) = (yyvsp[-2].with_description_vec);
 }
-#line 5500 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5678 "bison_parser.cpp"
     break;
 
-  case 339:
-#line 1429 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 340: /* with_description: IDENTIFIER AS select_with_paren  */
+#line 1430 "bison_parser.y"
+                                                   {
   (yyval.with_description_t) = new WithDescription();
   (yyval.with_description_t)->alias = (yyvsp[-2].sval);
   (yyval.with_description_t)->select = (yyvsp[0].select_stmt);
 }
-#line 5510 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5688 "bison_parser.cpp"
     break;
 
-  case 340:
-#line 1439 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 341: /* join_clause: table_ref_atomic NATURAL JOIN nonjoin_table_ref_atomic  */
+#line 1440 "bison_parser.y"
+                                                                     {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
   (yyval.table)->join->type = kJoinNatural;
   (yyval.table)->join->left = (yyvsp[-3].table);
   (yyval.table)->join->right = (yyvsp[0].table);
 }
-#line 5522 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5700 "bison_parser.cpp"
     break;
 
-  case 341:
-#line 1446 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 342: /* join_clause: table_ref_atomic opt_join_type JOIN table_ref_atomic ON join_condition  */
+#line 1447 "bison_parser.y"
+                                                                         {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
   (yyval.table)->join->type = (JoinType)(yyvsp[-4].join_type);
@@ -5531,12 +5709,12 @@ yyreduce:
   (yyval.table)->join->right = (yyvsp[-2].table);
   (yyval.table)->join->condition = (yyvsp[0].expr);
 }
-#line 5535 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5713 "bison_parser.cpp"
     break;
 
-  case 342:
-#line 1454 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 343: /* join_clause: table_ref_atomic opt_join_type JOIN table_ref_atomic USING '(' ident_commalist ')'  */
+#line 1455 "bison_parser.y"
+                                                                                     {
   (yyval.table) = new TableRef(kTableJoin);
   (yyval.table)->join = new JoinDefinition();
   (yyval.table)->join->type = (yyvsp[-6].join_type);
@@ -5544,89 +5722,90 @@ yyreduce:
   (yyval.table)->join->right = (yyvsp[-4].table);
   (yyval.table)->join->namedColumns = (yyvsp[-1].str_vec);
 }
-#line 5548 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5726 "bison_parser.cpp"
     break;
 
-  case 343:
-#line 1463 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinInner; }
-#line 5554 "bison_parser.cpp" /* yacc.c:1646  */
+  case 344: /* opt_join_type: INNER  */
+#line 1464 "bison_parser.y"
+                      { (yyval.join_type) = kJoinInner; }
+#line 5732 "bison_parser.cpp"
     break;
 
-  case 344:
-#line 1464 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinLeft; }
-#line 5560 "bison_parser.cpp" /* yacc.c:1646  */
+  case 345: /* opt_join_type: LEFT OUTER  */
+#line 1465 "bison_parser.y"
+             { (yyval.join_type) = kJoinLeft; }
+#line 5738 "bison_parser.cpp"
     break;
 
-  case 345:
-#line 1465 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinLeft; }
-#line 5566 "bison_parser.cpp" /* yacc.c:1646  */
+  case 346: /* opt_join_type: LEFT  */
+#line 1466 "bison_parser.y"
+       { (yyval.join_type) = kJoinLeft; }
+#line 5744 "bison_parser.cpp"
     break;
 
-  case 346:
-#line 1466 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinRight; }
-#line 5572 "bison_parser.cpp" /* yacc.c:1646  */
+  case 347: /* opt_join_type: RIGHT OUTER  */
+#line 1467 "bison_parser.y"
+              { (yyval.join_type) = kJoinRight; }
+#line 5750 "bison_parser.cpp"
     break;
 
-  case 347:
-#line 1467 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinRight; }
-#line 5578 "bison_parser.cpp" /* yacc.c:1646  */
+  case 348: /* opt_join_type: RIGHT  */
+#line 1468 "bison_parser.y"
+        { (yyval.join_type) = kJoinRight; }
+#line 5756 "bison_parser.cpp"
     break;
 
-  case 348:
-#line 1468 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinFull; }
-#line 5584 "bison_parser.cpp" /* yacc.c:1646  */
+  case 349: /* opt_join_type: FULL OUTER  */
+#line 1469 "bison_parser.y"
+             { (yyval.join_type) = kJoinFull; }
+#line 5762 "bison_parser.cpp"
     break;
 
-  case 349:
-#line 1469 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinFull; }
-#line 5590 "bison_parser.cpp" /* yacc.c:1646  */
+  case 350: /* opt_join_type: OUTER  */
+#line 1470 "bison_parser.y"
+        { (yyval.join_type) = kJoinFull; }
+#line 5768 "bison_parser.cpp"
     break;
 
-  case 350:
-#line 1470 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinFull; }
-#line 5596 "bison_parser.cpp" /* yacc.c:1646  */
+  case 351: /* opt_join_type: FULL  */
+#line 1471 "bison_parser.y"
+       { (yyval.join_type) = kJoinFull; }
+#line 5774 "bison_parser.cpp"
     break;
 
-  case 351:
-#line 1471 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinCross; }
-#line 5602 "bison_parser.cpp" /* yacc.c:1646  */
+  case 352: /* opt_join_type: CROSS  */
+#line 1472 "bison_parser.y"
+        { (yyval.join_type) = kJoinCross; }
+#line 5780 "bison_parser.cpp"
     break;
 
-  case 352:
-#line 1472 "bison_parser.y" /* yacc.c:1646  */
-    { (yyval.join_type) = kJoinInner; }
-#line 5608 "bison_parser.cpp" /* yacc.c:1646  */
+  case 353: /* opt_join_type: %empty  */
+#line 1473 "bison_parser.y"
+                       { (yyval.join_type) = kJoinInner; }
+#line 5786 "bison_parser.cpp"
     break;
 
-  case 356:
-#line 1483 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 357: /* ident_commalist: IDENTIFIER  */
+#line 1484 "bison_parser.y"
+                             {
   (yyval.str_vec) = new std::vector<char*>();
   (yyval.str_vec)->push_back((yyvsp[0].sval));
 }
-#line 5617 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5795 "bison_parser.cpp"
     break;
 
-  case 357:
-#line 1487 "bison_parser.y" /* yacc.c:1646  */
-    {
+  case 358: /* ident_commalist: ident_commalist ',' IDENTIFIER  */
+#line 1488 "bison_parser.y"
+                                 {
   (yyvsp[-2].str_vec)->push_back((yyvsp[0].sval));
   (yyval.str_vec) = (yyvsp[-2].str_vec);
 }
-#line 5626 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5804 "bison_parser.cpp"
     break;
 
 
-#line 5630 "bison_parser.cpp" /* yacc.c:1646  */
+#line 5808 "bison_parser.cpp"
+
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -5640,11 +5819,10 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
   *++yylsp = yyloc;
@@ -5652,14 +5830,13 @@ yyreduce:
   /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
@@ -5670,66 +5847,61 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == SQL_HSQL_EMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
-      yyerror (&yylloc, result, scanner, YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
       {
+        yypcontext_t yyctx
+          = {yyssp, yytoken, &yylloc};
         char const *yymsgp = YY_("syntax error");
         int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
+        yysyntax_error_status = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
         if (yysyntax_error_status == 0)
           yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
+        else if (yysyntax_error_status == -1)
           {
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
-            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
-            if (!yymsg)
+            yymsg = YY_CAST (char *,
+                             YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
+            if (yymsg)
               {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
+                yysyntax_error_status
+                  = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
+                yymsgp = yymsg;
               }
             else
               {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
+                yymsg = yymsgbuf;
+                yymsg_alloc = sizeof yymsgbuf;
+                yysyntax_error_status = YYENOMEM;
               }
           }
         yyerror (&yylloc, result, scanner, yymsgp);
-        if (yysyntax_error_status == 2)
-          goto yyexhaustedlab;
+        if (yysyntax_error_status == YYENOMEM)
+          YYNOMEM;
       }
-# undef YYSYNTAX_ERROR
-#endif
     }
 
   yyerror_range[1] = yylloc;
-
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
          error, discard it.  */
 
-      if (yychar <= YYEOF)
+      if (yychar <= SQL_YYEOF)
         {
           /* Return failure if at end of input.  */
-          if (yychar == YYEOF)
+          if (yychar == SQL_YYEOF)
             YYABORT;
         }
       else
         {
           yydestruct ("Error: discarding",
                       yytoken, &yylval, &yylloc, result, scanner);
-          yychar = YYEMPTY;
+          yychar = SQL_HSQL_EMPTY;
         }
     }
 
@@ -5742,14 +5914,12 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
+  ++yynerrs;
 
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
-
-  yyerror_range[1] = yylsp[1-yylen];
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
@@ -5765,13 +5935,14 @@ yyerrorlab:
 yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
               yyn = yytable[yyn];
               if (0 < yyn)
@@ -5785,7 +5956,7 @@ yyerrlab1:
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, yylsp, result, scanner);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp, result, scanner);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -5796,13 +5967,11 @@ yyerrlab1:
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
   yyerror_range[2] = yylloc;
-  /* Using YYLLOC is tempting, but would change the location of
-     the lookahead.  YYLOC is available though.  */
-  YYLLOC_DEFAULT (yyloc, yyerror_range, 2);
-  *++yylsp = yyloc;
+  ++yylsp;
+  YYLLOC_DEFAULT (*yylsp, yyerror_range, 2);
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -5813,27 +5982,31 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
-#if !defined yyoverflow || YYERROR_VERBOSE
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (&yylloc, result, scanner, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
-yyreturn:
-  if (yychar != YYEMPTY)
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
+  if (yychar != SQL_HSQL_EMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at
          user semantic actions for why this is necessary.  */
@@ -5848,20 +6021,19 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp, yylsp, result, scanner);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp, result, scanner);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
-#endif
   return yyresult;
 }
-#line 1493 "bison_parser.y" /* yacc.c:1906  */
+
+#line 1494 "bison_parser.y"
 
 
 /*********************************

--- a/src/parser/bison_parser.h
+++ b/src/parser/bison_parser.h
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -29,6 +30,10 @@
 
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
+
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
 #ifndef YY_HSQL_BISON_PARSER_H_INCLUDED
 # define YY_HSQL_BISON_PARSER_H_INCLUDED
@@ -48,7 +53,7 @@
 extern int hsql_debug;
 #endif
 /* "%code requires" blocks.  */
-#line 39 "bison_parser.y" /* yacc.c:1909  */
+#line 39 "bison_parser.y"
 
 // %code requires block
 
@@ -71,201 +76,205 @@ extern int hsql_debug;
     }                                         \
   }
 
-#line 75 "bison_parser.h" /* yacc.c:1909  */
+#line 80 "bison_parser.h"
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef HSQL_TOKENTYPE
 # define HSQL_TOKENTYPE
   enum hsql_tokentype
   {
-    SQL_IDENTIFIER = 258,
-    SQL_STRING = 259,
-    SQL_FLOATVAL = 260,
-    SQL_INTVAL = 261,
-    SQL_DEALLOCATE = 262,
-    SQL_PARAMETERS = 263,
-    SQL_INTERSECT = 264,
-    SQL_TEMPORARY = 265,
-    SQL_TIMESTAMP = 266,
-    SQL_DISTINCT = 267,
-    SQL_NVARCHAR = 268,
-    SQL_RESTRICT = 269,
-    SQL_TRUNCATE = 270,
-    SQL_ANALYZE = 271,
-    SQL_BETWEEN = 272,
-    SQL_CASCADE = 273,
-    SQL_COLUMNS = 274,
-    SQL_CONTROL = 275,
-    SQL_DEFAULT = 276,
-    SQL_EXECUTE = 277,
-    SQL_EXPLAIN = 278,
-    SQL_ENCODING = 279,
-    SQL_INTEGER = 280,
-    SQL_NATURAL = 281,
-    SQL_PREPARE = 282,
-    SQL_SCHEMAS = 283,
-    SQL_CHARACTER_VARYING = 284,
-    SQL_REAL = 285,
-    SQL_DECIMAL = 286,
-    SQL_SMALLINT = 287,
-    SQL_BIGINT = 288,
-    SQL_SPATIAL = 289,
-    SQL_VARCHAR = 290,
-    SQL_VIRTUAL = 291,
-    SQL_DESCRIBE = 292,
-    SQL_BEFORE = 293,
-    SQL_COLUMN = 294,
-    SQL_CREATE = 295,
-    SQL_DELETE = 296,
-    SQL_DIRECT = 297,
-    SQL_DOUBLE = 298,
-    SQL_ESCAPE = 299,
-    SQL_EXCEPT = 300,
-    SQL_EXISTS = 301,
-    SQL_EXTRACT = 302,
-    SQL_CAST = 303,
-    SQL_FORMAT = 304,
-    SQL_GLOBAL = 305,
-    SQL_HAVING = 306,
-    SQL_IMPORT = 307,
-    SQL_INSERT = 308,
-    SQL_ISNULL = 309,
-    SQL_OFFSET = 310,
-    SQL_RENAME = 311,
-    SQL_SCHEMA = 312,
-    SQL_SELECT = 313,
-    SQL_SORTED = 314,
-    SQL_TABLES = 315,
-    SQL_UNLOAD = 316,
-    SQL_UPDATE = 317,
-    SQL_VALUES = 318,
-    SQL_AFTER = 319,
-    SQL_ALTER = 320,
-    SQL_CROSS = 321,
-    SQL_DELTA = 322,
-    SQL_FLOAT = 323,
-    SQL_GROUP = 324,
-    SQL_INDEX = 325,
-    SQL_INNER = 326,
-    SQL_LIMIT = 327,
-    SQL_LOCAL = 328,
-    SQL_MERGE = 329,
-    SQL_MINUS = 330,
-    SQL_ORDER = 331,
-    SQL_OVER = 332,
-    SQL_OUTER = 333,
-    SQL_RIGHT = 334,
-    SQL_TABLE = 335,
-    SQL_UNION = 336,
-    SQL_USING = 337,
-    SQL_WHERE = 338,
-    SQL_CALL = 339,
-    SQL_CASE = 340,
-    SQL_CHAR = 341,
-    SQL_COPY = 342,
-    SQL_DATE = 343,
-    SQL_DATETIME = 344,
-    SQL_DESC = 345,
-    SQL_DROP = 346,
-    SQL_ELSE = 347,
-    SQL_FILE = 348,
-    SQL_FROM = 349,
-    SQL_FULL = 350,
-    SQL_HASH = 351,
-    SQL_HINT = 352,
-    SQL_INTO = 353,
-    SQL_JOIN = 354,
-    SQL_LEFT = 355,
-    SQL_LIKE = 356,
-    SQL_LOAD = 357,
-    SQL_LONG = 358,
-    SQL_NULL = 359,
-    SQL_PARTITION = 360,
-    SQL_PLAN = 361,
-    SQL_SHOW = 362,
-    SQL_TEXT = 363,
-    SQL_THEN = 364,
-    SQL_TIME = 365,
-    SQL_VIEW = 366,
-    SQL_WHEN = 367,
-    SQL_WITH = 368,
-    SQL_ADD = 369,
-    SQL_ALL = 370,
-    SQL_AND = 371,
-    SQL_ASC = 372,
-    SQL_END = 373,
-    SQL_FOR = 374,
-    SQL_INT = 375,
-    SQL_NOT = 376,
-    SQL_OFF = 377,
-    SQL_SET = 378,
-    SQL_TOP = 379,
-    SQL_AS = 380,
-    SQL_BY = 381,
-    SQL_IF = 382,
-    SQL_IN = 383,
-    SQL_IS = 384,
-    SQL_OF = 385,
-    SQL_ON = 386,
-    SQL_OR = 387,
-    SQL_TO = 388,
-    SQL_NO = 389,
-    SQL_ARRAY = 390,
-    SQL_CONCAT = 391,
-    SQL_ILIKE = 392,
-    SQL_SECOND = 393,
-    SQL_MINUTE = 394,
-    SQL_HOUR = 395,
-    SQL_DAY = 396,
-    SQL_MONTH = 397,
-    SQL_YEAR = 398,
-    SQL_SECONDS = 399,
-    SQL_MINUTES = 400,
-    SQL_HOURS = 401,
-    SQL_DAYS = 402,
-    SQL_MONTHS = 403,
-    SQL_YEARS = 404,
-    SQL_INTERVAL = 405,
-    SQL_TRUE = 406,
-    SQL_FALSE = 407,
-    SQL_BOOLEAN = 408,
-    SQL_TRANSACTION = 409,
-    SQL_BEGIN = 410,
-    SQL_COMMIT = 411,
-    SQL_ROLLBACK = 412,
-    SQL_NOWAIT = 413,
-    SQL_SKIP = 414,
-    SQL_LOCKED = 415,
-    SQL_SHARE = 416,
-    SQL_RANGE = 417,
-    SQL_ROWS = 418,
-    SQL_GROUPS = 419,
-    SQL_UNBOUNDED = 420,
-    SQL_FOLLOWING = 421,
-    SQL_PRECEDING = 422,
-    SQL_CURRENT_ROW = 423,
-    SQL_UNIQUE = 424,
-    SQL_PRIMARY = 425,
-    SQL_FOREIGN = 426,
-    SQL_KEY = 427,
-    SQL_REFERENCES = 428,
-    SQL_EQUALS = 429,
-    SQL_NOTEQUALS = 430,
-    SQL_LESS = 431,
-    SQL_GREATER = 432,
-    SQL_LESSEQ = 433,
-    SQL_GREATEREQ = 434,
-    SQL_NOTNULL = 435,
-    SQL_UMINUS = 436
+    SQL_HSQL_EMPTY = -2,
+    SQL_YYEOF = 0,                 /* "end of file"  */
+    SQL_HSQL_error = 256,          /* error  */
+    SQL_HSQL_UNDEF = 257,          /* "invalid token"  */
+    SQL_IDENTIFIER = 258,          /* IDENTIFIER  */
+    SQL_STRING = 259,              /* STRING  */
+    SQL_FLOATVAL = 260,            /* FLOATVAL  */
+    SQL_INTVAL = 261,              /* INTVAL  */
+    SQL_DEALLOCATE = 262,          /* DEALLOCATE  */
+    SQL_PARAMETERS = 263,          /* PARAMETERS  */
+    SQL_INTERSECT = 264,           /* INTERSECT  */
+    SQL_TEMPORARY = 265,           /* TEMPORARY  */
+    SQL_TIMESTAMP = 266,           /* TIMESTAMP  */
+    SQL_DISTINCT = 267,            /* DISTINCT  */
+    SQL_NVARCHAR = 268,            /* NVARCHAR  */
+    SQL_RESTRICT = 269,            /* RESTRICT  */
+    SQL_TRUNCATE = 270,            /* TRUNCATE  */
+    SQL_ANALYZE = 271,             /* ANALYZE  */
+    SQL_BETWEEN = 272,             /* BETWEEN  */
+    SQL_CASCADE = 273,             /* CASCADE  */
+    SQL_COLUMNS = 274,             /* COLUMNS  */
+    SQL_CONTROL = 275,             /* CONTROL  */
+    SQL_DEFAULT = 276,             /* DEFAULT  */
+    SQL_EXECUTE = 277,             /* EXECUTE  */
+    SQL_EXPLAIN = 278,             /* EXPLAIN  */
+    SQL_ENCODING = 279,            /* ENCODING  */
+    SQL_INTEGER = 280,             /* INTEGER  */
+    SQL_NATURAL = 281,             /* NATURAL  */
+    SQL_PREPARE = 282,             /* PREPARE  */
+    SQL_SCHEMAS = 283,             /* SCHEMAS  */
+    SQL_CHARACTER_VARYING = 284,   /* CHARACTER_VARYING  */
+    SQL_REAL = 285,                /* REAL  */
+    SQL_DECIMAL = 286,             /* DECIMAL  */
+    SQL_SMALLINT = 287,            /* SMALLINT  */
+    SQL_BIGINT = 288,              /* BIGINT  */
+    SQL_SPATIAL = 289,             /* SPATIAL  */
+    SQL_VARCHAR = 290,             /* VARCHAR  */
+    SQL_VIRTUAL = 291,             /* VIRTUAL  */
+    SQL_DESCRIBE = 292,            /* DESCRIBE  */
+    SQL_BEFORE = 293,              /* BEFORE  */
+    SQL_COLUMN = 294,              /* COLUMN  */
+    SQL_CREATE = 295,              /* CREATE  */
+    SQL_DELETE = 296,              /* DELETE  */
+    SQL_DIRECT = 297,              /* DIRECT  */
+    SQL_DOUBLE = 298,              /* DOUBLE  */
+    SQL_ESCAPE = 299,              /* ESCAPE  */
+    SQL_EXCEPT = 300,              /* EXCEPT  */
+    SQL_EXISTS = 301,              /* EXISTS  */
+    SQL_EXTRACT = 302,             /* EXTRACT  */
+    SQL_CAST = 303,                /* CAST  */
+    SQL_FORMAT = 304,              /* FORMAT  */
+    SQL_GLOBAL = 305,              /* GLOBAL  */
+    SQL_HAVING = 306,              /* HAVING  */
+    SQL_IMPORT = 307,              /* IMPORT  */
+    SQL_INSERT = 308,              /* INSERT  */
+    SQL_ISNULL = 309,              /* ISNULL  */
+    SQL_OFFSET = 310,              /* OFFSET  */
+    SQL_RENAME = 311,              /* RENAME  */
+    SQL_SCHEMA = 312,              /* SCHEMA  */
+    SQL_SELECT = 313,              /* SELECT  */
+    SQL_SORTED = 314,              /* SORTED  */
+    SQL_TABLES = 315,              /* TABLES  */
+    SQL_UNLOAD = 316,              /* UNLOAD  */
+    SQL_UPDATE = 317,              /* UPDATE  */
+    SQL_VALUES = 318,              /* VALUES  */
+    SQL_AFTER = 319,               /* AFTER  */
+    SQL_ALTER = 320,               /* ALTER  */
+    SQL_CROSS = 321,               /* CROSS  */
+    SQL_DELTA = 322,               /* DELTA  */
+    SQL_FLOAT = 323,               /* FLOAT  */
+    SQL_GROUP = 324,               /* GROUP  */
+    SQL_INDEX = 325,               /* INDEX  */
+    SQL_INNER = 326,               /* INNER  */
+    SQL_LIMIT = 327,               /* LIMIT  */
+    SQL_LOCAL = 328,               /* LOCAL  */
+    SQL_MERGE = 329,               /* MERGE  */
+    SQL_MINUS = 330,               /* MINUS  */
+    SQL_ORDER = 331,               /* ORDER  */
+    SQL_OVER = 332,                /* OVER  */
+    SQL_OUTER = 333,               /* OUTER  */
+    SQL_RIGHT = 334,               /* RIGHT  */
+    SQL_TABLE = 335,               /* TABLE  */
+    SQL_UNION = 336,               /* UNION  */
+    SQL_USING = 337,               /* USING  */
+    SQL_WHERE = 338,               /* WHERE  */
+    SQL_CALL = 339,                /* CALL  */
+    SQL_CASE = 340,                /* CASE  */
+    SQL_CHAR = 341,                /* CHAR  */
+    SQL_COPY = 342,                /* COPY  */
+    SQL_DATE = 343,                /* DATE  */
+    SQL_DATETIME = 344,            /* DATETIME  */
+    SQL_DESC = 345,                /* DESC  */
+    SQL_DROP = 346,                /* DROP  */
+    SQL_ELSE = 347,                /* ELSE  */
+    SQL_FILE = 348,                /* FILE  */
+    SQL_FROM = 349,                /* FROM  */
+    SQL_FULL = 350,                /* FULL  */
+    SQL_HASH = 351,                /* HASH  */
+    SQL_HINT = 352,                /* HINT  */
+    SQL_INTO = 353,                /* INTO  */
+    SQL_JOIN = 354,                /* JOIN  */
+    SQL_LEFT = 355,                /* LEFT  */
+    SQL_LIKE = 356,                /* LIKE  */
+    SQL_LOAD = 357,                /* LOAD  */
+    SQL_LONG = 358,                /* LONG  */
+    SQL_NULL = 359,                /* NULL  */
+    SQL_PARTITION = 360,           /* PARTITION  */
+    SQL_PLAN = 361,                /* PLAN  */
+    SQL_SHOW = 362,                /* SHOW  */
+    SQL_TEXT = 363,                /* TEXT  */
+    SQL_THEN = 364,                /* THEN  */
+    SQL_TIME = 365,                /* TIME  */
+    SQL_VIEW = 366,                /* VIEW  */
+    SQL_WHEN = 367,                /* WHEN  */
+    SQL_WITH = 368,                /* WITH  */
+    SQL_ADD = 369,                 /* ADD  */
+    SQL_ALL = 370,                 /* ALL  */
+    SQL_AND = 371,                 /* AND  */
+    SQL_ASC = 372,                 /* ASC  */
+    SQL_END = 373,                 /* END  */
+    SQL_FOR = 374,                 /* FOR  */
+    SQL_INT = 375,                 /* INT  */
+    SQL_NOT = 376,                 /* NOT  */
+    SQL_OFF = 377,                 /* OFF  */
+    SQL_SET = 378,                 /* SET  */
+    SQL_TOP = 379,                 /* TOP  */
+    SQL_AS = 380,                  /* AS  */
+    SQL_BY = 381,                  /* BY  */
+    SQL_IF = 382,                  /* IF  */
+    SQL_IN = 383,                  /* IN  */
+    SQL_IS = 384,                  /* IS  */
+    SQL_OF = 385,                  /* OF  */
+    SQL_ON = 386,                  /* ON  */
+    SQL_OR = 387,                  /* OR  */
+    SQL_TO = 388,                  /* TO  */
+    SQL_NO = 389,                  /* NO  */
+    SQL_ARRAY = 390,               /* ARRAY  */
+    SQL_CONCAT = 391,              /* CONCAT  */
+    SQL_ILIKE = 392,               /* ILIKE  */
+    SQL_SECOND = 393,              /* SECOND  */
+    SQL_MINUTE = 394,              /* MINUTE  */
+    SQL_HOUR = 395,                /* HOUR  */
+    SQL_DAY = 396,                 /* DAY  */
+    SQL_MONTH = 397,               /* MONTH  */
+    SQL_YEAR = 398,                /* YEAR  */
+    SQL_SECONDS = 399,             /* SECONDS  */
+    SQL_MINUTES = 400,             /* MINUTES  */
+    SQL_HOURS = 401,               /* HOURS  */
+    SQL_DAYS = 402,                /* DAYS  */
+    SQL_MONTHS = 403,              /* MONTHS  */
+    SQL_YEARS = 404,               /* YEARS  */
+    SQL_INTERVAL = 405,            /* INTERVAL  */
+    SQL_TRUE = 406,                /* TRUE  */
+    SQL_FALSE = 407,               /* FALSE  */
+    SQL_BOOLEAN = 408,             /* BOOLEAN  */
+    SQL_TRANSACTION = 409,         /* TRANSACTION  */
+    SQL_BEGIN = 410,               /* BEGIN  */
+    SQL_COMMIT = 411,              /* COMMIT  */
+    SQL_ROLLBACK = 412,            /* ROLLBACK  */
+    SQL_NOWAIT = 413,              /* NOWAIT  */
+    SQL_SKIP = 414,                /* SKIP  */
+    SQL_LOCKED = 415,              /* LOCKED  */
+    SQL_SHARE = 416,               /* SHARE  */
+    SQL_RANGE = 417,               /* RANGE  */
+    SQL_ROWS = 418,                /* ROWS  */
+    SQL_GROUPS = 419,              /* GROUPS  */
+    SQL_UNBOUNDED = 420,           /* UNBOUNDED  */
+    SQL_FOLLOWING = 421,           /* FOLLOWING  */
+    SQL_PRECEDING = 422,           /* PRECEDING  */
+    SQL_CURRENT_ROW = 423,         /* CURRENT_ROW  */
+    SQL_UNIQUE = 424,              /* UNIQUE  */
+    SQL_PRIMARY = 425,             /* PRIMARY  */
+    SQL_FOREIGN = 426,             /* FOREIGN  */
+    SQL_KEY = 427,                 /* KEY  */
+    SQL_REFERENCES = 428,          /* REFERENCES  */
+    SQL_EQUALS = 429,              /* EQUALS  */
+    SQL_NOTEQUALS = 430,           /* NOTEQUALS  */
+    SQL_LESS = 431,                /* LESS  */
+    SQL_GREATER = 432,             /* GREATER  */
+    SQL_LESSEQ = 433,              /* LESSEQ  */
+    SQL_GREATEREQ = 434,           /* GREATEREQ  */
+    SQL_NOTNULL = 435,             /* NOTNULL  */
+    SQL_UMINUS = 436               /* UMINUS  */
   };
+  typedef enum hsql_tokentype hsql_token_kind_t;
 #endif
 
 /* Value type.  */
 #if ! defined HSQL_STYPE && ! defined HSQL_STYPE_IS_DECLARED
-
 union HSQL_STYPE
 {
-#line 102 "bison_parser.y" /* yacc.c:1909  */
+#line 102 "bison_parser.y"
 
   // clang-format on
   bool bval;
@@ -340,9 +349,9 @@ union HSQL_STYPE
 
   // clang-format off
 
-#line 344 "bison_parser.h" /* yacc.c:1909  */
-};
+#line 353 "bison_parser.h"
 
+};
 typedef union HSQL_STYPE HSQL_STYPE;
 # define HSQL_STYPE_IS_TRIVIAL 1
 # define HSQL_STYPE_IS_DECLARED 1
@@ -364,6 +373,8 @@ struct HSQL_LTYPE
 
 
 
+
 int hsql_parse (hsql::SQLParserResult* result, yyscan_t scanner);
+
 
 #endif /* !YY_HSQL_BISON_PARSER_H_INCLUDED  */

--- a/src/parser/bison_parser.y
+++ b/src/parser/bison_parser.y
@@ -1230,6 +1230,7 @@ between_expr : operand BETWEEN operand AND operand { $$ = Expr::makeBetween($1, 
 
 column_name : IDENTIFIER { $$ = Expr::makeColumnRef($1); }
 | IDENTIFIER '.' IDENTIFIER { $$ = Expr::makeColumnRef($1, $3); }
+| IDENTIFIER '.' IDENTIFIER '.' IDENTIFIER { $$ = Expr::makeColumnRef($1, $3, $5); }
 | '*' { $$ = Expr::makeStar(); }
 | IDENTIFIER '.' '*' { $$ = Expr::makeStar($1); };
 

--- a/src/sql/Expr.cpp
+++ b/src/sql/Expr.cpp
@@ -201,6 +201,14 @@ Expr* Expr::makeColumnRef(char* table, char* name) {
   return e;
 }
 
+Expr* Expr::makeColumnRef(char* schema, char* table, char* name) {
+  Expr* e = new Expr(kExprColumnRef);
+  e->name = name;
+  e->table = table;
+  e->schema = schema;
+  return e;
+}
+
 Expr* Expr::makeStar(void) {
   Expr* e = new Expr(kExprStar);
   return e;

--- a/src/sql/Expr.h
+++ b/src/sql/Expr.h
@@ -195,6 +195,8 @@ struct Expr {
 
   static Expr* makeColumnRef(char* table, char* name);
 
+  static Expr* makeColumnRef(char* schema, char* table, char* name);
+
   static Expr* makeStar(void);
 
   static Expr* makeStar(char* table);

--- a/test/select_tests.cpp
+++ b/test/select_tests.cpp
@@ -47,6 +47,16 @@ TEST(SelectExprTest) {
   ASSERT_STREQ(stmt->selectList->at(2)->exprList->at(1)->exprList->at(0)->getName(), "un");
 }
 
+TEST(SelectThreePartColumnRefTest) {
+  TEST_PARSE_SINGLE_SQL("SELECT catalog.students.grade FROM students;", kStmtSelect, SelectStatement, result, stmt);
+
+  ASSERT_EQ(stmt->selectList->size(), 1);
+  ASSERT(stmt->selectList->at(0)->isType(kExprColumnRef));
+  ASSERT_STREQ(stmt->selectList->at(0)->schema, "catalog");
+  ASSERT_STREQ(stmt->selectList->at(0)->table, "students");
+  ASSERT_STREQ(stmt->selectList->at(0)->name, "grade");
+}
+
 TEST(SelectUnaryMinusTest) {
   TEST_PARSE_SINGLE_SQL(
       "SELECT 10 - 20, 10 + -20, 10 +-20, 10+-20, 9223372036854775807, -9223372036854775808, 10-5.2, 10+-5.2",


### PR DESCRIPTION
This adds support for three-part column references:

```sql
SELECT schema.table.column FROM table;
```
So something like `SELECT catalog.students.grade FROM students;` will populate the schema field in `Expr`:

```c++
expr->schema = "catalog";
expr->table = "students";
expr->name = "grade";
```

The changes are fairly light:
  - Added a grammar entry for `IDENTIFIER '.' IDENTIFIER '.' IDENTIFIER`
  - Added `Expr::makeColumnRef(char* schema, char* table, char* name)`
  - Added a test case covering this scenario

I have confirmed this passes the test suite and leak test on Linux 6.18.35-1-lts and test suite on macOS 26.5.1. I also see that the repo has the Bison output checked in so I did so as well for this PR, but please let me know if I should exclude it or need to run with the same version of Bison that was previously used to generate the files.

Thanks for this great library, it's very clean and easy to work with!